### PR TITLE
Update config register to use coreir

### DIFF
--- a/common/config_register.py
+++ b/common/config_register.py
@@ -33,8 +33,8 @@ def define_config_register(width, address, has_reset, _type=m.Bits):
                                   init=0,
                                   has_ce=True,
                                   has_reset=has_reset)
-            cmp = mantle.EQ(AddressType.N)
-            m.wire(reg(io.I, CE=cmp(io.addr, address)), io.O)
+            CE = (io.addr == address) & m.bit(io.CE)
+            m.wire(reg(io.I, CE=CE), io.O)
             if has_reset:
                 m.wire(io.RESET, reg.RESET)
 

--- a/test_common/gold/config_register.json
+++ b/test_common/gold/config_register.json
@@ -22,16 +22,21 @@
           },
           "inst1":{
             "modref":"global.EQ8"
+          },
+          "inst2":{
+            "modref":"global.and_wrapped"
           }
         },
         "connections":[
           ["inst1.I1","const_4_8.out"],
-          ["inst1.O","inst0.CE"],
+          ["inst2.O","inst0.CE"],
           ["self.CLK","inst0.CLK"],
           ["self.I","inst0.I"],
           ["self.O","inst0.O"],
           ["self.RESET","inst0.RESET"],
-          ["self.addr","inst1.I0"]
+          ["self.addr","inst1.I0"],
+          ["inst2.I0","inst1.O"],
+          ["self.CE","inst2.I1"]
         ]
       },
       "DFF_init0_has_ceTrue_has_resetTrue_has_async_resetFalse":{
@@ -376,6 +381,23 @@
           ["self.I.9","inst9.I"],
           ["self.O.9","inst9.O"],
           ["self.RESET","inst9.RESET"]
+        ]
+      },
+      "and_wrapped":{
+        "type":["Record",[
+          ["I0","BitIn"],
+          ["I1","BitIn"],
+          ["O","Bit"]
+        ]],
+        "instances":{
+          "inst0":{
+            "modref":"corebit.and"
+          }
+        },
+        "connections":[
+          ["self.I0","inst0.in0"],
+          ["self.I1","inst0.in1"],
+          ["self.O","inst0.out"]
         ]
       }
     }

--- a/test_common/test_config_register.py
+++ b/test_common/test_config_register.py
@@ -2,7 +2,7 @@ import os
 import filecmp
 import magma as m
 from magma.bit_vector import BitVector
-from magma.simulator.python_simulator import PythonSimulator
+from magma.simulator.coreir_simulator import CoreIRSimulator
 from common.config_register import define_config_register
 
 
@@ -21,7 +21,7 @@ def test_config_register():
     assert res == 0
 
     # Check the module against a simple simulation.
-    simulator = PythonSimulator(cr, clock=cr.CLK)
+    simulator = CoreIRSimulator(cr, clock=cr.CLK)
 
     def reg_value():
         return simulator.get_value(cr.O)
@@ -29,14 +29,15 @@ def test_config_register():
     def step(I, addr):
         simulator.set_value(cr.I, I)
         simulator.set_value(cr.addr, addr)
+        simulator.set_value(cr.CE, 1)
         simulator.advance(2)
         return reg_value()
 
     assert BitVector(reg_value()) == BitVector(0, WIDTH)
     sequence = [(0, 0, 0),
-                (12, 4, 0),
+                (12, 4, 12),
                 (0, 0, 12),
-                (0, 0, 12)]
+                (9, 4, 9)]
     for (I, addr, out_expected) in sequence:
         out = step(BitVector(I, WIDTH), BitVector(addr, ADDR_WIDTH))
         assert BitVector(out) == BitVector(out_expected, WIDTH)


### PR DESCRIPTION
It uses the coreir mux implementation, which is not supported by the
Python simulator because it uses a commonlib mux which has a tuple.
The coreir simulator supports the tuple value.

Also update the config register CE logic to actually use outer most
CE. (This was causing the coreir simulation to fail, because CE was unwired).

Also, there was some difference in the semantics of the simulation results. @rsetaluri can you double check the updated test vectors? My though is that each sequence calls `advance(2) with the inputs `I` and `addr`, so the `out_expected` in the sequence should immediately be updated with the `I` value (in the same step call).