### PR TITLE
Add read data

### DIFF
--- a/column/column_magma.py
+++ b/column/column_magma.py
@@ -4,6 +4,7 @@ import generator.generator as generator
 from common.side_type import SideType
 from generator.configurable import ConfigurationType
 from generator.from_magma import FromMagma
+from generator.const import Const
 
 
 class Column(generator.Generator):
@@ -21,7 +22,8 @@ class Column(generator.Generator):
             config=magma.In(ConfigurationType(32, 32)),
             clk=magma.In(magma.Clock),
             rst=magma.In(magma.Reset),
-            read_config_data=magma.Out(32)
+            read_config_data=magma.Out(32),
+            column_num=magma.In(8)
         )
 
         self.read_data_OR = FromMagma(mantle.Or(self.height, 32))
@@ -35,6 +37,10 @@ class Column(generator.Generator):
             self.wire(self.ports.east[i], tile.ports.east)
             self.wire(tile.ports.read_config_data,
                       self.read_data_OR.ports["I"+i])
+            # Wire upper 8 bits of tile ID to row number
+            self.wire(tile.ports.tile_id[8:16], Const(magma.bits(i, 8)))
+            # Wire lower 8 bits of tile ID to col number
+            self.wire(tile.ports.tile_id[0:8], self.ports.column_num)
         for i in range(1, self.height):
             t0 = self.tiles[i - 1]
             t1 = self.tiles[i]

--- a/column/column_magma.py
+++ b/column/column_magma.py
@@ -3,6 +3,7 @@ import mantle
 import generator.generator as generator
 from common.side_type import SideType
 from generator.configurable import ConfigurationType
+from generator.from_magma import FromMagma
 
 
 class Column(generator.Generator):
@@ -23,8 +24,8 @@ class Column(generator.Generator):
             read_config_data=magma.Out(32)
         )
 
-        read_data_OR = self.FromMagma(mantle.Or(self.height, 32))
-        self.wire(read_data_OR.ports.O, self.read_config_data)
+        self.read_data_OR = FromMagma(mantle.Or(self.height, 32))
+        self.wire(self.read_data_OR.ports.O, self.read_config_data)
         for tile in self.tiles:
             self.wire(self.ports.config, tile.ports.config)
         self.wire(self.ports.north, self.tiles[0].ports.north)
@@ -32,7 +33,8 @@ class Column(generator.Generator):
         for i, tile in enumerate(self.tiles):
             self.wire(self.ports.west[i], tile.ports.west)
             self.wire(self.ports.east[i], tile.ports.east)
-            self.wire(tile.ports.read_config_data, read_data_OR.ports["I"+i])
+            self.wire(tile.ports.read_config_data,
+                      self.read_data_OR.ports["I"+i])
         for i in range(1, self.height):
             t0 = self.tiles[i - 1]
             t1 = self.tiles[i]

--- a/column/column_magma.py
+++ b/column/column_magma.py
@@ -22,12 +22,12 @@ class Column(generator.Generator):
             config=magma.In(ConfigurationType(32, 32)),
             clk=magma.In(magma.Clock),
             rst=magma.In(magma.Reset),
-            read_config_data=magma.Out(32),
-            column_num=magma.In(8)
+            read_config_data=magma.Out(magma.Bits(32)),
+            column_num=magma.In(magma.Bits(8)),
         )
 
-        self.read_data_OR = FromMagma(mantle.Or(self.height, 32))
-        self.wire(self.read_data_OR.ports.O, self.read_config_data)
+        self.read_data_OR = FromMagma(mantle.DefineOr(self.height, 32))
+        self.wire(self.read_data_OR.ports.O, self.ports.read_config_data)
         for tile in self.tiles:
             self.wire(self.ports.config, tile.ports.config)
         self.wire(self.ports.north, self.tiles[0].ports.north)
@@ -36,7 +36,7 @@ class Column(generator.Generator):
             self.wire(self.ports.west[i], tile.ports.west)
             self.wire(self.ports.east[i], tile.ports.east)
             self.wire(tile.ports.read_config_data,
-                      self.read_data_OR.ports["I"+i])
+                      self.read_data_OR.ports[f"I{i}"])
             # Wire upper 8 bits of tile ID to row number
             self.wire(tile.ports.tile_id[8:16], Const(magma.bits(i, 8)))
             # Wire lower 8 bits of tile ID to col number

