### PR TITLE
Gc functional model

### DIFF
--- a/global_controller/README.md
+++ b/global_controller/README.md
@@ -21,3 +21,35 @@
 |  READ_CLK_SWITCH_DELAY_SEL   | 16 |  |   |  :heavy_check_mark: |
 
 ## Using the functional Model:
+An example:
+```
+gc_inst = gc()
+res = gc_inst(op=GCOp.CONFIG_WRITE, addr=random_addr, data=random_data)
+```
+
+When calling the global controller functional model, you can provide 3 kwargs: 
+- op (GCOp)
+- addr
+- data
+
+Op is required, but data, and addr may or may not be required, depending on the op (see the table of ops for more info).
+Calling the functional model.
+
+This returns the global controller object which you can probe to see the output sequence that resulted from the op.
+
+Here's a list of the attributes you can probe:
+- config_addr_out
+- config_data_out
+- read
+- config_data_to_jtag
+- rw_delay_sel
+- clk_switch_delay_sel
+- TST
+- stall
+- clk_sel
+
+Each of these attributes represents either an output or internal register of the GC. Because the responses to many of the global controller ops span multiple clock cycles, each of these attributes is a Python list, where each element of the list corresponds to the value of that register in a single clock cycle. If an op doesn't affect a specific attribute, it is left as a list of length 1. The sole element of this list is the value of this signal for the duration of the op.
+
+### Things That Aren't Modeled (yet):
+- For clock switching, you just write to a clock select register. There are no clock inputs or outputs in the functional model.
+- Clock switch delay select. You can select whether at the end of a clock switch, the clock is ungated on a rising or falling edge in the actual hardware. Again, in the functional model, this is just a 1 bit register you can read from/write to.

--- a/global_controller/README.md
+++ b/global_controller/README.md
@@ -1,1 +1,23 @@
-Global Controller source
+# Global Controller source
+
+## Global Controller ops:
+| Op                           | Opcode |config_data required   | config_addr required | Has output | Notes
+| -----------------------------| :----: | :--------:            | :-------:            | :----:     | --------
+|  NOP                         | 0 |                      |                      | 
+|  CONFIG_WRITE                | 1 |:heavy_check_mark:   | :heavy_check_mark:   |            |        
+|  CONFIG_READ                 | 2 |                     |  :heavy_check_mark:  | :heavy_check_mark: |           
+|  WRITE_A050                  | 4 |                      |                      | :heavy_check_mark: | output A050 to JTAG. "Is the chip alive?"
+|  WRITE_TST                   | 5 | :heavy_check_mark:   |                      |                    | A register we can r/w to. Doesn't do anything.
+|  READ_TST                    | 6 |   |    | :heavy_check_mark: |          
+|  GLOBAL_RESET                | 7 |:heavy_check_mark:  |   |   | Reset the CGRA fabric, but not the controller.
+|  WRITE_STALL                 | 8 |:heavy_check_mark: |   |    |  Stall: N-bit register, where N=# of stall domains
+|  READ_STALL                  | 9 |  |   | :heavy_check_mark: |       
+|  ADVANCE_CLK                 | 10 |:heavy_check_mark:  | :heavy_check_mark:  |  |  Deassert stall domains asserted in config_addr for config_data cycles
+|  READ_CLK_DOMAIN             | 11 |  |   |   :heavy_check_mark: |  Are we running the tiles on TCK or the faster system_clk? 0: TCK, 1: system_clk
+|  SWITCH_CLK                  | 12 |:heavy_check_mark:  |   |     |    Switch to fast clk (config_data=1) or TCK (config_data=0)
+|  WRITE_RW_DELAY_SEL          | 13 |:heavy_check_mark:  |    |     |  controls how long read/write as asserted for a config_read or config_write
+|  READ_RW_DELAY_SEL           | 14 | |   |  :heavy_check_mark: |      
+|  WRITE_CLK_SWITCH_DELAY_SEL  | 15 | :heavy_check_mark: |   |    |  Controls whether the clock is ungated on a rising edge (config_data=1) or a falling edge (config_data=0). Not actually modeled in functional model   
+|  READ_CLK_SWITCH_DELAY_SEL   | 16 |  |   |  :heavy_check_mark: |
+
+## Using the functional Model:

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -25,7 +25,6 @@ class opcode(Enum):
     rd_analog_reg = 21
 
 
