### PR TITLE
Update sram stub to match semantics of IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg-info
 __pycache__
 *.v
+!test_memory_core/sram_stub.v
 *.json
 genesis.log
 genesis_clean.cmd

--- a/test_memory_core/sram_stub.v
+++ b/test_memory_core/sram_stub.v
@@ -1,13 +1,13 @@
 // sram_512w_16b mem_inst(
-// .Q(data_out),
+// .Q(data_out), 
 // .CLK(clk),
-// .CEN(~cen),
-// .WEN(~wen),
-// .A(addr),
-// .D(data_in),
-// .EMA(3'd0),
-// .EMAW(2'd0),
-// .EMAS(1'b0),
+// .CEN(~cen), 
+// .WEN(~wen), 
+// .A(addr), 
+// .D(data_in), 
+// .EMA(3'd0), 
+// .EMAW(2'd0), 
+// .EMAS(1'b0), 
 // .TEN(1'b1),
 // .BEN(1'b1),
 // .RET1N(1'b1),
@@ -20,7 +20,7 @@ module sram_512w_16b (Q, CLK, CEN, WEN, A, D, EMA, EMAW, EMAS, TEN, BEN, RET1N, 
    input        WEN;
    input [8:0]  A;
    input [15:0] D;
-
+   
    input [2:0]  EMA;
    input [1:0]  EMAW;
    input        EMAS;
@@ -28,7 +28,7 @@ module sram_512w_16b (Q, CLK, CEN, WEN, A, D, EMA, EMAW, EMAS, TEN, BEN, RET1N, 
    input        BEN;
    input        RET1N;
    input        STOV;
-
+   
    reg [15:0]   data_array [0:511];
 
    always @(posedge CLK) begin

--- a/test_memory_core/sram_stub.v
+++ b/test_memory_core/sram_stub.v
@@ -1,13 +1,13 @@
 // sram_512w_16b mem_inst(
-// .Q(data_out), 
+// .Q(data_out),
 // .CLK(clk),
-// .CEN(~cen), 
-// .WEN(~wen), 
-// .A(addr), 
-// .D(data_in), 
-// .EMA(3'd0), 
-// .EMAW(2'd0), 
-// .EMAS(1'b0), 
+// .CEN(~cen),
+// .WEN(~wen),
+// .A(addr),
+// .D(data_in),
+// .EMA(3'd0),
+// .EMAW(2'd0),
+// .EMAS(1'b0),
 // .TEN(1'b1),
 // .BEN(1'b1),
 // .RET1N(1'b1),
@@ -20,7 +20,7 @@ module sram_512w_16b (Q, CLK, CEN, WEN, A, D, EMA, EMAW, EMAS, TEN, BEN, RET1N, 
    input        WEN;
    input [8:0]  A;
    input [15:0] D;
-   
+
    input [2:0]  EMA;
    input [1:0]  EMAW;
    input        EMAS;
@@ -28,7 +28,7 @@ module sram_512w_16b (Q, CLK, CEN, WEN, A, D, EMA, EMAW, EMAS, TEN, BEN, RET1N, 
    input        BEN;
    input        RET1N;
    input        STOV;
-   
+
    reg [15:0]   data_array [0:511];
 
    always @(posedge CLK) begin
@@ -36,8 +36,8 @@ module sram_512w_16b (Q, CLK, CEN, WEN, A, D, EMA, EMAW, EMAS, TEN, BEN, RET1N, 
       // Use all the unused wires (note at least one of them must be nonzero!)
       if (| {EMA, EMAW, EMAS, TEN, BEN, RET1N, STOV}) begin
          if (CEN == 1'b0) begin                  // ACTIVE LOW!!
-            Q = data_array[A];
             if (WEN == 1'b0) data_array[A] = D;  // ACTIVE LOW!!
+            else Q = data_array[A];
          end
       end
    end


### PR DESCRIPTION
Here is an update to the sram stub that I believe makes it match the behavior of the IP we're using. Basically, it shouldn't perform the read if WEN is active.

I'm planning to add some units tests for this module once we've merged this in (so we can also run the tests against the IP to make sure our understanding is correct).