--- a/column/column_magma.py
+++ b/column/column_magma.py
@@ -1,4 +1,5 @@
 import magma
+import mantle
 import generator.generator as generator
 from common.side_type import SideType
 from generator.configurable import ConfigurationType
@@ -19,8 +20,11 @@ class Column(generator.Generator):
             config=magma.In(ConfigurationType(32, 32)),
             clk=magma.In(magma.Clock),
             rst=magma.In(magma.Reset),
+            read_config_data=magma.Out(32)
         )
 
+        read_data_OR = self.FromMagma(mantle.Or(self.height, 32))
+        self.wire(read_data_OR.ports.O, self.read_config_data)
         for tile in self.tiles:
             self.wire(self.ports.config, tile.ports.config)
         self.wire(self.ports.north, self.tiles[0].ports.north)
@@ -28,6 +32,7 @@ class Column(generator.Generator):
         for i, tile in enumerate(self.tiles):
             self.wire(self.ports.west[i], tile.ports.west)
             self.wire(self.ports.east[i], tile.ports.east)
+            self.wire(tile.ports.read_config_data, read_data_OR.ports["I"+i])
         for i in range(1, self.height):
             t0 = self.tiles[i - 1]
             t1 = self.tiles[i]

--- a/common/mux_with_default.py
+++ b/common/mux_with_default.py
@@ -6,7 +6,7 @@ from generator.const import Const
 from generator.from_magma import FromMagma
 
 
-class mux_with_default_wrapper(generator.Generator):
+class MuxWithDefaultWrapper(generator.Generator):
     def __init__(self, height, width, default=0):
         super().__init__()
 

--- a/common/mux_with_default.py
+++ b/common/mux_with_default.py
@@ -1,0 +1,47 @@
+import magma
+import mantle
+from common.mux_wrapper import MuxWrapper
+import generator.generator as generator
+from generator.const import Const
+from generator.from_magma import FromMagma
+
+
+class mux_with_default_wrapper(generator.Generator):
+    def __init__(self, height, width, default=0):
+        super().__init__()
+
+        self.data_mux = MuxWrapper(height, width)
+        self.default_mux = MuxWrapper(2, width)
+        self.sel_bits = self.data_mux.sel_bits
+        lt = mantle.ULT(self.sel_bits+1)
+        and_gate = mantle.And(2)
+        self.lt = FromMagma(lt)
+        self.and_gate = FromMagma(and_gate)
+
+        T = magma.Bits(width)
+        self.add_ports(
+            I=magma.In(magma.Array(height, T)),
+            S=magma.In(magma.Bits(self.sel_bits)),
+            EN=magma.In(1),
+            O=magma.Out(T)
+        )
+        # Wire data inputs to data mux
+        for i in range(self.height):
+            self.wire(self.ports.I[i], self.data_mux.ports[f"I{i}"])
+        # wire select input to select input of data_mux
+        self.wire(self.ports.S, self.data_mux.ports.S)
+        # wire default value of first input of default mux
+        self.wire(Const(magma.bits(default, 32)),
+                  self.read_config_data_mux.ports.I[0])
+        # wire output of data_mux to second input of default mux
+        self.wire(self.data_mux.ports.O, self.default_mux.ports.I[1])
+        # if(S < height & EN):
+        #     O = I[S]
+        # else:
+        #     O = default
+        self.wire(self.ports.S, self.lt.ports.I0)
+        self.wire(Const(magma.bits(height, self.sel_bits+1)),
+                  self.lt.ports.I1)
+        self.wire(self.lt.ports.O, self.and_gate.ports.I0)
+        self.wire(self.ports.EN, self.and_gate.ports.I1)
+        self.wire(self.and_gate.ports.O, self.default_mux.ports.S)

--- a/common/mux_with_default.py
+++ b/common/mux_with_default.py
@@ -10,11 +10,14 @@ class MuxWithDefaultWrapper(generator.Generator):
     def __init__(self, height, width, default=0):
         super().__init__()
 
+        self.height = height
+        self.width = width
+        self.default = default
         self.data_mux = MuxWrapper(height, width)
         self.default_mux = MuxWrapper(2, width)
         self.sel_bits = self.data_mux.sel_bits
