### PR TITLE
Refactor regression tests

### DIFF
--- a/cb/cb.py
+++ b/cb/cb.py
@@ -80,9 +80,10 @@ def gen_cb(width: int,
             if select_as_int in range(len(inputs)):
                 self.out = args[select_as_int]
                 return self.out
-            # TODO(raj): Handle the case where we select the constant value or
-            # resort to default.
-            raise Exception()
+            if has_constant:
+                return default_value
+            else:
+                return 0
 
         # Debug method to read config data.
         @property

--- a/cb/cb.py
+++ b/cb/cb.py
@@ -81,9 +81,10 @@ def gen_cb(width: int,
                 self.out = args[select_as_int]
                 return self.out
             if has_constant:
-                return default_value
+                return self.__get_config_bits(mux_sel_bits,
+                                              mux_sel_bits + width)
             else:
-                return 0
+                return BitVector(0, width)
 
         # Debug method to read config data.
         @property

--- a/common/model.py
+++ b/common/model.py
@@ -9,7 +9,7 @@ class Model(ABC):
     mechanism of evaluating the functional model.
     """
     @abstractmethod
-    def __init__(self):
+    def __init__(self):  # pragma: nocover
         pass
 
     """
@@ -17,5 +17,5 @@ class Model(ABC):
     appropriate). All subclasses should implement this function.
     """
     @abstractmethod
-    def __call__(self, *args):
+    def __call__(self, *args):  # pragma: nocover
         pass

--- a/common/regression_test.py
+++ b/common/regression_test.py
@@ -16,6 +16,15 @@ def parse_genesis_circuit(circuit):
 
 
 def check_interfaces(magma_circuit, genesis_circuit):
+    """
+    This checks that the interface to the genesis circuit is
+    compatible with the magma circuit. It does that by looping
+    over all the ports in the genesis circuit and checking that
+    the magma circuit has the same port and type.
+
+    It currently does not check the other direction (e.g. the magma circuit
+    could have ports not included in the genesis circuit interface)
+    """
     genesis_port_names = genesis_circuit.interface.ports.keys()
     for name in genesis_port_names:
         assert hasattr(magma_circuit, name), \

--- a/common/regression_test.py
+++ b/common/regression_test.py
@@ -1,20 +1,6 @@
 import magma as m
 
 
-def parse_genesis_circuit(circuit):
-    data_width = None
-    inputs = []
-    for port in circuit.interface:
-        if port[:3] == "in_":
-            inputs.append(port)
-            port_width = len(circuit.interface.ports[port])
-            if data_width is None:
-                data_width = port_width
-            else:
-                assert data_width == port_width
-    return inputs, data_width
-
-
 def check_interfaces(magma_circuit, genesis_circuit):
     """
     This checks that the interface to the genesis circuit is

--- a/common/regression_test.py
+++ b/common/regression_test.py
@@ -1,7 +1,11 @@
 import magma as m
 
 
-def check_interfaces(magma_circuit, genesis_circuit):
+def check_interfaces(magma_circuit, genesis_circuit,
+                     type_mapping={
+                         "clk": m.ClockKind,
+                         "reset": m.AsyncResetKind
+                     }):
     """
     This checks that the interface to the genesis circuit is
     compatible with the magma circuit. It does that by looping
@@ -10,6 +14,11 @@ def check_interfaces(magma_circuit, genesis_circuit):
 
     It currently does not check the other direction (e.g. the magma circuit
     could have ports not included in the genesis circuit interface)
+
+    `type_mapping` parameter allows the user to map genesis ports to a
+    different type (by name). This reconciles differences between the generated
+    verilog and the magma definition, e.g. for the ClockType, which doesn't
+    exist in verilog.
     """
     genesis_port_names = genesis_circuit.interface.ports.keys()
     for name in genesis_port_names:
@@ -18,9 +27,7 @@ def check_interfaces(magma_circuit, genesis_circuit):
         genesis_kind = type(type(getattr(genesis_circuit, name)))
         magma_kind = type(type(getattr(magma_circuit, name)))
         # Special case genesis signals that aren't typed
-        if name == "clk":
-            genesis_kind = m.ClockKind
-        elif name == "reset":
-            genesis_kind = m.AsyncResetKind
+        if name in type_mapping:
+            genesis_kind = type_mapping[name]
         assert issubclass(magma_kind, genesis_kind) or \
             issubclass(genesis_kind, magma_kind), "Types don't match"

--- a/test_cb/test_cb_regression.py
+++ b/test_cb/test_cb_regression.py
@@ -48,25 +48,6 @@ def test_regression(default_value, num_tracks, has_constant):
     genesis_verilog = "genesis_verif/cb.v"
     shutil.copy(genesis_verilog, "test_cb/build")
 
-    def get_inputs_and_data_width(circuit):
-        data_width = None
-
-        inputs = []
-        for port in circuit.interface:
-            if port[:3] == "in_":
-                inputs.append(port)
-                port_width = len(circuit.interface.ports[port])
-                if data_width is None:
-                    data_width = port_width
-                else:
-                    assert data_width == port_width
-        return inputs, data_width
-
-    inputs, data_width = get_inputs_and_data_width(genesis_cb)
-
-    assert (inputs, data_width) == get_inputs_and_data_width(magma_cb), \
-        "Inputs should be the same"
-
     config_addr = BitVector(0, 32)
 
     cb_functional_model = gen_cb(**params)()
@@ -75,14 +56,10 @@ def test_regression(default_value, num_tracks, has_constant):
         pass
 
     tester = CBTester(genesis_cb, genesis_cb.clk, cb_functional_model)
-    for config_data in [BitVector(x, 32) for x in range(0, len(inputs))]:
+    for config_data in [BitVector(x, 32) for x in range(0, num_tracks)]:
+        tester.zero_inputs()
         tester.reset()
         tester.configure(config_addr, config_data)
-
-        # init inputs to 0
-        for i in range(0, num_tracks):
-            if feedthrough_outputs[i] == "1":
-                tester.poke(getattr(genesis_cb, f"in_{i}"), 0)
 
         tester.test_vectors += \
             generate_test_vectors_from_streams(

--- a/test_cb/test_cb_regression.py
+++ b/test_cb/test_cb_regression.py
@@ -13,6 +13,7 @@ import pytest
 
 from fault.test_vector_generator import generate_test_vectors_from_streams
 from common.testers import ResetTester, ConfigurationTester
+from common.regression_test import check_interfaces
 from fault.random import random_bv
 
 
@@ -46,6 +47,8 @@ def test_regression(default_value, num_tracks, has_constant):
     genesis_cb = cb_wrapper.generator()(
         **params, input_files=["cb/genesis/cb.vp"])
     genesis_verilog = "genesis_verif/cb.v"
+
+    check_interfaces(magma_cb, genesis_cb)
     shutil.copy(genesis_verilog, "test_cb/build")
 
     config_addr = BitVector(0, 32)

--- a/test_simple_cb/test_simple_cb_regression.py
+++ b/test_simple_cb/test_simple_cb_regression.py
@@ -20,20 +20,6 @@ def teardown_function():
         os.system(f"rm -r {item}")
 
 
-def parse_genesis_circuit(circuit):
-    data_width = None
-    inputs = []
-    for port in circuit.interface:
-        if port[:3] == "in_":
-            inputs.append(port)
-            port_width = len(circuit.interface.ports[port])
-            if data_width is None:
-                data_width = port_width
-            else:
-                assert data_width == port_width
-    return inputs, data_width
-
-
 # FIXME: this fails
 # @pytest.mark.parametrize('num_tracks', range(2,10))
 @pytest.mark.parametrize('num_tracks', [10])
@@ -54,15 +40,6 @@ def test_regression(num_tracks):
     genesis_verilog = "genesis_verif/simple_cb.v"
     shutil.copy(genesis_verilog, "test_simple_cb/build/")
 
-    # Introspect each circuit (get data inputs and width).
-    genesis_inputs, genesis_width = parse_genesis_circuit(genesis_simple_cb)
-    magma_input = magma_simple_cb.interface.ports["I"]
-
-    # Check that the data input ports on the magma circuit match that of the
-    # genesis circuit.
-    assert magma_input.N == len(genesis_inputs)
-    assert genesis_width == magma_input.T.N
-
     # TODO: Do we need this extra instantiation, could the function do it for
     # us?
     simple_cb_functional_model = gen_simple_cb(**params)()
@@ -81,7 +58,7 @@ def test_regression(num_tracks):
                 if field in self.renamed_ports:
                     field = self.renamed_ports[field]
                 elif "in_" in field:
-                    return self.circuit.I[i]
+                    return self.circuit.I[int(field.split("_")[-1])]
             return getattr(self.circuit, field)
 
     class SimpleCBTester(ResetTester, ConfigurationTester):
@@ -95,9 +72,7 @@ def test_regression(num_tracks):
         tester = SimpleCBTester(simple_cb, simple_cb.clk,
                                 simple_cb_functional_model, input_mapping)
 
-        # Init inputs to 0.
-        for i in range(num_tracks):
-            tester.poke(getattr(simple_cb, f"in_{i}"), 0)
+        tester.zero_inputs()
 
         for config_data in [BitVector(x, 32) for x in range(0, 1)]:
             tester.reset()

--- a/test_simple_cb/test_simple_cb_regression.py
+++ b/test_simple_cb/test_simple_cb_regression.py
@@ -9,6 +9,7 @@ from simple_cb.simple_cb_genesis2 import simple_cb_wrapper
 
 import magma as m
 from common.testers import ResetTester, ConfigurationTester
+from common.regression_test import check_interfaces
 from fault.test_vector_generator import generate_test_vectors_from_streams
 from fault.random import random_bv
 
@@ -60,6 +61,8 @@ def test_regression(num_tracks):
                 elif "in_" in field:
                     return self.circuit.I[int(field.split("_")[-1])]
             return getattr(self.circuit, field)
+
+    check_interfaces(MappedCB(magma_simple_cb), genesis_simple_cb)
 
     class SimpleCBTester(ResetTester, ConfigurationTester):
         pass


### PR DESCRIPTION
Here's an attempt to remove more boilerplate from the regression tests (motivated by https://github.com/StanfordAHA/garnet/issues/14).

The logic to zero the inputs is moved into the fault.tester.

The logic to check consistency of the interfaces is moved into `common/regression_test.py`