-
 def gen_global_controller(config_data_width: int,
                           config_addr_width: int,
                           config_op_width: int,

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -13,6 +13,25 @@ class GC_reg_addr(Enum):
     clk_switch_delay_sel_addr = 4
 
 
+class GC_op(Enum):
+    NOP = 0
+    write_config = 1
+    read_config = 2
+    write_A050 = 4
+    write_TST = 5
+    read_TST = 6
+    global_reset = 7
+    write_stall = 8
+    read_stall = 9
+    advance_clk = 10
+    read_clk_domain = 11
+    switch_clk = 12
+    wr_rd_delay_reg = 13
+    rd_rd_delay_reg = 14
+    wr_delay_sel_reg = 15
+    rd_delay_sel_reg = 16
+
+
 def gen_global_controller(config_data_width: int,
                           config_addr_width: int,
                           config_op_width: int):

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -24,26 +24,22 @@ def gen_global_controller(config_data_width: int,
             self.reset()
 
         def reset(self):
-            self.GC_regs = {GC_reg_addr.TST_addr:
-                            [BitVector(0, config_data_width)],
-                            GC_reg_addr.stall_addr:
-                            [BitVector(0, self.NUM_STALL_DOMAINS)],
-                            GC_reg_addr.clk_sel_addr:
-                            [BitVector(0, 1)],
-                            [GC_reg_addr.rw_delay_sel_addr]:
-                            [BitVector(0, config_data_width)],
-                            GC_reg_addr.clk_switch_delay_sel_addr:
-                            [BitVector(0, 1)]}
+            self.TST = [BitVector(0, config_data_width)]
+            self.stall = [BitVector(0, self.NUM_STALL_DOMAINS)]
+            self.clk_sel = [BitVector(0, 1)]
+            self.rw_delay_sel = [BitVector(0, config_data_width)]
+            self.clk_switch_delay_sel = [BitVector(0, 1)]
+
             self.reset_out = [0]
             self.config_addr_out = [BitVector(0, config_addr_width)]
             self.config_data_out = [BitVector(0, config_data_width)]
             self.config_data_in = fault.UnknownValue
             self.read = [0]
             self.write = [0]
-            self.config_data_to_jtag = [0]
+            self.config_data_to_jtag = [BitVector(0, config_data_width)]
 
         def config_read(self, addr):
-            rw_delay = self.GC_regs[GC_reg_addr.rw_delay_sel_addr][0]
+            rw_delay = self.rw_delay_sel[0]
             duration = rw_delay.as_uint()
             self.read = [1] * duration + [0]
             self.write = [0] * (duration + 1)
@@ -53,7 +49,7 @@ def gen_global_controller(config_data_width: int,
                 + [self.config_data_in] * duration
 
         def config_write(self, addr, data):
-            rw_delay = self.GC_regs[GC_reg_addr.rw_delay_sel_addr][0]
+            rw_delay = self.rw_delay_sel[0]
             duration = rw_delay.as_uint()
             self.read = [0] * (duration + 1)
             self.write = [1] * duration + [0]
@@ -63,12 +59,33 @@ def gen_global_controller(config_data_width: int,
                 * (duration + 1)
 
         def read_GC_reg(self, addr):
-            self.config_data_to_jtag = [BitVector(self.GC_regs[addr][-1],
-                                                  config_data_width)]
+            if (addr == GC_reg_addr.TST_addr):
+                out = self.TST[-1]
+            elif (addr == GC_reg_addr.stall_addr):
+                out = self.stall[-1]
+            elif (addr == GC_reg_addr.clk_sel_addr):
+                out = self.clk_sel[-1]
+            elif (addr == GC_reg_addr.rw_delay_sel_addr):
+                out = self.rw_delay_sel[-1]
+            elif (addr == GC_reg_addr.clk_switch_delay_sel_addr):
+                out = self.clk_switch_delay_sel[-1]
+            else:
+                raise ValueError("Reading from invalid GC_reg address")
+            self.config_data_to_jtag = [BitVector(out, config_data_width)]
 
-        def write_GC_reg(self, addr, data):
-            reg_width = self.GC_regs[addr].num_bits
-            self.GC_regs[addr] = [BitVector(data, reg_width)]
+        def write_GC_reg(self, addr, data: BitVector):
+            if (addr == GC_reg_addr.TST_addr):
+                self.TST = [BitVector(data, config_data_width)]
+            elif (addr == GC_reg_addr.stall_addr):
+                self.stall = [BitVector(data, self.NUM_STALL_DOMAINS)]
+            elif (addr == GC_reg_addr.clk_sel_addr):
+                self.clk_sel = [BitVector(data, 1)]
+            elif (addr == GC_reg_addr.rw_delay_sel_addr):
+                self.rw_delay_sel = [BitVector(data, config_data_width)]
+            elif (addr == GC_reg_addr.clk_switch_delay_sel_addr):
+                self.clk_switch_delay_sel = [BitVector(data, 1)]
+            else:
+                raise ValueError("Writing to invalid GC_reg address")
 
         def global_reset(self, data: BitVector):
             if (data > 0):
@@ -77,15 +94,14 @@ def gen_global_controller(config_data_width: int,
                 self.reset_out = [1] * 20 + [0]
 
         def advance_clk(self, addr: BitVector, data: BitVector):
-            save_stall_reg = self.GC_regs[GC_reg_addr.stall_addr][-1]
+            save_stall_reg = self.stall[-1]
             temp_stall_reg = BitVector(0, self.NUM_STALL_DOMAINS)
             for i in range(self.NUM_STALL_DOMAINS):
                 if (addr[i] == 1 and save_stall_reg[i] == 1):
                     temp_stall_reg[i] = 0
                 else:
                     temp_stall_reg[i] = save_stall_reg[i]
-            self.GC_regs[GC_reg_addr.stall_addr] = [temp_stall_reg] \
-                * data.as_uint() + [save_stall_reg]
+            self.stall = [temp_stall_reg] * data.as_uint() + [save_stall_reg]
 
         def set_config_data_in(self, data):
             self.config_data_in = BitVector(data, config_data_width)
@@ -93,8 +109,7 @@ def gen_global_controller(config_data_width: int,
         def __cleanup(self):
             # Remove sequences from outputs/regs in preparation for the next
             # op.
-            self.GC_regs[GC_reg_addr.stall_addr] \
-                = [self.GC_regs[GC_reg_addr.stall_addr][-1]]
+            self.stall = [self.stall[-1]]
             self.config_addr_out = [self.config_addr_out[-1]]
             self.config_data_out = [self.config_data_out[-1]]
             self.read = [self.read[-1]]

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -4,21 +4,32 @@ from enum import Enum
 import magma as m
 
 
-class State(Enum):
-    READY = 0
-    READING = 1
-    RESETTING = 2
-    ADVANCING_CLK = 3
-    SWITCHING_CLK = 4
+class opcode(Enum):
+    NOP = 0
+    write_config = 1
+    read_config = 2
+    write_A050 = 7
+    write_TST = 8
+    read_TST = 9
+    global_reset = 10
+    write_stall = 11
+    read_stall = 12
+    advance_clk = 13
+    read_clk_domain = 14
+    switch_clk = 15
+    wr_rd_delay_reg = 16
+    rd_rd_delay_reg = 17
+    wr_delay_sel_reg = 18
+    rd_delay_sel_reg = 19
+    wr_analog_reg = 20
+    rd_analog_reg = 21
 
 
-def gen_global_controller(config_data_with: int,
+
+def gen_global_controller(config_data_width: int,
                           config_addr_width: int,
-                          config_op_with: int,
+                          config_op_width: int,
                           num_analog_regs: int):
-    CONFIG_ADDR_WIDTH = 32
-    CONFIG_DATA_WIDTH = 32
-    CONFIG_OP_WIDTH = 5
 
     class GlobalController(Model()):
         def __init__(self):
@@ -32,20 +43,17 @@ def gen_global_controller(config_data_with: int,
             self.write = None
             self.cgra_stalled = None
             self.reset_out = 1
-            self.state = State.READY
 
         def config_read(self, addr):
-            if (self.state == State.READY):
-                self.read = 1
-                self.write = 0
-                self.config_addr_out = addr
+            self.read = 1
+            self.write = 0
+            self.config_addr_out = addr
 
         def config_write(self, addr, data):
-            if (self.state == State.READY):
-                self.read = 0
-                self.write = 1
-                self.config_addr_out = addr
-                self.config_data_out = data
+            self.read = 0
+            self.write = 1
+            self.config_addr_out = addr
+            self.config_data_out = data
 
         def __call__(self, *args, **kwargs):
             raise NotImplementedError()

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -15,8 +15,8 @@ class GC_reg_addr(Enum):
 
 class GC_op(Enum):
     NOP = 0
-    write_config = 1
-    read_config = 2
+    config_write = 1
+    config_read = 2
     write_A050 = 4
     write_TST = 5
     read_TST = 6
@@ -26,10 +26,10 @@ class GC_op(Enum):
     advance_clk = 10
     read_clk_domain = 11
     switch_clk = 12
-    wr_rd_delay_reg = 13
-    rd_rd_delay_reg = 14
-    wr_delay_sel_reg = 15
-    rd_delay_sel_reg = 16
+    write_rw_delay_sel = 13
+    read_rd_delay_reg = 14
+    write_clk_switch_delay_sel = 15
+    read_clk_switch_delay_sel = 16
 
 
 def gen_global_controller(config_data_width: int,
@@ -141,7 +141,42 @@ def gen_global_controller(config_data_width: int,
             self.write = [self.write[-1]]
             self.config_data_to_jtag = [self.config_data_to_jtag[-1]]
 
-        def __call__(self, *args, **kwargs):
+        def __call__(self, **kwargs):
+            # Op is mandatory. Other args are optional
+            op = kwargs['op']
+            if 'data' in kwargs:
+                data = kwargs['data']
+            if 'addr' in kwargs:
+                addr = kwargs['addr']
+            # Decode op
+            if (op == GC_op.config_write):
+                self.config_write(addr, data)
+            elif (op == GC_op.config_write_A050):
+                raise NotImplementedError()
+            elif (op == GC_op.write_TST):
+                self.write_GC_reg(GC_reg_addr.TST_addr, data)
+            elif (op == GC_op.read_TST):
+                self.read_GC_reg(GC_reg_addr.TST_addr)
+            elif (op == GC_op.global_reset):
+                self.global_reset(data)
+            elif (op == GC_op.write_stall):
+                self.write_GC_reg(GC_reg_addr.stall_addr, data)
+            elif (op == GC_op.read_stall):
+                self.read_GC_reg(GC_reg_addr.stall_addr)
+            elif (op == GC_op.advance_clk):
+                self.advance_clk(addr, data)
+            elif (op == GC_op.read_clk_domain):
+                self.read_GC_reg(GC_reg_addr.clk_sel_addr)
+            elif (op == GC_op.switch_clk):
+                self.write_GC_reg(GC_reg_addr.clk_sel_addr, data)
+            elif (op == GC_op.write_rw_delay_sel):
+                self.write_GC_reg(GC_reg_addr.rw_delay_sel_addr, data)
+            elif (op == GC_op.read_rw_delay_sel):
+                self.read_GC_reg(GC_reg_addr.rw_delay_sel_addr)
+            elif (op == GC_op.write_clk_switch_delay_sel):
+                self.write_GC_reg(GC_reg_addr.clk_switch_delay_sel_addr, data)
+            elif (op == GC_op.read_clk_switch_delay_sel):
+                self.read_GC_reg(GC_reg_addr.clk_switch_delay_sel_addr)
             return self
 
     return _GlobalController

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -1,0 +1,21 @@
+from common.model import Model
+from bit_vector import BitVector
+from enum import Enum
+import magma as m
+
+
+class State(Enum):
+    READY = 0
+    READING = 1
+    RESETTING = 2
+    ADVANCING_CLK = 3
+    SWITCHING_CLK = 4
+
+
+class GlobalController:
+    def __init__(self, config_addr_width, config_data_width, config_op_width,
+                 num_analog_regs):
+        self.config_addr_width = config_addr_width
+        self.config_data_width = config_data_width
+        self.config_op_width = config_op_width
+        self.num_analog_regs = num_analog_regs

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -91,10 +91,10 @@ def gen_global_controller(config_data_width: int,
             else:
                 raise ValueError("Writing to invalid GC_reg address")
 
-        def global_reset(self, data: BitVector):
+        def global_reset(self, data):
             self.__cleanup()
             if (data > 0):
-                self.reset_out = [1] * data.as_uint() + [0]
+                self.reset_out = [1] * data + [0]
             else:
                 self.reset_out = [1] * 20 + [0]
 

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -118,7 +118,7 @@ def gen_global_controller(config_data_width: int,
 
         def __call__(self, *args, **kwargs):
             output_obj = self
-            self._cleanup()
+            self.__cleanup()
             return output_obj
 
     return _GlobalController

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -5,31 +5,31 @@ import magma as m
 import fault
 
 
-class GC_reg_addr(Enum):
-    TST_addr = 0
-    stall_addr = 1
-    clk_sel_addr = 2
-    rw_delay_sel_addr = 3
-    clk_switch_delay_sel_addr = 4
+class GCRegAddr(Enum):
+    TST_ADDR = 0
+    STALL_ADDR = 1
+    CLK_SEL_ADDR = 2
+    RW_DELAY_SEL_ADDR = 3
+    CLK_SWITCH_DELAY_SEL_ADDR = 4
 
 
-class GC_op(Enum):
+class GCOp(Enum):
     NOP = 0
-    config_write = 1
-    config_read = 2
-    write_A050 = 4
-    write_TST = 5
-    read_TST = 6
-    global_reset = 7
-    write_stall = 8
-    read_stall = 9
-    advance_clk = 10
-    read_clk_domain = 11
-    switch_clk = 12
-    write_rw_delay_sel = 13
-    read_rw_delay_sel = 14
-    write_clk_switch_delay_sel = 15
-    read_clk_switch_delay_sel = 16
+    CONFIG_WRITE = 1
+    CONFIG_READ = 2
+    WRITE_A050 = 4
+    WRITE_TST = 5
+    READ_TST = 6
+    GLOBAL_RESET = 7
+    WRITE_STALL = 8
+    READ_STALL = 9
+    ADVANCE_CLK = 10
+    READ_CLK_DOMAIN = 11
+    SWITCH_CLK = 12
+    WRITE_RW_DELAY_SEL = 13
+    READ_RW_DELAY_SEL = 14
+    WRITE_CLK_SWITCH_DELAY_SEL = 15
+    READ_CLK_SWITCH_DELAY_SEL = 16
 
 
 def gen_global_controller(config_data_width: int,
@@ -57,7 +57,7 @@ def gen_global_controller(config_data_width: int,
             self.write = [0]
             self.config_data_to_jtag = [BitVector(0, config_data_width)]
 
-        def config_read(self, addr):
+        def CONFIG_READ(self, addr):
             rw_delay = self.rw_delay_sel[0]
             duration = rw_delay.as_uint()
             self.read = [1] * duration + [0]
@@ -67,7 +67,7 @@ def gen_global_controller(config_data_width: int,
             self.config_data_to_jtag = [self.config_data_to_jtag[-1]] \
                 + [self.config_data_in] * duration
 
-        def config_write(self, addr, data):
+        def CONFIG_WRITE(self, addr, data):
             rw_delay = self.rw_delay_sel[0]
             duration = rw_delay.as_uint()
             self.read = [0] * (duration + 1)
@@ -78,35 +78,35 @@ def gen_global_controller(config_data_width: int,
                 * (duration + 1)
 
         def read_GC_reg(self, addr):
-            if (addr == GC_reg_addr.TST_addr):
+            if (addr == GCRegAddr.TST_ADDR):
                 out = self.TST[-1]
-            elif (addr == GC_reg_addr.stall_addr):
+            elif (addr == GCRegAddr.STALL_ADDR):
                 out = self.stall[-1]
-            elif (addr == GC_reg_addr.clk_sel_addr):
+            elif (addr == GCRegAddr.CLK_SEL_ADDR):
                 out = self.clk_sel[-1]
-            elif (addr == GC_reg_addr.rw_delay_sel_addr):
+            elif (addr == GCRegAddr.RW_DELAY_SEL_ADDR):
                 out = self.rw_delay_sel[-1]
-            elif (addr == GC_reg_addr.clk_switch_delay_sel_addr):
+            elif (addr == GCRegAddr.CLK_SWITCH_DELAY_SEL_ADDR):
                 out = self.clk_switch_delay_sel[-1]
             else:
                 raise ValueError("Reading from invalid GC_reg address")
             self.config_data_to_jtag = [BitVector(out, config_data_width)]
 
         def write_GC_reg(self, addr, data):
-            if (addr == GC_reg_addr.TST_addr):
+            if (addr == GCRegAddr.TST_ADDR):
                 self.TST = [BitVector(data, config_data_width)]
-            elif (addr == GC_reg_addr.stall_addr):
+            elif (addr == GCRegAddr.STALL_ADDR):
                 self.stall = [BitVector(data, self.NUM_STALL_DOMAINS)]
-            elif (addr == GC_reg_addr.clk_sel_addr):
+            elif (addr == GCRegAddr.CLK_SEL_ADDR):
                 self.clk_sel = [BitVector(data, 1)]
-            elif (addr == GC_reg_addr.rw_delay_sel_addr):
+            elif (addr == GCRegAddr.RW_DELAY_SEL_ADDR):
                 self.rw_delay_sel = [BitVector(data, config_data_width)]
-            elif (addr == GC_reg_addr.clk_switch_delay_sel_addr):
+            elif (addr == GCRegAddr.CLK_SWITCH_DELAY_SEL_ADDR):
                 self.clk_switch_delay_sel = [BitVector(data, 1)]
             else:
                 raise ValueError("Writing to invalid GC_reg address")
 
-        def global_reset(self, data):
+        def GLOBAL_RESET(self, data):
             if (data > 0):
                 self.reset_out = [1] * data + [0]
             else:
@@ -115,7 +115,7 @@ def gen_global_controller(config_data_width: int,
         def wr_A050(self):
             self.config_data_to_jtag = [BitVector(0xA050, config_data_width)]
 
-        def advance_clk(self, addr, data):
+        def ADVANCE_CLK(self, addr, data):
             save_stall_reg = self.stall[-1]
             temp_stall_reg = BitVector(0, self.NUM_STALL_DOMAINS)
             mask = BitVector(addr, self.NUM_STALL_DOMAINS)
@@ -146,36 +146,36 @@ def gen_global_controller(config_data_width: int,
             if 'addr' in kwargs:
                 addr = kwargs['addr']
             # Decode op
-            if (op == GC_op.config_write):
-                self.config_write(addr, data)
-            if (op == GC_op.config_read):
-                self.config_read(addr)
-            elif (op == GC_op.write_A050):
+            if (op == GCOp.CONFIG_WRITE):
+                self.CONFIG_WRITE(addr, data)
+            if (op == GCOp.CONFIG_READ):
+                self.CONFIG_READ(addr)
+            elif (op == GCOp.WRITE_A050):
                 self.wr_A050()
-            elif (op == GC_op.write_TST):
-                self.write_GC_reg(GC_reg_addr.TST_addr, data)
-            elif (op == GC_op.read_TST):
-                self.read_GC_reg(GC_reg_addr.TST_addr)
-            elif (op == GC_op.global_reset):
-                self.global_reset(data)
-            elif (op == GC_op.write_stall):
-                self.write_GC_reg(GC_reg_addr.stall_addr, data)
-            elif (op == GC_op.read_stall):
-                self.read_GC_reg(GC_reg_addr.stall_addr)
-            elif (op == GC_op.advance_clk):
-                self.advance_clk(addr, data)
-            elif (op == GC_op.read_clk_domain):
-                self.read_GC_reg(GC_reg_addr.clk_sel_addr)
-            elif (op == GC_op.switch_clk):
-                self.write_GC_reg(GC_reg_addr.clk_sel_addr, data)
-            elif (op == GC_op.write_rw_delay_sel):
-                self.write_GC_reg(GC_reg_addr.rw_delay_sel_addr, data)
-            elif (op == GC_op.read_rw_delay_sel):
-                self.read_GC_reg(GC_reg_addr.rw_delay_sel_addr)
-            elif (op == GC_op.write_clk_switch_delay_sel):
-                self.write_GC_reg(GC_reg_addr.clk_switch_delay_sel_addr, data)
-            elif (op == GC_op.read_clk_switch_delay_sel):
-                self.read_GC_reg(GC_reg_addr.clk_switch_delay_sel_addr)
+            elif (op == GCOp.WRITE_TST):
+                self.write_GC_reg(GCRegAddr.TST_ADDR, data)
+            elif (op == GCOp.READ_TST):
+                self.read_GC_reg(GCRegAddr.TST_ADDR)
+            elif (op == GCOp.GLOBAL_RESET):
+                self.GLOBAL_RESET(data)
+            elif (op == GCOp.WRITE_STALL):
+                self.write_GC_reg(GCRegAddr.STALL_ADDR, data)
+            elif (op == GCOp.READ_STALL):
+                self.read_GC_reg(GCRegAddr.STALL_ADDR)
+            elif (op == GCOp.ADVANCE_CLK):
+                self.ADVANCE_CLK(addr, data)
+            elif (op == GCOp.READ_CLK_DOMAIN):
+                self.read_GC_reg(GCRegAddr.CLK_SEL_ADDR)
+            elif (op == GCOp.SWITCH_CLK):
+                self.write_GC_reg(GCRegAddr.CLK_SEL_ADDR, data)
+            elif (op == GCOp.WRITE_RW_DELAY_SEL):
+                self.write_GC_reg(GCRegAddr.RW_DELAY_SEL_ADDR, data)
+            elif (op == GCOp.READ_RW_DELAY_SEL):
+                self.read_GC_reg(GCRegAddr.RW_DELAY_SEL_ADDR)
+            elif (op == GCOp.WRITE_CLK_SWITCH_DELAY_SEL):
+                self.write_GC_reg(GCRegAddr.CLK_SWITCH_DELAY_SEL_ADDR, data)
+            elif (op == GCOp.READ_CLK_SWITCH_DELAY_SEL):
+                self.read_GC_reg(GCRegAddr.CLK_SWITCH_DELAY_SEL_ADDR)
             return self
 
     return _GlobalController

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -98,16 +98,17 @@ def gen_global_controller(config_data_width: int,
             else:
                 self.reset_out = [1] * 20 + [0]
 
-        def advance_clk(self, addr: BitVector, data: BitVector):
+        def advance_clk(self, addr, data):
             self.__cleanup()
             save_stall_reg = self.stall[-1]
             temp_stall_reg = BitVector(0, self.NUM_STALL_DOMAINS)
+            mask = BitVector(addr, self.NUM_STALL_DOMAINS)
             for i in range(self.NUM_STALL_DOMAINS):
-                if (addr[i] == 1 and save_stall_reg[i] == 1):
+                if (mask[i] == 1 and save_stall_reg[i] == 1):
                     temp_stall_reg[i] = 0
                 else:
                     temp_stall_reg[i] = save_stall_reg[i]
-            self.stall = [temp_stall_reg] * data.as_uint() + [save_stall_reg]
+            self.stall = [temp_stall_reg] * data + [save_stall_reg]
 
         def set_config_data_in(self, data):
             self.__cleanup()

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -54,5 +54,19 @@ def gen_global_controller(config_data_width: int,
             self.config_addr_out = addr
             self.config_data_out = data
 
+        def clock_switch(self, data):
+            raise notimplementederror()
+
+        def read_GC_reg(self, addr):
+            raise notimplementederror()
+  
+        def write_GC_reg(self, addr, data):
+            raise notimplementederror()
+
+
+
+
+
+
         def __call__(self, *args, **kwargs):
-            raise NotImplementedError()
+            raise notimplementederror()

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -2,7 +2,7 @@ from common.model import Model
 from bit_vector import BitVector
 from enum import Enum
 import magma as m
-
+import fault
 
 class GC_reg_addr(Enum):
     TST_addr = 0
@@ -34,7 +34,7 @@ def gen_global_controller(config_data_width: int,
             self.reset_out = 0
             self.config_addr_out = BitVector(0, config_addr_width)
             self.config_data_out = BitVector(0, config_data_width)
-            self.config_data_in = None
+            self.config_data_in = fault.UnknownValue
             self.read = 0
             self.write = 0
 

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -27,7 +27,7 @@ def gen_global_controller(config_data_width: int,
             self.TST = [BitVector(0, config_data_width)]
             self.stall = [BitVector(0, self.NUM_STALL_DOMAINS)]
             self.clk_sel = [BitVector(0, 1)]
-            self.rw_delay_sel = [BitVector(0, config_data_width)]
+            self.rw_delay_sel = [BitVector(2, config_data_width)]
             self.clk_switch_delay_sel = [BitVector(0, 1)]
 
             self.reset_out = [0]

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -39,12 +39,12 @@ def gen_global_controller(config_data_width: int,
     class _GlobalController(ConfigurableModel(32, 32)):
         def __init__(self):
             super().__init__()
-            self.NUM_STALL_DOMAINS = 4
+            self.num_stall_domains = 4
             self.reset()
 
         def reset(self):
             self.TST = [BitVector(0, config_data_width)]
-            self.stall = [BitVector(0, self.NUM_STALL_DOMAINS)]
+            self.stall = [BitVector(0, self.num_stall_domains)]
             self.clk_sel = [BitVector(0, 1)]
             self.rw_delay_sel = [BitVector(2, config_data_width)]
             self.clk_switch_delay_sel = [BitVector(0, 1)]
@@ -96,7 +96,7 @@ def gen_global_controller(config_data_width: int,
             if (addr == GCRegAddr.TST_ADDR):
                 self.TST = [BitVector(data, config_data_width)]
             elif (addr == GCRegAddr.STALL_ADDR):
-                self.stall = [BitVector(data, self.NUM_STALL_DOMAINS)]
+                self.stall = [BitVector(data, self.num_stall_domains)]
             elif (addr == GCRegAddr.CLK_SEL_ADDR):
                 self.clk_sel = [BitVector(data, 1)]
             elif (addr == GCRegAddr.RW_DELAY_SEL_ADDR):
@@ -117,9 +117,9 @@ def gen_global_controller(config_data_width: int,
 
         def ADVANCE_CLK(self, addr, data):
             save_stall_reg = self.stall[-1]
-            temp_stall_reg = BitVector(0, self.NUM_STALL_DOMAINS)
-            mask = BitVector(addr, self.NUM_STALL_DOMAINS)
-            for i in range(self.NUM_STALL_DOMAINS):
+            temp_stall_reg = BitVector(0, self.num_stall_domains)
+            mask = BitVector(addr, self.num_stall_domains)
+            for i in range(self.num_stall_domains):
                 if (mask[i] == 1):
                     temp_stall_reg[i] = 0
             self.stall = [temp_stall_reg] * data + [save_stall_reg]

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -31,22 +31,24 @@ def gen_global_controller(config_data_width: int,
                          BitVector(0, config_data_width),
                          GC_reg_addr.clk_switch_delay_sel_addr:
                          BitVector(0, 1)}
-            self.reset_out = BitVector(0, 1)
+            self.reset_out = 0
             self.config_addr_out = BitVector(0, config_addr_width)
             self.config_data_out = BitVector(0, config_data_width)
-            self.read = BitVector(0, 1)
-            self.write = BitVector(0, 1)
+            self.config_data_in = None
+            self.read = 0
+            self.write = 0
 
         def config_read(self, addr):
             self.read = 1
             self.write = 0
-            self.config_addr_out = addr
+            self.config_addr_out = BitVector(addr, config_addr_width)
+            self.config_data_to_jtag = self.config_data_in
 
         def config_write(self, addr, data):
             self.read = 0
             self.write = 1
-            self.config_addr_out = addr
-            self.config_data_out = data
+            self.config_addr_out = BitVector(addr, config_addr_width)
+            self.config_data_out = BitVector(data, config_data_width)
 
         def read_GC_reg(self, addr):
             self.config_data_to_jtag = BitVector(self.regs[addr]._value,
@@ -56,11 +58,16 @@ def gen_global_controller(config_data_width: int,
             reg_width = self.regs[addr].num_bits
             self.regs[addr] = BitVector(data._value, reg_width)
 
-        def advance_clk(self, addr: BitVector):
-            raise NotImplementedError()
-
         def global_reset(self, data: BitVector):
-            raise NotImplementedError()
+            self.reset_out = 0
+
+        def advance_clk(self, addr: BitVector, data: BitVector):
+            for i in range(self.NUM_STALL_DOMAINS):
+                if (data[i] == 1):
+                    self.regs[GC_reg_addr.stall_addr][i] = 0
+
+        def set_config_data_in(self, data):
+            self.config_data_in = BitVector(data, config_data_width)
 
         def __call__(self, *args, **kwargs):
             raise NotImplementedError()

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -26,3 +26,20 @@ def gen_global_controller(config_data_with: int, config_addr_width: int,
             self.write = None
             self.cgra_stalled = None
             self.reset_out = 1
+            self.state = State.READY
+
+        def config_read(self, addr):
+            if (self.state == State.READY):
+                self.read = 1
+                self.write = 0
+                self.config_addr_out = addr
+
+        def config_write(self, addr, data):
+            if (self.state == State.READY):
+                self.read = 0
+                self.write = 1
+                self.config_addr_out = addr
+                self.config_data_out = data
+
+        def __call__(self, *args, **kwargs):
+            raise NotImplementedError()

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -43,8 +43,8 @@ def gen_global_controller(config_data_width: int,
             self.config_data_to_jtag = [0]
 
         def config_read(self, addr):
-            duration = BitVector.as_uint(self.GC_regs
-                                         [GC_reg_addr.rw_delay_sel_addr])
+            rw_delay = self.GC_regs[GC_reg_addr.rw_delay_sel_addr][0]
+            duration = rw_delay.as_uint()
             self.read = [1] * duration + [0]
             self.write = [0] * (duration + 1)
             self.config_addr_out = [BitVector(addr, config_addr_width)] \
@@ -53,8 +53,8 @@ def gen_global_controller(config_data_width: int,
                 + [self.config_data_in] * duration
 
         def config_write(self, addr, data):
-            duration = BitVector.as_uint(
-                       self.GC_regs[GC_reg_addr.rw_delay_sel_addr])
+            rw_delay = self.GC_regs[GC_reg_addr.rw_delay_sel_addr][0]
+            duration = rw_delay.as_uint()
             self.read = [0] * (duration + 1)
             self.write = [1] * duration + [0]
             self.config_addr_out = [BitVector(addr, config_addr_width)] \
@@ -70,9 +70,9 @@ def gen_global_controller(config_data_width: int,
             reg_width = self.GC_regs[addr].num_bits
             self.GC_regs[addr] = [BitVector(data, reg_width)]
 
-        def global_reset(self, data):
+        def global_reset(self, data: BitVector):
             if (data > 0):
-                self.reset_out = [1] * BitVector.as_uint(data) + [0]
+                self.reset_out = [1] * data.as_uint() + [0]
             else:
                 self.reset_out = [1] * 20 + [0]
 
@@ -85,7 +85,7 @@ def gen_global_controller(config_data_width: int,
                 else:
                     temp_stall_reg[i] = save_stall_reg[i]
             self.GC_regs[GC_reg_addr.stall_addr] = [temp_stall_reg] \
-                * BitVector.as_uint(data) + [save_stall_reg]
+                * data.as_uint() + [save_stall_reg]
 
         def set_config_data_in(self, data):
             self.config_data_in = BitVector(data, config_data_width)

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -39,6 +39,7 @@ def gen_global_controller(config_data_width: int,
             self.config_data_to_jtag = [BitVector(0, config_data_width)]
 
         def config_read(self, addr):
+            self.__cleanup()
             rw_delay = self.rw_delay_sel[0]
             duration = rw_delay.as_uint()
             self.read = [1] * duration + [0]
@@ -49,6 +50,7 @@ def gen_global_controller(config_data_width: int,
                 + [self.config_data_in] * duration
 
         def config_write(self, addr, data):
+            self.__cleanup()
             rw_delay = self.rw_delay_sel[0]
             duration = rw_delay.as_uint()
             self.read = [0] * (duration + 1)
@@ -59,6 +61,7 @@ def gen_global_controller(config_data_width: int,
                 * (duration + 1)
 
         def read_GC_reg(self, addr):
+            self.__cleanup()
             if (addr == GC_reg_addr.TST_addr):
                 out = self.TST[-1]
             elif (addr == GC_reg_addr.stall_addr):
@@ -74,6 +77,7 @@ def gen_global_controller(config_data_width: int,
             self.config_data_to_jtag = [BitVector(out, config_data_width)]
 
         def write_GC_reg(self, addr, data: BitVector):
+            self.__cleanup()
             if (addr == GC_reg_addr.TST_addr):
                 self.TST = [BitVector(data, config_data_width)]
             elif (addr == GC_reg_addr.stall_addr):
@@ -88,12 +92,14 @@ def gen_global_controller(config_data_width: int,
                 raise ValueError("Writing to invalid GC_reg address")
 
         def global_reset(self, data: BitVector):
+            self.__cleanup()
             if (data > 0):
                 self.reset_out = [1] * data.as_uint() + [0]
             else:
                 self.reset_out = [1] * 20 + [0]
 
         def advance_clk(self, addr: BitVector, data: BitVector):
+            self.__cleanup()
             save_stall_reg = self.stall[-1]
             temp_stall_reg = BitVector(0, self.NUM_STALL_DOMAINS)
             for i in range(self.NUM_STALL_DOMAINS):
@@ -104,6 +110,7 @@ def gen_global_controller(config_data_width: int,
             self.stall = [temp_stall_reg] * data.as_uint() + [save_stall_reg]
 
         def set_config_data_in(self, data):
+            self.__cleanup()
             self.config_data_in = BitVector(data, config_data_width)
 
         def __cleanup(self):
@@ -114,11 +121,9 @@ def gen_global_controller(config_data_width: int,
             self.config_data_out = [self.config_data_out[-1]]
             self.read = [self.read[-1]]
             self.write = [self.write[-1]]
-            self.config_data_to_jtag = self.config_data_to_jtag[-1]
+            self.config_data_to_jtag = [self.config_data_to_jtag[-1]]
 
         def __call__(self, *args, **kwargs):
-            output_obj = self
-            self.__cleanup()
-            return output_obj
+            return self
 
     return _GlobalController

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -104,10 +104,8 @@ def gen_global_controller(config_data_width: int,
             temp_stall_reg = BitVector(0, self.NUM_STALL_DOMAINS)
             mask = BitVector(addr, self.NUM_STALL_DOMAINS)
             for i in range(self.NUM_STALL_DOMAINS):
-                if (mask[i] == 1 and save_stall_reg[i] == 1):
+                if (mask[i] == 1):
                     temp_stall_reg[i] = 0
-                else:
-                    temp_stall_reg[i] = save_stall_reg[i]
             self.stall = [temp_stall_reg] * data + [save_stall_reg]
 
         def set_config_data_in(self, data):

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -12,8 +12,14 @@ class State(Enum):
     SWITCHING_CLK = 4
 
 
-def gen_global_controller(config_data_with: int, config_addr_width: int,
-                          config_op_with: int, num_analog_regs: int):
+def gen_global_controller(config_data_with: int,
+                          config_addr_width: int,
+                          config_op_with: int,
+                          num_analog_regs: int):
+    CONFIG_ADDR_WIDTH = 32
+    CONFIG_DATA_WIDTH = 32
+    CONFIG_OP_WIDTH = 5
+
     class GlobalController(Model()):
         def __init__(self):
             super().__init__()

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -76,7 +76,7 @@ def gen_global_controller(config_data_width: int,
                 raise ValueError("Reading from invalid GC_reg address")
             self.config_data_to_jtag = [BitVector(out, config_data_width)]
 
-        def write_GC_reg(self, addr, data: BitVector):
+        def write_GC_reg(self, addr, data):
             self.__cleanup()
             if (addr == GC_reg_addr.TST_addr):
                 self.TST = [BitVector(data, config_data_width)]

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -12,10 +12,17 @@ class State(Enum):
     SWITCHING_CLK = 4
 
 
-class GlobalController:
-    def __init__(self, config_addr_width, config_data_width, config_op_width,
-                 num_analog_regs):
-        self.config_addr_width = config_addr_width
-        self.config_data_width = config_data_width
-        self.config_op_width = config_op_width
-        self.num_analog_regs = num_analog_regs
+def gen_global_controller(config_data_with: int, config_addr_width: int,
+                          config_op_with: int, num_analog_regs: int):
+    class GlobalController(Model()):
+        def __init__(self):
+            super().__init__()
+            self.reset()
+
+        def reset(self):
+            self.config_addr_out = None
+            self.config_data_out = None
+            self.read = None
+            self.write = None
+            self.cgra_stalled = None
+            self.reset_out = 1

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -24,16 +24,16 @@ def gen_global_controller(config_data_width: int,
             self.reset()
 
         def reset(self):
-            self.regs = {GC_reg_addr.TST_addr:
-                         [BitVector(0, config_data_width)],
-                         GC_reg_addr.stall_addr:
-                         [BitVector(0, self.NUM_STALL_DOMAINS)],
-                         GC_reg_addr.clk_sel_addr:
-                         [BitVector(0, 1)],
-                         GC_reg_addr.rw_delay_sel_addr:
-                         [BitVector(0, config_data_width)],
-                         GC_reg_addr.clk_switch_delay_sel_addr:
-                         [BitVector(0, 1)]}
+            self.GC_regs = {GC_reg_addr.TST_addr:
+                            [BitVector(0, config_data_width)],
+                            GC_reg_addr.stall_addr:
+                            [BitVector(0, self.NUM_STALL_DOMAINS)],
+                            GC_reg_addr.clk_sel_addr:
+                            [BitVector(0, 1)],
+                            [GC_reg_addr.rw_delay_sel_addr]:
+                            [BitVector(0, config_data_width)],
+                            GC_reg_addr.clk_switch_delay_sel_addr:
+                            [BitVector(0, 1)]}
             self.reset_out = [0]
             self.config_addr_out = [BitVector(0, config_addr_width)]
             self.config_data_out = [BitVector(0, config_data_width)]
@@ -42,7 +42,7 @@ def gen_global_controller(config_data_width: int,
             self.write = [0]
 
         def config_read(self, addr):
-            duration = BitVector.as_uint(self.regs
+            duration = BitVector.as_uint(self.GC_regs
                                          [GC_reg_addr.rw_delay_sel_addr])
             self.read = [1] * duration + [0]
             self.write = [0] * (duration + 1)
@@ -50,21 +50,22 @@ def gen_global_controller(config_data_width: int,
             self.config_data_to_jtag = self.config_data_in
 
         def config_write(self, addr, data):
-            duration = BitVector.as_uint(self.regs[GC_reg_addr.rw_delay_sel_addr])
+            duration = BitVector.as_uint(
+                       self.GC_regs[GC_reg_addr.rw_delay_sel_addr])
             self.read = [0] * (duration + 1)
             self.write = [1] * duration + [0]
             self.config_addr_out = [BitVector(addr, config_addr_width)] \
-                                    * (duration + 1)
+                * (duration + 1)
             self.config_data_out = [BitVector(data, config_data_width)] \
-                                    * (duration + 1)
+                * (duration + 1)
 
         def read_GC_reg(self, addr):
-            self.config_data_to_jtag = BitVector(self.regs[addr],
-                                                 config_data_width)
+            self.config_data_to_jtag = [BitVector(self.GC_regs[addr][-1],
+                                                  config_data_width)]
 
         def write_GC_reg(self, addr, data):
-            reg_width = self.regs[addr].num_bits
-            self.regs[addr] = BitVector(data, reg_width)
+            reg_width = self.GC_regs[addr].num_bits
+            self.GC_regs[addr] = BitVector(data, reg_width)
 
         def global_reset(self, data):
             if (data > 0):
@@ -73,12 +74,30 @@ def gen_global_controller(config_data_width: int,
                 self.reset_out = [1] * 20 + [0]
 
         def advance_clk(self, addr: BitVector, data: BitVector):
+            save_stall_reg = self.GC_regs[GC_reg_addr.stall_addr][0]
+            temp_stall_reg = BitVector(0, self.NUM_STALL_DOMAINS)
             for i in range(self.NUM_STALL_DOMAINS):
-                if (addr[i] == 1):
-                    self.regs[GC_reg_addr.stall_addr][i] = 0
+                if (addr[i] == 1 and save_stall_reg[i] == 1):
+                    temp_stall_reg[i] = 0
+                else:
+                    temp_stall_reg[i] = save_stall_reg[i]
+            self.GC_regs[GC_reg_addr.stall_addr] = [temp_stall_reg] \
+                * BitVector.as_uint(data) + [save_stall_reg]
 
         def set_config_data_in(self, data):
             self.config_data_in = BitVector(data, config_data_width)
 
+        def _cleanup(self):
+            # Remove sequences from outputs/regs in preparation for the next
+            # op.
+            self.GC_regs[GC_reg_addr.stall_addr] \
+                = [self.GC_regs[GC_reg_addr.stall_addr][-1]]
+            self.config_addr_out = [self.config_addr_out[-1]]
+            self.config_data_out = [self.config_data_out[-1]]
+            self.read = [self.read[-1]]
+            self.write = [self.write[-1]]
+
         def __call__(self, *args, **kwargs):
-            raise NotImplementedError()
+            output_obj = self
+            self._cleanup()
+            return output_obj

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -4,31 +4,15 @@ from enum import Enum
 import magma as m
 
 
-class opcode(Enum):
-    NOP = 0
-    write_config = 1
-    read_config = 2
-    write_A050 = 7
-    write_TST = 8
-    read_TST = 9
-    global_reset = 10
-    write_stall = 11
-    read_stall = 12
-    advance_clk = 13
-    read_clk_domain = 14
-    switch_clk = 15
-    wr_rd_delay_reg = 16
-    rd_rd_delay_reg = 17
-    wr_delay_sel_reg = 18
-    rd_delay_sel_reg = 19
-    wr_analog_reg = 20
-    rd_analog_reg = 21
+class GC_reg_addr(Enum):
+    TST_addr = 0
+    stall_addr = 1
+    
 
 
 def gen_global_controller(config_data_width: int,
                           config_addr_width: int,
-                          config_op_width: int,
-                          num_analog_regs: int):
+                          config_op_width: int):
 
     class GlobalController(Model()):
         def __init__(self):
@@ -36,12 +20,19 @@ def gen_global_controller(config_data_width: int,
             self.reset()
 
         def reset(self):
-            self.config_addr_out = None
-            self.config_data_out = None
-            self.read = None
-            self.write = None
-            self.cgra_stalled = None
-            self.reset_out = 1
+            self.TST = BitVector(0, config_data_width)
+            # There are 4 stall domains.
+            # Should parametrize this in the RTL
+            self.stall = BitVector(0, 4)
+            # 0: slow JTAG clk, 1: fast sys_clk
+            self.clock_sel = BitVector(0, 1)
+            self.reset_out = BitVector(0, 1)
+            self.config_addr_out = BitVector(0, config_addr_width)
+            self.config_data_out = BitVector(0, config_data_width)
+            self.read = BitVector(0, 1)
+            self.write = BitVector(0, 1)
+            self.rw_delay_sel = BitVector(config_data_width, 2)
+            self.clk_switch_delay_sel = BitVector(0, 2)
 
         def config_read(self, addr):
             self.read = 1
@@ -55,18 +46,13 @@ def gen_global_controller(config_data_width: int,
             self.config_data_out = data
 
         def clock_switch(self, data):
-            raise notimplementederror()
+            raise NotImplementedError()
 
         def read_GC_reg(self, addr):
-            raise notimplementederror()
+            raise NotImplementedError()
   
         def write_GC_reg(self, addr, data):
-            raise notimplementederror()
-
-
-
-
-
+            raise NotImplementedError()
 
         def __call__(self, *args, **kwargs):
-            raise notimplementederror()
+            raise NotImplementedError()

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -57,7 +57,7 @@ def gen_global_controller(config_data_width: int,
             self.write = [0]
             self.config_data_to_jtag = [BitVector(0, config_data_width)]
 
-        def CONFIG_READ(self, addr):
+        def config_read(self, addr):
             rw_delay = self.rw_delay_sel[0]
             duration = rw_delay.as_uint()
             self.read = [1] * duration + [0]
@@ -67,7 +67,7 @@ def gen_global_controller(config_data_width: int,
             self.config_data_to_jtag = [self.config_data_to_jtag[-1]] \
                 + [self.config_data_in] * duration
 
-        def CONFIG_WRITE(self, addr, data):
+        def config_write(self, addr, data):
             rw_delay = self.rw_delay_sel[0]
             duration = rw_delay.as_uint()
             self.read = [0] * (duration + 1)
@@ -77,7 +77,7 @@ def gen_global_controller(config_data_width: int,
             self.config_data_out = [BitVector(data, config_data_width)] \
                 * (duration + 1)
 
-        def read_GC_reg(self, addr):
+        def read_gc_reg(self, addr):
             if (addr == GCRegAddr.TST_ADDR):
                 out = self.TST[-1]
             elif (addr == GCRegAddr.STALL_ADDR):
@@ -92,7 +92,7 @@ def gen_global_controller(config_data_width: int,
                 raise ValueError("Reading from invalid GC_reg address")
             self.config_data_to_jtag = [BitVector(out, config_data_width)]
 
-        def write_GC_reg(self, addr, data):
+        def write_gc_reg(self, addr, data):
             if (addr == GCRegAddr.TST_ADDR):
                 self.TST = [BitVector(data, config_data_width)]
             elif (addr == GCRegAddr.STALL_ADDR):
@@ -106,7 +106,7 @@ def gen_global_controller(config_data_width: int,
             else:
                 raise ValueError("Writing to invalid GC_reg address")
 
-        def GLOBAL_RESET(self, data):
+        def global_reset(self, data):
             if (data > 0):
                 self.reset_out = [1] * data + [0]
             else:
@@ -115,7 +115,7 @@ def gen_global_controller(config_data_width: int,
         def wr_A050(self):
             self.config_data_to_jtag = [BitVector(0xA050, config_data_width)]
 
-        def ADVANCE_CLK(self, addr, data):
+        def advance_clk(self, addr, data):
             save_stall_reg = self.stall[-1]
             temp_stall_reg = BitVector(0, self.num_stall_domains)
             mask = BitVector(addr, self.num_stall_domains)
@@ -147,35 +147,35 @@ def gen_global_controller(config_data_width: int,
                 addr = kwargs['addr']
             # Decode op
             if (op == GCOp.CONFIG_WRITE):
-                self.CONFIG_WRITE(addr, data)
+                self.config_write(addr, data)
             if (op == GCOp.CONFIG_READ):
-                self.CONFIG_READ(addr)
+                self.config_read(addr)
             elif (op == GCOp.WRITE_A050):
                 self.wr_A050()
             elif (op == GCOp.WRITE_TST):
-                self.write_GC_reg(GCRegAddr.TST_ADDR, data)
+                self.write_gc_reg(GCRegAddr.TST_ADDR, data)
             elif (op == GCOp.READ_TST):
-                self.read_GC_reg(GCRegAddr.TST_ADDR)
+                self.read_gc_reg(GCRegAddr.TST_ADDR)
             elif (op == GCOp.GLOBAL_RESET):
-                self.GLOBAL_RESET(data)
+                self.global_reset(data)
             elif (op == GCOp.WRITE_STALL):
-                self.write_GC_reg(GCRegAddr.STALL_ADDR, data)
+                self.write_gc_reg(GCRegAddr.STALL_ADDR, data)
             elif (op == GCOp.READ_STALL):
-                self.read_GC_reg(GCRegAddr.STALL_ADDR)
+                self.read_gc_reg(GCRegAddr.STALL_ADDR)
             elif (op == GCOp.ADVANCE_CLK):
-                self.ADVANCE_CLK(addr, data)
+                self.advance_clk(addr, data)
             elif (op == GCOp.READ_CLK_DOMAIN):
-                self.read_GC_reg(GCRegAddr.CLK_SEL_ADDR)
+                self.read_gc_reg(GCRegAddr.CLK_SEL_ADDR)
             elif (op == GCOp.SWITCH_CLK):
-                self.write_GC_reg(GCRegAddr.CLK_SEL_ADDR, data)
+                self.write_gc_reg(GCRegAddr.CLK_SEL_ADDR, data)
             elif (op == GCOp.WRITE_RW_DELAY_SEL):
-                self.write_GC_reg(GCRegAddr.RW_DELAY_SEL_ADDR, data)
+                self.write_gc_reg(GCRegAddr.RW_DELAY_SEL_ADDR, data)
             elif (op == GCOp.READ_RW_DELAY_SEL):
-                self.read_GC_reg(GCRegAddr.RW_DELAY_SEL_ADDR)
+                self.read_gc_reg(GCRegAddr.RW_DELAY_SEL_ADDR)
             elif (op == GCOp.WRITE_CLK_SWITCH_DELAY_SEL):
-                self.write_GC_reg(GCRegAddr.CLK_SWITCH_DELAY_SEL_ADDR, data)
+                self.write_gc_reg(GCRegAddr.CLK_SWITCH_DELAY_SEL_ADDR, data)
             elif (op == GCOp.READ_CLK_SWITCH_DELAY_SEL):
-                self.read_GC_reg(GCRegAddr.CLK_SWITCH_DELAY_SEL_ADDR)
+                self.read_gc_reg(GCRegAddr.CLK_SWITCH_DELAY_SEL_ADDR)
             return self
 
     return _GlobalController

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -27,7 +27,7 @@ class GC_op(Enum):
     read_clk_domain = 11
     switch_clk = 12
     write_rw_delay_sel = 13
-    read_rd_delay_reg = 14
+    read_rw_delay_sel = 14
     write_clk_switch_delay_sel = 15
     read_clk_switch_delay_sel = 16
 
@@ -151,7 +151,9 @@ def gen_global_controller(config_data_width: int,
             # Decode op
             if (op == GC_op.config_write):
                 self.config_write(addr, data)
-            elif (op == GC_op.config_write_A050):
+            if (op == GC_op.config_read):
+                self.config_read(addr)
+            elif (op == GC_op.write_A050):
                 raise NotImplementedError()
             elif (op == GC_op.write_TST):
                 self.write_GC_reg(GC_reg_addr.TST_addr, data)

--- a/global_controller/global_controller.py
+++ b/global_controller/global_controller.py
@@ -1,4 +1,4 @@
-from common.model import Model
+from common.configurable_model import ConfigurableModel
 from bit_vector import BitVector
 from enum import Enum
 import magma as m
@@ -17,7 +17,7 @@ def gen_global_controller(config_data_width: int,
                           config_addr_width: int,
                           config_op_width: int):
 
-    class GlobalController(Model()):
+    class _GlobalController(ConfigurableModel(32, 32)):
         def __init__(self):
             super().__init__()
             self.NUM_STALL_DOMAINS = 4
@@ -105,3 +105,5 @@ def gen_global_controller(config_data_width: int,
             output_obj = self
             self._cleanup()
             return output_obj
+
+    return _GlobalController

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -1,7 +1,6 @@
 from bit_vector import BitVector
 from global_controller.global_controller import \
     gen_global_controller, GCOp, GCRegAddr
-import fault
 import random
 
 

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -47,7 +47,7 @@ def test_global_controller_functional_model():
     gc_inst = gc()
     max_config_data = (2**CONFIG_DATA_WIDTH) - 1
     max_config_addr = (2**CONFIG_ADDR_WIDTH) - 1
-    max_stall = (2**gc_inst.NUM_STALL_DOMAINS) - 1
+    max_stall = (2**gc_inst.num_stall_domains) - 1
     # Check wr_A050. What you'd do when you bring up the chip
     res = gc_inst(op=GCOp.WRITE_A050)
     assert len(res.config_data_to_jtag) == 1
@@ -92,14 +92,14 @@ def test_global_controller_functional_model():
     assert len(res.stall) == 1
 
     # Now Try advancing the clk (Temporary stall deassertion)
-    adv_clk_addr = BitVector.random(gc_inst.NUM_STALL_DOMAINS)
+    adv_clk_addr = BitVector.random(gc_inst.num_stall_domains)
     duration = random.randint(1, 100)
     res = gc_inst(op=GCOp.ADVANCE_CLK, addr=adv_clk_addr, data=duration)
     assert len(res.stall) == duration + 1
     # Make sure that we reverted back to original stall value at end
     assert res.stall[-1] == new_stall
     # Now check that stall was deasserted for the specified values
-    for i in range(res.NUM_STALL_DOMAINS):
+    for i in range(res.num_stall_domains):
         if(adv_clk_addr[i] == 1):
             for j in range(duration):
                 assert(res.stall[j][i] == 0)

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -1,33 +1,33 @@
 from bit_vector import BitVector
 from global_controller.global_controller import (gen_global_controller,
-                                                 GC_op,
-                                                 GC_reg_addr)
+                                                 GCOp,
+                                                 GCRegAddr)
 import fault
 import random
 
 
 # Function to read and write to global controller regs
 # and perform checks
-def check_GC_reg(gc_inst, reg: GC_reg_addr):
-    if (reg == GC_reg_addr.TST_addr):
-        rd_op = GC_op.read_TST
-        wr_op = GC_op.write_TST
+def check_GC_reg(gc_inst, reg: GCRegAddr):
+    if (reg == GCRegAddr.TST_ADDR):
+        rd_op = GCOp.READ_TST
+        wr_op = GCOp.WRITE_TST
         width = gc_inst.TST[0].num_bits
-    elif (reg == GC_reg_addr.stall_addr):
-        rd_op = GC_op.read_stall
-        wr_op = GC_op.write_stall
+    elif (reg == GCRegAddr.STALL_ADDR):
+        rd_op = GCOp.READ_STALL
+        wr_op = GCOp.WRITE_STALL
         width = gc_inst.stall[0].num_bits
-    elif (reg == GC_reg_addr.clk_sel_addr):
-        rd_op = GC_op.read_clk_domain
-        wr_op = GC_op.switch_clk
+    elif (reg == GCRegAddr.CLK_SEL_ADDR):
+        rd_op = GCOp.READ_CLK_DOMAIN
+        wr_op = GCOp.SWITCH_CLK
         width = 1
-    elif (reg == GC_reg_addr.rw_delay_sel_addr):
-        rd_op = GC_op.read_rw_delay_sel
-        wr_op = GC_op.write_rw_delay_sel
+    elif (reg == GCRegAddr.RW_DELAY_SEL_ADDR):
+        rd_op = GCOp.READ_RW_DELAY_SEL
+        wr_op = GCOp.WRITE_RW_DELAY_SEL
         width = gc_inst.rw_delay_sel[0].num_bits
-    elif (reg == GC_reg_addr.clk_switch_delay_sel_addr):
-        rd_op = GC_op.read_clk_switch_delay_sel
-        wr_op = GC_op.write_clk_switch_delay_sel
+    elif (reg == GCRegAddr.CLK_SWITCH_DELAY_SEL_ADDR):
+        rd_op = GCOp.READ_CLK_SWITCH_DELAY_SEL
+        wr_op = GCOp.WRITE_CLK_SWITCH_DELAY_SEL
         width = 1
     random_data = BitVector.random(width)
     res = gc_inst(op=wr_op, data=random_data)
@@ -49,7 +49,7 @@ def test_global_controller_functional_model():
     max_config_addr = (2**CONFIG_ADDR_WIDTH) - 1
     max_stall = (2**gc_inst.NUM_STALL_DOMAINS) - 1
     # Check wr_A050. What you'd do when you bring up the chip
-    res = gc_inst(op=GC_op.write_A050)
+    res = gc_inst(op=GCOp.WRITE_A050)
     assert len(res.config_data_to_jtag) == 1
     assert res.config_data_to_jtag[0] == 0xA050
     # Set some data to read later
@@ -57,7 +57,7 @@ def test_global_controller_functional_model():
     gc_inst.set_config_data_in(random_input)
     random_addr = random.randint(1, max_config_addr)
     # read the random input data
-    res = gc_inst(op=GC_op.config_read, addr=random_addr)
+    res = gc_inst(op=GCOp.CONFIG_READ, addr=random_addr)
     # assert read immediately
     assert res.read[0] == 1
     # Read must be deasserted by the end of the top
@@ -67,7 +67,7 @@ def test_global_controller_functional_model():
 
     # Try changing the read_delay
     new_rw_delay = random.randint(1, 20)
-    res = gc_inst(op=GC_op.write_rw_delay_sel, data=new_rw_delay)
+    res = gc_inst(op=GCOp.WRITE_RW_DELAY_SEL, data=new_rw_delay)
     # assert that the register val was written properly
     assert res.rw_delay_sel[-1] == new_rw_delay
 
@@ -75,7 +75,7 @@ def test_global_controller_functional_model():
     # Perform a config write
     random_data = random.randint(1, max_config_data)
     random_addr = random.randint(1, max_config_addr)
-    res = gc_inst(op=GC_op.config_write, addr=random_addr, data=random_data)
+    res = gc_inst(op=GCOp.CONFIG_WRITE, addr=random_addr, data=random_data)
     # check that write was asserted and read wasn't
     assert len(res.write) == (new_rw_delay+1)
     assert all(res.write[0:new_rw_delay])
@@ -87,14 +87,14 @@ def test_global_controller_functional_model():
 
     # Now Try stalling
     new_stall = BitVector(random.randint(1, max_stall))
-    res = gc_inst(op=GC_op.write_stall, data=new_stall)
+    res = gc_inst(op=GCOp.WRITE_STALL, data=new_stall)
     assert res.stall[0] == new_stall
     assert len(res.stall) == 1
 
     # Now Try advancing the clk (Temporary stall deassertion)
     adv_clk_addr = BitVector.random(gc_inst.NUM_STALL_DOMAINS)
     duration = random.randint(1, 100)
-    res = gc_inst(op=GC_op.advance_clk, addr=adv_clk_addr, data=duration)
+    res = gc_inst(op=GCOp.ADVANCE_CLK, addr=adv_clk_addr, data=duration)
     assert len(res.stall) == duration + 1
     # Make sure that we reverted back to original stall value at end
     assert res.stall[-1] == new_stall
@@ -106,9 +106,9 @@ def test_global_controller_functional_model():
 
     # Test Global Reset
     reset_duration = random.randint(1, 100)
-    res = gc_inst(op=GC_op.global_reset, data=reset_duration)
+    res = gc_inst(op=GCOp.GLOBAL_RESET, data=reset_duration)
     assert len(res.reset_out) == reset_duration + 1
 
     # Write to and read from the rest of the GC regs
-    for reg in GC_reg_addr:
+    for reg in GCRegAddr:
         check_GC_reg(gc_inst, reg)

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -7,7 +7,7 @@ import random
 
 # Function to read and write to global controller regs
 # and perform checks
-def check_GC_reg(gc_inst, reg: GCRegAddr):
+def check_gc_reg(gc_inst, reg: GCRegAddr):
     if (reg == GCRegAddr.TST_ADDR):
         rd_op = GCOp.READ_TST
         wr_op = GCOp.WRITE_TST
@@ -110,4 +110,4 @@ def test_global_controller_functional_model():
 
     # Write to and read from the rest of the GC regs
     for reg in GCRegAddr:
-        check_GC_reg(gc_inst, reg)
+        check_gc_reg(gc_inst, reg)

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -1,13 +1,11 @@
 from bit_vector import BitVector
-from global_controller.global_controller import gen_global_controller
+from global_controller.global_controller import (gen_global_controller,
+                                                 GC_reg_addr)
 import fault
 import random
 
 
 def test_global_controller_functional_model():
-    """
-    Small test to show the usage of the GC functional model.
-    """
     CONFIG_DATA_WIDTH = 32
     CONFIG_ADDR_WIDTH = 32
     CONFIG_OP_WIDTH = 5
@@ -31,3 +29,7 @@ def test_global_controller_functional_model():
     assert res.read[-1] == 0
     assert res.config_addr_out[0] == random_addr
     assert res.config_data_to_jtag[-1] == random_input
+
+    # Try changing the read_delay
+    new_read_delay = random.randint(1, 20)
+    gc_inst.write_GC_reg(GC_reg_addr.rw_delay_sel_addr, new_read_delay)

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -1,16 +1,33 @@
 from bit_vector import BitVector
 from global_controller.global_controller import gen_global_controller
+import fault
+import random
 
 
 def test_global_controller_functional_model():
     """
     Small test to show the usage of the GC functional model.
     """
-    gc = gen_global_controller(32, 32, 5)
+    CONFIG_DATA_WIDTH = 32
+    CONFIG_ADDR_WIDTH = 32
+    CONFIG_OP_WIDTH = 5
+    gc = gen_global_controller(CONFIG_DATA_WIDTH,
+                               CONFIG_ADDR_WIDTH,
+                               CONFIG_OP_WIDTH)
     gc_inst = gc()
-    gc_inst.set_config_data_in(24)
-    gc_inst.config_read(99)
+    max_config_data = (2**CONFIG_DATA_WIDTH) - 1
+    max_config_addr = (2**CONFIG_ADDR_WIDTH) - 1
+    # Set some data to read later
+    random_input = random.randint(1, max_config_data)
+    gc_inst.set_config_data_in(random_input)
+
+    random_addr = random.randint(1, max_config_addr)
+    # read the random input data
+    gc_inst.config_read(random_addr)
     res = gc_inst()
+    # assert read immediately
     assert res.read[0] == 1
-    assert res.config_addr_out[0] == 99
-    assert res.config_data_to_jtag[1] == 24
+    # Read must be deasserted by the end of the top
+    assert res.read[-1] == 0
+    assert res.config_addr_out[0] == random_addr
+    assert res.config_data_to_jtag[-1] == random_input

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -16,6 +16,10 @@ def test_global_controller_functional_model():
     max_config_data = (2**CONFIG_DATA_WIDTH) - 1
     max_config_addr = (2**CONFIG_ADDR_WIDTH) - 1
     max_stall = (2**gc_inst.NUM_STALL_DOMAINS) - 1
+    # Check wr_A050. What you'd do when you bring up the chip
+    res = gc_inst(op=GC_op.write_A050)
+    assert len(res.config_data_to_jtag) == 1
+    assert res.config_data_to_jtag[0] == 0xA050
     # Set some data to read later
     random_input = random.randint(1, max_config_data)
     gc_inst.set_config_data_in(random_input)

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -1,7 +1,6 @@
 from bit_vector import BitVector
-from global_controller.global_controller import (gen_global_controller,
-                                                 GCOp,
-                                                 GCRegAddr)
+from global_controller.global_controller import \
+    gen_global_controller, GCOp, GCRegAddr
 import fault
 import random
 

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -1,6 +1,6 @@
 from bit_vector import BitVector
 from global_controller.global_controller import (gen_global_controller,
-                                                 GC_reg_addr)
+                                                 GC_op)
 import fault
 import random
 
@@ -21,55 +21,55 @@ def test_global_controller_functional_model():
     gc_inst.set_config_data_in(random_input)
     random_addr = random.randint(1, max_config_addr)
     # read the random input data
-    gc_inst.config_read(random_addr)
+    res = gc_inst(op=GC_op.config_read, addr=random_addr)
     # assert read immediately
-    assert gc_inst.read[0] == 1
+    assert res.read[0] == 1
     # Read must be deasserted by the end of the top
-    assert gc_inst.read[-1] == 0
-    assert gc_inst.config_addr_out[0] == random_addr
-    assert gc_inst.config_data_to_jtag[-1] == random_input
+    assert res.read[-1] == 0
+    assert res.config_addr_out[0] == random_addr
+    assert res.config_data_to_jtag[-1] == random_input
 
     # Try changing the read_delay
     new_rw_delay = random.randint(1, 20)
-    gc_inst.write_GC_reg(GC_reg_addr.rw_delay_sel_addr, new_rw_delay)
+    res = gc_inst(op=GC_op.write_rw_delay_sel, data=new_rw_delay)
     # assert that the register val was written properly
-    assert gc_inst.rw_delay_sel[-1] == new_rw_delay
+    assert res.rw_delay_sel[-1] == new_rw_delay
 
     # Now, verify that that change actually took effect
     # Perform a config write
     random_data = random.randint(1, max_config_data)
     random_addr = random.randint(1, max_config_addr)
-    gc_inst.config_write(random_addr, random_data)
+    res = gc_inst(op=GC_op.config_write, addr=random_addr, data=random_data)
     # check that write was asserted and read wasn't
-    assert len(gc_inst.write) == (new_rw_delay+1)
-    assert all(gc_inst.write[0:new_rw_delay])
-    assert gc_inst.write[-1] == 0
-    assert len(gc_inst.read) == (new_rw_delay+1)
-    assert all(rd == 0 for rd in gc_inst.read)
-    assert all(addr == random_addr for addr in gc_inst.config_addr_out)
-    assert all(data == random_data for data in gc_inst.config_data_out)
+    assert len(res.write) == (new_rw_delay+1)
+    assert all(res.write[0:new_rw_delay])
+    assert res.write[-1] == 0
+    assert len(res.read) == (new_rw_delay+1)
+    assert all(rd == 0 for rd in res.read)
+    assert all(addr == random_addr for addr in res.config_addr_out)
+    assert all(data == random_data for data in res.config_data_out)
 
     # Now Try stalling
     new_stall = BitVector(random.randint(1, max_stall))
-    gc_inst.write_GC_reg(GC_reg_addr.stall_addr, new_stall)
-    assert gc_inst.stall[0] == new_stall
-    assert len(gc_inst.stall) == 1
+    res = gc_inst(op=GC_op.write_stall, data=new_stall)
+    assert res.stall[0] == new_stall
+    assert len(res.stall) == 1
 
     # Now Try advancing the clk (Temporary stall deassertion)
     adv_clk_addr = BitVector.random(gc_inst.NUM_STALL_DOMAINS)
-    adv_clk_duration = random.randint(1, 100)
-    gc_inst.advance_clk(adv_clk_addr, adv_clk_duration)
-    assert len(gc_inst.stall) == adv_clk_duration + 1
+    duration = random.randint(1, 100)
+    res = gc_inst(op=GC_op.advance_clk, addr=adv_clk_addr, data=duration)
+    assert len(res.stall) == duration + 1
     # Make sure that we reverted back to original stall value at end
-    assert gc_inst.stall[-1] == new_stall
+    assert res.stall[-1] == new_stall
     # Now check that stall was deasserted for the specified values
-    for i in range(gc_inst.NUM_STALL_DOMAINS):
+    for i in range(res.NUM_STALL_DOMAINS):
         if(adv_clk_addr[i] == 1):
-            for j in range(adv_clk_duration):
-                assert(gc_inst.stall[j][i] == 0)
+            for j in range(duration):
+                assert(res.stall[j][i] == 0)
 
     # Test Global Reset
     reset_duration = random.randint(1, 100)
-    gc_inst.global_reset(reset_duration)
-    assert len(gc_inst.reset_out) == reset_duration + 1
-    assert all(gc_inst.reset_out[0:reset_duration])
+    res = gc_inst(op=GC_op.global_reset, data=reset_duration)
+    assert len(res.reset_out) == reset_duration + 1
+    

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -31,5 +31,22 @@ def test_global_controller_functional_model():
     assert res.config_data_to_jtag[-1] == random_input
 
     # Try changing the read_delay
-    new_read_delay = random.randint(1, 20)
-    gc_inst.write_GC_reg(GC_reg_addr.rw_delay_sel_addr, new_read_delay)
+    new_rw_delay = random.randint(1, 20)
+    gc_inst.write_GC_reg(GC_reg_addr.rw_delay_sel_addr, new_rw_delay)
+    res = gc_inst()
+    # assert that the register val was written properly
+    assert res.rw_delay_sel[-1] == new_rw_delay
+
+    # Now, verify that that change actually took effect
+    # Perform a config write
+    random_data = random.randint(1, max_config_data)
+    random_addr = random.randint(1, max_config_addr)
+    gc_inst.config_write(random_addr, random_data)
+    # check that write was asserted and read wasn't
+    assert len(gc_inst.write) == (new_rw_delay+1)
+    assert all(gc_inst.write[0:new_rw_delay])
+    assert gc_inst.write[-1] == 0
+    assert len(gc_inst.read) == (new_rw_delay+1)
+    assert all(rd == 0 for rd in gc_inst.read)
+    assert all(addr == random_addr for addr in gc_inst.config_addr_out)
+    assert all(data == random_data for data in gc_inst.config_data_out)

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -72,4 +72,3 @@ def test_global_controller_functional_model():
     reset_duration = random.randint(1, 100)
     res = gc_inst(op=GC_op.global_reset, data=reset_duration)
     assert len(res.reset_out) == reset_duration + 1
-    

--- a/test_global_controller/test_global_controller.py
+++ b/test_global_controller/test_global_controller.py
@@ -1,0 +1,16 @@
+from bit_vector import BitVector
+from global_controller.global_controller import gen_global_controller
+
+
+def test_global_controller_functional_model():
+    """
+    Small test to show the usage of the GC functional model.
+    """
+    gc = gen_global_controller(32, 32, 5)
+    gc_inst = gc()
+    gc_inst.set_config_data_in(24)
+    gc_inst.config_read(99)
+    res = gc_inst()
+    assert res.read[0] == 1
+    assert res.config_addr_out[0] == 99
+    assert res.config_data_to_jtag[1] == 24


### PR DESCRIPTION
Adds the functional model for the global controller and the accompanying tests.

The global controller differs pretty significantly from the other modules in that for many of the opcodes, multiple sequences of outputs need to be modeled. To do this, I model the outputs as lists of BitVectors, where each element of an output list is the value of that output in a given clock cycle.

Some things regarding clock switching aren't completely modeled here:

- For clock switching, you just write to a clock select register. There are no clock inputs or outputs in the functional model.
- Clock switch delay select. You can select whether at the end of a clock switch, the clock is ungated on a rising or falling edge in the actual hardware. Again, in the functional model, this is just a 1 bit register you can read from/write to.