-        lt = mantle.ULT(self.sel_bits+1)
-        and_gate = mantle.And(2)
+        lt = mantle.DefineULT(self.sel_bits)
+        and_gate = mantle.DefineAnd(2)
         self.lt = FromMagma(lt)
         self.and_gate = FromMagma(and_gate)
 
@@ -22,17 +25,17 @@ class MuxWithDefaultWrapper(generator.Generator):
         self.add_ports(
             I=magma.In(magma.Array(height, T)),
             S=magma.In(magma.Bits(self.sel_bits)),
-            EN=magma.In(1),
+            EN=magma.In(magma.Bits(1)),
             O=magma.Out(T)
         )
         # Wire data inputs to data mux
         for i in range(self.height):
-            self.wire(self.ports.I[i], self.data_mux.ports[f"I{i}"])
+            self.wire(self.ports.I[i], self.data_mux.ports.I[i])
         # wire select input to select input of data_mux
         self.wire(self.ports.S, self.data_mux.ports.S)
         # wire default value of first input of default mux
         self.wire(Const(magma.bits(default, 32)),
-                  self.read_config_data_mux.ports.I[0])
+                  self.default_mux.ports.I[0])
         # wire output of data_mux to second input of default mux
         self.wire(self.data_mux.ports.O, self.default_mux.ports.I[1])
         # if(S < height & EN):
@@ -40,8 +43,13 @@ class MuxWithDefaultWrapper(generator.Generator):
         # else:
         #     O = default
         self.wire(self.ports.S, self.lt.ports.I0)
