### PR TITLE
Update code based on upstream bv/fault changes

### DIFF
--- a/cb/cb.py
+++ b/cb/cb.py
@@ -1,5 +1,6 @@
 import math
 from bit_vector import BitVector
+import fault
 
 
 def gen_cb(width: int,
@@ -42,14 +43,15 @@ def gen_cb(width: int,
 
         def reset(self):
             self.configure(BitVector(0, CONFIG_ADDR_WIDTH), reset_val)
-            self.out = None
-            self.read_data = None
+
+            self.out = fault.UnknownValue
+            self.read_data = fault.UnknownValue
 
         def configure(self, addr: BitVector, data: BitVector):
             assert addr.num_bits == CONFIG_ADDR_WIDTH
             assert data.num_bits == CONFIG_ADDR_WIDTH
             addr_high_bits = addr[24:32]
-            config_reg_select = addr_high_bits.as_int()
+            config_reg_select = addr_high_bits.as_uint()
             if config_reg_select in range(num_config_regs):
                 self.__config[config_reg_select] = data
 
@@ -75,10 +77,10 @@ def gen_cb(width: int,
         def __call__(self, *args):
             assert len(args) == len(inputs)
             select = self.__get_config_bits(0, mux_sel_bits)
-            select_as_int = select.as_int()
+            select_as_uint = select.as_uint()
             # TODO: read_data logic
-            if select_as_int in range(len(inputs)):
-                self.out = args[select_as_int]
+            if select_as_uint in range(len(inputs)):
+                self.out = args[select_as_uint]
                 return self.out
             if has_constant:
                 return self.__get_config_bits(mux_sel_bits,

--- a/common/configurable_model.py
+++ b/common/configurable_model.py
@@ -33,7 +33,7 @@ def ConfigurableModel(config_data_width, config_addr_width):
                 if not addr.num_bits == config_addr_width:
                     raise ValueError("Expected addr to be of width "
                                      f"{config_addr_width}")
-                return self.__map[addr.unsigned_value]
+                return self.__map[addr.as_uint()]
 
             def __setitem__(self, addr, data):
                 if not addr.num_bits == config_addr_width:
@@ -42,7 +42,7 @@ def ConfigurableModel(config_data_width, config_addr_width):
                 if not data.num_bits == config_data_width:
                     raise ValueError("Expected data to be of width "
                                      f"{config_data_width}")
-                self.__map[addr.unsigned_value] = data
+                self.__map[addr.as_uint()] = data
 
         def __init__(self):
             self.__config = _ConfigurableModel._Map()

--- a/common/testers.py
+++ b/common/testers.py
@@ -4,6 +4,7 @@ from fault.functional_tester import FunctionalTester
 class ResetTester(FunctionalTester):
     def reset(self):
         self.functional_model.reset()
+        self.expect_any_outputs()
         self.poke(self.circuit.reset, 1)
         self.eval()
         self.poke(self.circuit.reset, 0)

--- a/memory_core/memory_core.py
+++ b/memory_core/memory_core.py
@@ -3,6 +3,7 @@ import functools
 from bit_vector import BitVector
 from enum import Enum
 import magma as m
+import fault
 import logging
 logging.basicConfig(level=logging.DEBUG)
 
@@ -59,18 +60,18 @@ def gen_memory_core(data_width: int, data_depth: int):
         def reset(self):
             address_width = m.bitutils.clog2(data_depth)
             self.memory = Memory(address_width, data_width)
-            self.data_out = None
-            self.read_data = None
+            self.data_out = fault.UnknownValue
+            self.read_data = fault.UnknownValue
             # TODO: Is the initial config actually 0?
             self.configure(CONFIG_ADDR, BitVector(0, 32))
             # Ignore these signals for now
-            self.valid_out = None
-            self.chain_out = None
-            self.chain_valid_out = None
-            self.almost_full = None
-            self.almost_empty = None
-            self.read_data_sram = None
-            self.read_data_linebuf = None
+            self.valid_out = fault.UnknownValue
+            self.chain_out = fault.UnknownValue
+            self.chain_valid_out = fault.UnknownValue
+            self.almost_full = fault.UnknownValue
+            self.almost_empty = fault.UnknownValue
+            self.read_data_sram = fault.UnknownValue
+            self.read_data_linebuf = fault.UnknownValue
 
         def read(self, addr):
             if self.__mode == Mode.SRAM:
@@ -97,5 +98,5 @@ def gen_memory_core(data_width: int, data_depth: int):
             The mode is stored in the lowest 2 (least significant) bits of the
             configuration data.
             """
-            return Mode((self.config[CONFIG_ADDR] & 0x3).unsigned_value)
+            return Mode((self.config[CONFIG_ADDR] & 0x3).as_uint())
     return MemoryCore

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
         # magma/mantle not on PYPI yet
         # "magma",
         # "mantle",
-        "coreir",
-        "bit_vector",
+        "coreir==0.23a",
+        "bit_vector==0.30a",
         "fault==0.17"
     ],
     python_requires='>=3.6'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         # "mantle",
         "coreir",
         "bit_vector",
-        "fault"
+        "fault==0.17"
     ],
     python_requires='>=3.6'
 )

--- a/simple_cb/simple_cb.py
+++ b/simple_cb/simple_cb.py
@@ -1,6 +1,7 @@
 import math
 from bit_vector import BitVector
 from common.configurable_model import ConfigurableModel
+import fault
 
 
 def gen_simple_cb(width: int,
@@ -24,8 +25,8 @@ def gen_simple_cb(width: int,
             self.reset()
 
         def reset(self):
-            self.out = None
-            self.read_data = None
+            self.out = fault.UnknownValue
+            self.read_data = fault.UnknownValue
             self.configure(CONFIG_ADDR, BitVector(0, 32))
 
         def configure(self, addr, data):
@@ -34,9 +35,9 @@ def gen_simple_cb(width: int,
         def __call__(self, *args):
             assert len(args) == num_tracks
             select = self.config[CONFIG_ADDR]
-            select_as_int = select.unsigned_value
-            if select_as_int in range(num_tracks):
-                return args[select_as_int]
+            select_as_uint = select.as_uint()
+            if select_as_uint in range(num_tracks):
+                return args[select_as_uint]
             return BitVector(0, width)
 
     return _SimpleCB

--- a/test_cb/test_cb_regression.py
+++ b/test_cb/test_cb_regression.py
@@ -37,7 +37,7 @@ def test_regression(default_value, num_tracks, has_constant):
         "num_tracks": num_tracks,
         "feedthrough_outputs": feedthrough_outputs,
         "has_constant": has_constant,
-        "default_value": default_value.as_int()
+        "default_value": default_value.as_uint()
     }
 
     magma_cb = define_cb(**params)

--- a/test_common/test_config_register.py
+++ b/test_common/test_config_register.py
@@ -32,14 +32,14 @@ def test_config_register():
         simulator.advance(2)
         return reg_value()
 
-    assert reg_value() == BitVector(0, WIDTH)
+    assert BitVector(reg_value()) == BitVector(0, WIDTH)
     sequence = [(0, 0, 0),
                 (12, 4, 0),
                 (0, 0, 12),
                 (0, 0, 12)]
     for (I, addr, out_expected) in sequence:
         out = step(BitVector(I, WIDTH), BitVector(addr, ADDR_WIDTH))
-        assert out == BitVector(out_expected, WIDTH)
+        assert BitVector(out) == BitVector(out_expected, WIDTH)
 
 
 def test_error():

--- a/test_memory_core/test_memory_core_genesis2.py
+++ b/test_memory_core/test_memory_core_genesis2.py
@@ -65,7 +65,7 @@ class MemoryCoreTester(ResetTester, ConfigurationTester):
         self.poke(self.circuit.clk_in, 1)
         self.eval()
         # Don't expect anything after for now
-        self.functional_model.data_out = None
+        self.functional_model.data_out = fault.AnyValue
 
     def read_and_write(self, addr, data):
         self.poke(self.circuit.clk_in, 0)
@@ -104,12 +104,8 @@ def test_sram_basic():
 
     tester = MemoryCoreTester(Mem, clock=Mem.clk_in,
                               functional_model=mem_functional_model_inst)
-    # Initialize all inputs to 0
-    # TODO: Make this a convenience function in Tester?
-    # We have to get the `outputs` because the ports are flipped to use the
-    # polarity for definitions. TODO: This is a confusing wart
-    for port in Mem.interface.outputs():
-        tester.poke(getattr(Mem, str(port)), 0)
+    tester.zero_inputs()
+    tester.expect_any_outputs()
 
     tester.eval()
 


### PR DESCRIPTION
* Support for None values were removed.  Changed the functional models
to use fault.UnknownValue (X) by default. Then the test logic was
updated to expect `AnyValue` on the outputs when they are
unspecified/undefined. For example, the test expects AnyValue for
outputs of the memory during the reset sequence since the values are
undefined.

* bit_vector `as_uint()` instead of `as_int()`, since `as_int()` returns
the signed representation now (before it depended on whether the signed
flag was set on initialization).

* bit_vector `as_uint()` instead of `.unsigned_value` since the API
has changed to be consistent with the `as_int` pattern.

* Explicitly cast lists to BitVectors for tests since the BitVector
`==` operator no longer does implicit conversions.