-        self.wire(Const(magma.bits(height, self.sel_bits+1)),
+        self.wire(Const(magma.bits(height, self.sel_bits)),
                   self.lt.ports.I1)
         self.wire(self.lt.ports.O, self.and_gate.ports.I0)
-        self.wire(self.ports.EN, self.and_gate.ports.I1)
-        self.wire(self.and_gate.ports.O, self.default_mux.ports.S)
+        self.wire(self.ports.EN[0], self.and_gate.ports.I1)
+        self.wire(self.and_gate.ports.O, self.default_mux.ports.S[0])
+        self.wire(self.default_mux.ports.O, self.ports.O)
+
+    def name(self):
+        return f"MuxWithDefaultWrapper_{self.height}_{self.width}"\
+            f"_{self.default}"

--- a/common/mux_wrapper.py
+++ b/common/mux_wrapper.py
@@ -29,5 +29,3 @@ class MuxWrapper(generator.Generator):
 
     def name(self):
         return f"MuxWrapper_{self.height}_{self.width}"
-
-

--- a/common/mux_wrapper.py
+++ b/common/mux_wrapper.py
@@ -24,7 +24,8 @@ class MuxWrapper(generator.Generator):
 
         for i in range(self.height):
             self.wire(self.ports.I[i], self.mux.ports[f"I{i}"])
-        self.wire(self.ports.S, self.mux.ports.S)
+        mux_in = self.ports.S if self.sel_bits > 1 else self.ports.S[0]
+        self.wire(mux_in, self.mux.ports.S)
         self.wire(self.mux.ports.O, self.ports.O)
 
     def name(self):

--- a/common/side_type.py
+++ b/common/side_type.py
@@ -2,7 +2,7 @@ import magma
 
 
 def SideType(num_tracks, layers):
-    layers_dict = {f"layer{l}" : magma.Array(num_tracks, magma.Bits(l)) \
+    layers_dict = {f"layer{l}": magma.Array(num_tracks, magma.Bits(l))
                    for l in layers}
     T = magma.Tuple(**layers_dict)
     return magma.Tuple(I=magma.In(T), O=magma.Out(T))

--- a/common/zext_wrapper.py
+++ b/common/zext_wrapper.py
@@ -1,0 +1,31 @@
+import magma
+import generator.generator as generator
+
+
+class ZextWrapper(generator.Generator):
+    def __init__(self, in_width, out_width):
+        super().__init__()
+
+        self.in_width = in_width
+        self.out_width = out_width
+
+        self.add_ports(
+            I=magma.In(magma.In(magma.Bits(self.in_width))),
+            O=magma.Out(magma.Out(magma.Bits(self.out_width))),
+        )
+
+    def circuit(self):
+        diff = self.out_width - self.in_width
+
+        class _ZextWrapperCircuit(magma.Circuit):
+            name = self.name()
+            IO = self.decl()
+
+            @classmethod
+            def definition(io):
+                magma.wire(magma.zext(io.I, diff), io.O)
+
+        return _ZextWrapperCircuit
+
+    def name(self):
+        return f"ZextWrapper_{self.in_width}_{self.out_width}"

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@ from magma import clear_cachedFunctions
 import magma.backend.coreir_ as coreir_
 
 collect_ignore = [
+    "experimental",  # directory for experimental projects
     "src",  # pip folder that contains dependencies like magma
     "parsetab.py",
     "CoSA"

--- a/generator/configurable.py
+++ b/generator/configurable.py
@@ -7,7 +7,10 @@ from generator.port_reference import PortReferenceBase
 
 def ConfigurationType(addr_width, data_width):
     return magma.Tuple(config_addr=magma.Bits(addr_width),
-                       config_data=magma.Bits(data_width))
+                       config_data=magma.Bits(data_width),
+                       read=magma.Bits(1),
+                       write=magma.Bits(1)
+                       )
 
 
 class Configurable(generator.Generator):

--- a/generator/const.py
+++ b/generator/const.py
@@ -19,7 +19,7 @@ class ConstPortReference(PortReferenceBase):
         self._value = value
         self._owner = ConstGenerator()
 
-    def get_port(self, inst):        
+    def get_port(self, inst):
         assert inst is None
         return self._value
 

--- a/global_controller/global_controller_magma.py
+++ b/global_controller/global_controller_magma.py
@@ -19,7 +19,7 @@ class GlobalController(generator.Generator):
         self.add_ports(
             jtag=JTAGType,
             config=magma.Out(self.config_type),
-            read_data_in=magma.In(self.data_width),
+            read_data_in=magma.In(magma.Bits(self.data_width)),
             clk_in=magma.In(magma.Clock),
             reset_in=magma.In(magma.Reset),
             clk_out=magma.Out(magma.Clock),
@@ -50,12 +50,12 @@ class GlobalController(generator.Generator):
                   self.ports.config.config_addr)
         self.wire(self.underlying.ports.config_data_out,
                   self.ports.config.config_data)
+        self.wire(self.underlying.ports.read, self.ports.config.read[0])
+        self.wire(self.underlying.ports.write, self.ports.config.write[0])
         self.wire(self.underlying.ports.clk_out, self.ports.clk_out)
         self.wire(self.underlying.ports.reset_out, self.ports.reset_out)
 
-        # TODO(rsetaluri): wire debug read_data into underlying.config_data_in.
-        self.wire(Const(magma.bits(0, self.data_width)),
-                  self.underlying.ports.config_data_in)
+        self.wire(self.ports.read_data_in, self.underlying.ports.config_data_in)
 
     def name(self):
         return f"GlobalController_{self.addr_width}_{self.data_width}"

--- a/global_controller/global_controller_magma.py
+++ b/global_controller/global_controller_magma.py
@@ -19,6 +19,7 @@ class GlobalController(generator.Generator):
         self.add_ports(
             jtag=JTAGType,
             config=magma.Out(self.config_type),
+            read_data_in=magma.In(self.data_width),
             clk_in=magma.In(magma.Clock),
             reset_in=magma.In(magma.Reset),
             clk_out=magma.Out(magma.Clock),

--- a/interconnect/interconnect_magma.py
+++ b/interconnect/interconnect_magma.py
@@ -5,7 +5,7 @@ from generator.configurable import ConfigurationType
 
 
 def SideType(num_tracks, layers):
-    layers_dict = {f"layer{l}" : magma.Array(num_tracks, magma.Bits(l)) \
+    layers_dict = {f"layer{l}": magma.Array(num_tracks, magma.Bits(l))
                    for l in layers}
     T = magma.Tuple(**layers_dict)
     return magma.Tuple(I=magma.In(T), O=magma.Out(T))

--- a/interconnect/interconnect_magma.py
+++ b/interconnect/interconnect_magma.py
@@ -1,7 +1,10 @@
 import magma
+import mantle
 import generator.generator as generator
 from common.side_type import SideType
 from generator.configurable import ConfigurationType
+from generator.const import Const
+from generator.from_magma import FromMagma
 
 
 def SideType(num_tracks, layers):
@@ -29,6 +32,7 @@ class Interconnect(generator.Generator):
             config=magma.In(ConfigurationType(32, 32)),
             clk=magma.In(magma.Clock),
             rst=magma.In(magma.Reset),
+            read_config_data=magma.Out(magma.Bits(32)),
         )
 
         for column in self.columns:
@@ -44,6 +48,16 @@ class Interconnect(generator.Generator):
             for j in range(self.height):
                 self.wire(c1.ports.west[j].O, c0.ports.east[j].I)
                 self.wire(c0.ports.east[j].O, c1.ports.west[j].I)
+
+        # OR together read_data outputs from each column
+        # number of inputs = number of columns
+        self.read_data_OR = FromMagma(mantle.DefineOr(len(self.columns), 32))
+        for i, col in enumerate(columns):
+            self.wire(self.read_data_OR.ports[f"I{i}"],
+                      col.ports.read_config_data)
+            # wire up column number input
+            self.wire(col.ports.column_num, Const(magma.bits(i, 8)))
+        self.wire(self.read_data_OR.ports.O, self.ports.read_config_data)
 
     def name(self):
         return "Interconnect_" + "_".join([c.name() for c in self.columns])

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -21,6 +21,7 @@ class MemCore(Core):
             data_out=magma.Out(TData),
             clk=magma.In(magma.Clock),
             config=magma.In(ConfigurationType(8, 32)),
+            read_config_data=magma.Out(magma.Bits(32)),
         )
 
         wrapper = memory_core_genesis2.memory_core_wrapper
@@ -40,6 +41,7 @@ class MemCore(Core):
                   self.underlying.ports.config_addr[24:32])
         self.wire(self.ports.config.config_data,
                   self.underlying.ports.config_data)
+        self.wire(self.underlying.ports.read_data, self.ports.read_config_data)
 
         # TODO(rsetaluri): Actually wire these inputs.
         signals = (

--- a/pe_core/pe_core_magma.py
+++ b/pe_core/pe_core_magma.py
@@ -35,6 +35,7 @@ class PECore(Core):
             res_p=magma.Out(TBit),
             clk=magma.In(magma.Clock),
             config=magma.In(ConfigurationType(8, 32)),
+            read_config_data=magma.Out(magma.Bits(32)),
         )
 
         self.wire(self.ports.data0, self.underlying.ports.data0)
@@ -48,6 +49,7 @@ class PECore(Core):
         self.wire(self.ports.config.config_addr, self.underlying.ports.cfg_a)
         self.wire(self.ports.config.config_data,
                   self.underlying.ports.cfg_d)
+        self.wire(self.underlying.ports.read_data, self.ports.read_config_data)
 
         # TODO(rsetaluri): Actually wire these inputs.
         signals = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 fault
 -e git://github.com/phanrahan/magma.git#egg=magma
 -e git://github.com/phanrahan/mantle.git#egg=mantle
+ordered_set

--- a/simple_cb/simple_cb_magma.py
+++ b/simple_cb/simple_cb_magma.py
@@ -20,6 +20,7 @@ class CB(Configurable):
             O=magma.Out(T),
             clk=magma.In(magma.Clock),
             config=magma.In(ConfigurationType(8, 32)),
+            read_config_data=magma.Out(32)
         )
         self.add_configs(
            S=sel_bits,

--- a/simple_cb/simple_cb_magma.py
+++ b/simple_cb/simple_cb_magma.py
@@ -26,6 +26,19 @@ class CB(Configurable):
            S=sel_bits,
         )
 
+        # read_config_data output
+        num_config_reg = len(self.registers)
+        if(num_config_reg > 1):
+            self.read_config_data_mux = MuxWrapper(num_config_reg, 32)
+            self.wire(self.read_config_data_mux.ports.O,
+                      self.ports.read_config_data)
+            for idx, reg in enumerate(self.registers.values()):
+                self.wire(reg.ports.O, self.read_config_data_mux.ports.I[idx])
+        # If we only have 1 config register, we don't need a mux
+        # Wire sole config register directly to read_config_data_output
+        else:
+            self.wire(self.registers[0].ports.O, self.ports.read_config_data)
+
         self.wire(self.ports.I, self.mux.ports.I)
         self.wire(self.registers.S.ports.O, self.mux.ports.S)
         self.wire(self.mux.ports.O, self.ports.O)

--- a/simple_cb/simple_cb_magma.py
+++ b/simple_cb/simple_cb_magma.py
@@ -30,6 +30,7 @@ class CB(Configurable):
         num_config_reg = len(self.registers)
         if(num_config_reg > 1):
             self.read_config_data_mux = MuxWrapper(num_config_reg, 32)
+            # TODO: wire up select input of read_data_mux
             self.wire(self.read_config_data_mux.ports.O,
                       self.ports.read_config_data)
             for idx, reg in enumerate(self.registers.values()):

--- a/simple_cb/simple_cb_magma.py
+++ b/simple_cb/simple_cb_magma.py
@@ -30,7 +30,8 @@ class CB(Configurable):
         num_config_reg = len(self.registers)
         if(num_config_reg > 1):
             self.read_config_data_mux = MuxWrapper(num_config_reg, 32)
-            # TODO: wire up select input of read_data_mux
+            self.wire(self.ports.config.config_addr,
+                      self.read_config_data_mux.ports.S)
             self.wire(self.read_config_data_mux.ports.O,
                       self.ports.read_config_data)
             for idx, reg in enumerate(self.registers.values()):

--- a/simple_cb/simple_cb_magma_old.py
+++ b/simple_cb/simple_cb_magma_old.py
@@ -1,0 +1,72 @@
+import os
+import math
+
+import magma as m
+import mantle as mantle
+from common.configurable_circuit import ConfigInterface
+
+
+def make_name(width, num_tracks):
+    return (f"simple_cb_width_{width}"
+            f"_num_tracks_{num_tracks}")
+
+
+def generate_mux(inputs, sel, default=None):
+    if default is None:
+        height = len(inputs)
+        mux_inputs = [i for i in inputs]
+    else:
+        height = 2 ** m.bitutils.clog2(len(inputs))
+        mux_inputs = [i for i in inputs]
+        mux_inputs += [default for _ in range(height - len(inputs))]
+    return mantle.mux(mux_inputs, sel)
+
+
+@m.cache_definition
+def define_simple_cb(width, num_tracks):
+    CONFIG_DATA_WIDTH = 32
+    CONFIG_ADDR_WIDTH = 32
+
+    assert num_tracks > 0
+    sel_bits = m.bitutils.clog2(num_tracks)
+    # TODO(rsetaluri): This assert is hacky! Instead we should make the config
+    # general for any number of tracks. Furthermore, we should abstract out the
+    # config into a separate module.
+    assert sel_bits <= CONFIG_DATA_WIDTH
+    config_reset = num_tracks - 1
+
+    T = m.Bits(width)
+
+    class _SimpleCB(m.Circuit):
+        name = make_name(width, num_tracks)
+
+        IO = [
+            "I", m.In(m.Array(num_tracks, T)),
+            "O", m.Out(T),
+        ]
+        IO += ConfigInterface(CONFIG_ADDR_WIDTH, CONFIG_DATA_WIDTH)
+        IO += m.ClockInterface(has_async_reset=True)
+
+        @classmethod
+        def definition(io):
+            config = mantle.Register(CONFIG_DATA_WIDTH,
+                                     init=config_reset,
+                                     has_ce=True,
+                                     has_async_reset=True)
+
+            config_addr_zero = m.bits(0, 8) == io.config_addr[24:32]
+            config(io.config_data, CE=(m.bit(io.config_en) & config_addr_zero))
+
+            # If the top 8 bits of config_addr are 0, then read_data is equal
+            # to the value of the config register, otherwise it is 0.
+            m.wire(io.read_data,
+                   mantle.mux([m.uint(0, CONFIG_DATA_WIDTH), config.O],
+                              config_addr_zero))
+
+            # NOTE: This is not robust in the case that the mux which needs more
+            # than 32 select bits (i.e. >= 2^32 inputs). This is unlikely to
+            # happen, but this code is not general.
+            out = generate_mux(io.I, config.O[:sel_bits], m.uint(0, width))
+            m.wire(out, io.O)
+
+    return _SimpleCB

--- a/simple_sb/simple_sb_magma.py
+++ b/simple_sb/simple_sb_magma.py
@@ -69,7 +69,9 @@ class SB(Configurable):
         num_config_reg = len(self.registers)
         if(num_config_reg > 1):
             self.read_config_data_mux = MuxWrapper(num_config_reg, 32)
-            # TODO: Wire up the select input of read_data MUX
+            # Wire up config_addr to select input of read_data MUX
+            self.wire(self.ports.config.config_addr,
+                      self.read_config_data_mux.ports.S)
             self.wire(self.read_config_data_mux.ports.O,
                       self.ports.read_config_data)
             for idx, reg in enumerate(self.registers.values()):

--- a/simple_sb/simple_sb_magma.py
+++ b/simple_sb/simple_sb_magma.py
@@ -65,6 +65,20 @@ class SB(Configurable):
             self.wire(self.ports.config.config_addr, reg.ports.config_addr)
             self.wire(self.ports.config.config_data, reg.ports.config_data)
 
+        # read_config_data output
+        num_config_reg = len(self.registers)
+        if(num_config_reg > 1):
+            self.read_config_data_mux = MuxWrapper(num_config_reg, 32)
+            # TODO: Wire up the select input of read_data MUX
+            self.wire(self.read_config_data_mux.ports.O,
+                      self.ports.read_config_data)
+            for idx, reg in enumerate(self.registers.values()):
+                self.wire(reg.ports.O, self.read_config_data_mux.ports.I[idx])
+        # If we only have 1 config register, we don't need a mux
+        # Wire sole config register directly to read_config_data_output
+        else:
+            self.wire(self.registers[0].ports.O, self.ports.read_config_data)
+
     def __organize_inputs(self, inputs):
         ret = {1: [], 16: []}
         for input_ in inputs:

--- a/simple_sb/simple_sb_magma.py
+++ b/simple_sb/simple_sb_magma.py
@@ -27,6 +27,7 @@ class SB(Configurable):
             east=SideType(5, (1, 16)),
             clk=magma.In(magma.Clock),
             config=magma.In(ConfigurationType(8, 32)),
+            read_config_data=magma.Out(32),
         )
 
         # TODO(rsetaluri): Clean up this logic.

--- a/test_simple_cb/test_simple_cb_regression.py
+++ b/test_simple_cb/test_simple_cb_regression.py
@@ -3,7 +3,7 @@ import os
 import glob
 from bit_vector import BitVector
 
-from simple_cb.simple_cb_magma import define_simple_cb
+from simple_cb.simple_cb_magma_old import define_simple_cb
 from simple_cb.simple_cb import gen_simple_cb
 from simple_cb.simple_cb_genesis2 import simple_cb_wrapper
 

--- a/test_top/test_top_magma.py
+++ b/test_top/test_top_magma.py
@@ -1,3 +1,4 @@
+import magma
 from top.top_magma import CGRA
 
 

--- a/test_top/test_top_magma.py
+++ b/test_top/test_top_magma.py
@@ -1,0 +1,7 @@
+from top.top_magma import CGRA
+
+
+def test_top_magma():
+    cgra = CGRA(4, 4)
+    cgra_circ = cgra.circuit()
+    magma.compile("cgra", cgra_circ, output="coreir-verilog")

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -66,7 +66,7 @@ class Tile(generator.Generator):
         for i, feat in enumerate(self.features()):
             self.wire(feat.ports.read_config_data,
                       self.read_config_data_mux.I[i])
-        # TODO: Connect S input to config_addr[feature]
+        # Connect S input to config_addr[feature]
         self.wire(self.read_config_data_mux.S,
                   self.ports.config.config_addr[16:24])
         self.wire(self.read_config_data_mux.O, self.ports.read_config_data)

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -4,6 +4,7 @@ from simple_sb.simple_sb_magma import SB
 from simple_cb.simple_cb_magma import CB
 from common.side_type import SideType
 from generator.configurable import ConfigurationType
+from common.mux_with_default import MuxWithDefaultWrapper
 
 
 def get_width(T):
@@ -55,6 +56,16 @@ class Tile(generator.Generator):
                       feature.ports.config.config_addr)
             self.wire(self.ports.config.config_data,
                       feature.ports.config.config_data)
+
+        # read_data mux
+        num_mux_inputs = len(self.features())
+        self.read_data_mux = MuxWithDefaultWrapper(num_mux_inputs, 32, 0)
+        for i, feat in enumerate(self.features()):
+            self.wire(feat.ports.read_config_data,
+                      self.read_config_data_mux.I[i])
+        self.wire(self.read_config_data_mux.O, self.ports.read_config_data)
+        # TODO: Connect S input to feature section of config_addr
+        # TODO: Connect EN input to (config_addr[tile_id] == self.tile_id)
 
     def __wire_cb(self, side, cb):
         if cb.width == 1:

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -31,6 +31,7 @@ class Tile(generator.Generator):
             config=magma.In(ConfigurationType(32, 32)),
             clk=magma.In(magma.Clock),
             rst=magma.In(magma.Reset),
+            read_config_data=magma.Out(32)
         )
 
         self.wire(self.ports.north, self.sb.ports.north)

--- a/top/top_magma.py
+++ b/top/top_magma.py
@@ -67,13 +67,3 @@ class CGRA(generator.Generator):
 
     def name(self):
         return "CGRA"
-
-
-def main():
-    cgra = CGRA(4, 4)
-    cgra_circ = cgra.circuit()
-    magma.compile("cgra", cgra_circ, output="coreir-verilog")
-
-
-if __name__ == "__main__":
-    main()

--- a/top/top_magma.py
+++ b/top/top_magma.py
@@ -10,6 +10,7 @@ from memory_core.memory_core_magma import MemCore
 from common.side_type import SideType
 from common.jtag_type import JTAGType
 from generator.from_magma import FromMagma
+from generator.const import Const
 
 
 class CGRA(generator.Generator):
@@ -59,6 +60,8 @@ class CGRA(generator.Generator):
         for i, col in enumerate(columns):
             self.wire(self.read_data_OR.ports["I"+i],
                       col.ports.read_config_data)
+            # wire up column number input
+            self.wire(col.ports.column_num, Const(magma.bits(i, 8)))
         self.wire(self.read_data_OR.ports.O,
                   self.global_controller.ports.read_data_in)
 

--- a/top/top_magma.py
+++ b/top/top_magma.py
@@ -54,15 +54,7 @@ class CGRA(generator.Generator):
         self.wire(self.global_controller.ports.reset_out,
                   self.interconnect.ports.rst)
 
-        # OR together read_data outputs from each column
-        # number of inputs = number of columns
-        self.read_data_OR = FromMagma(mantle.Or(len(columns), 32))
-        for i, col in enumerate(columns):
-            self.wire(self.read_data_OR.ports["I"+i],
-                      col.ports.read_config_data)
-            # wire up column number input
-            self.wire(col.ports.column_num, Const(magma.bits(i, 8)))
-        self.wire(self.read_data_OR.ports.O,
+        self.wire(self.interconnect.ports.read_config_data,
                   self.global_controller.ports.read_data_in)
 
     def name(self):

--- a/top/top_magma.py
+++ b/top/top_magma.py
@@ -1,4 +1,5 @@
 import magma
+import mantle
 import generator.generator as generator
 from global_controller.global_controller_magma import GlobalController
 from interconnect.interconnect_magma import Interconnect
@@ -8,6 +9,7 @@ from pe_core.pe_core_magma import PECore
 from memory_core.memory_core_magma import MemCore
 from common.side_type import SideType
 from common.jtag_type import JTAGType
+from generator.from_magma import FromMagma
 
 
 class CGRA(generator.Generator):
@@ -50,6 +52,15 @@ class CGRA(generator.Generator):
                   self.interconnect.ports.clk)
         self.wire(self.global_controller.ports.reset_out,
                   self.interconnect.ports.rst)
+
+        # OR together read_data outputs from each column
+        # number of inputs = number of columns
+        self.read_data_OR = FromMagma(mantle.Or(len(columns), 32))
+        for i, col in enumerate(columns):
+            self.wire(self.read_data_OR.ports["I"+i],
+                      col.ports.read_config_data)
+        self.wire(self.read_data_OR.ports.O,
+                  self.global_controller.ports.read_data_in)
 
     def name(self):
         return "CGRA"


### PR DESCRIPTION
This PR primarily adds the ability for the global controller to read configuration state from the CGRA.

Each feature within a tile has a read_data output, which is equal to the register corresponding to the register field within config_addr. If a feature has only 1 feature, there is no mux... it is wired directly to the read_data output.

At the tile level, read_data outputs from each feature are muxed together. However, since we want to output 0 here, I've introduced a "mux with default" generator. It behaves like a mux, except it also has an enable signal. For the mux to output one of the inputs, its enable signal must be high and the select bit must be valid (SEL < NUM_INPUTS). The enable signal here is the config_read input to the tile.

At the column level, each tile's read_data output is OR'ed together, and at the top level each column's read_data output is OR'd together. Finally, the output of that OR gate is input to the global controller.