### PR TITLE
Updates for fault 0.23 release

### DIFF
--- a/cb/cb_genesis2.py
+++ b/cb/cb_genesis2.py
@@ -1,4 +1,4 @@
-from common.genesis_wrapper import GenesisWrapper
+from common.genesis_wrapper import GenesisWrapper, default_type_map
 from common.generator_interface import GeneratorInterface
 import magma as m
 
@@ -11,9 +11,7 @@ interface = GeneratorInterface()\
             .register("default_value", int, 0)
 
 cb_wrapper = GenesisWrapper(interface, "cb", ["cb/genesis/cb.vp"],
-                            type_map={"clk": m.In(m.Clock),
-                                      "reset": m.In(m.AsyncReset),
-                                      "config_en": m.In(m.Enable)})
+                            type_map=default_type_map)
 
 """
 This program generates the verilog for the connect box and parses it into a

--- a/cb/cb_genesis2.py
+++ b/cb/cb_genesis2.py
@@ -1,5 +1,6 @@
 from common.genesis_wrapper import GenesisWrapper
 from common.generator_interface import GeneratorInterface
+import magma as m
 
 
 interface = GeneratorInterface()\
@@ -9,7 +10,10 @@ interface = GeneratorInterface()\
             .register("has_constant", int, 0)\
             .register("default_value", int, 0)
 
-cb_wrapper = GenesisWrapper(interface, "cb", ["cb/genesis/cb.vp"])
+cb_wrapper = GenesisWrapper(interface, "cb", ["cb/genesis/cb.vp"],
+                            type_map ={"clk": m.In(m.Clock),
+                                       "reset": m.In(m.AsyncReset),
+                                       "config_en": m.In(m.Enable)})
 
 """
 This program generates the verilog for the connect box and parses it into a

--- a/cb/cb_genesis2.py
+++ b/cb/cb_genesis2.py
@@ -11,9 +11,9 @@ interface = GeneratorInterface()\
             .register("default_value", int, 0)
 
 cb_wrapper = GenesisWrapper(interface, "cb", ["cb/genesis/cb.vp"],
-                            type_map ={"clk": m.In(m.Clock),
-                                       "reset": m.In(m.AsyncReset),
-                                       "config_en": m.In(m.Enable)})
+                            type_map={"clk": m.In(m.Clock),
+                                      "reset": m.In(m.AsyncReset),
+                                      "config_en": m.In(m.Enable)})
 
 """
 This program generates the verilog for the connect box and parses it into a

--- a/common/genesis_wrapper.py
+++ b/common/genesis_wrapper.py
@@ -6,17 +6,24 @@ from common.run_genesis import run_genesis
 
 class GenesisWrapper:
     def __init__(self, interface, top_name, default_infiles,
-                 system_verilog=False):
+                 system_verilog=False, type_map={}):
         """
         `interface`: the generator params and default values
         `top_name`: the name of the top module
         `default_infiles` : a default list of .vp files to pass to genesis
         `system_verilog` : whether the top output file is system_verilog (.sv)
+        `type_map`: mapping between port name to type that converts the
+                    genesis/verilog port into a magma type, e.g.:
+                    {"clk"      : m.In(m.Clock),
+                     "reset"    : m.In(m.AsyncReset),
+                     "config_en": m.In(m.Enable)}
+
         """
         self.__interface = interface
         self.__top_name = top_name
         self.__default_infiles = default_infiles
         self.__system_verilog = system_verilog
+        self.__type_map = type_map
 
     def generator(self, param_mapping: Dict[str, str]=None):
         """
@@ -42,9 +49,7 @@ class GenesisWrapper:
             outfile = run_genesis(self.__top_name, infiles, parameters,
                                   system_verilog=self.__system_verilog)
             return m.DefineFromVerilogFile(
-                outfile, type_map={"clk": m.In(m.Clock),
-                                   "reset": m.In(m.AsyncReset),
-                                   "config_en": m.In(m.Enable)}
+                outfile, type_map=self.__type_map
             )[0]
 
         return define_wrapper

--- a/common/genesis_wrapper.py
+++ b/common/genesis_wrapper.py
@@ -4,6 +4,11 @@ import magma as m
 from common.run_genesis import run_genesis
 
 
+default_type_map = {"clk": m.In(m.Clock),
+                    "reset": m.In(m.AsyncReset),
+                    "config_en": m.In(m.Enable)}
+
+
 class GenesisWrapper:
     def __init__(self, interface, top_name, default_infiles,
                  system_verilog=False, type_map={}):

--- a/common/genesis_wrapper.py
+++ b/common/genesis_wrapper.py
@@ -41,7 +41,11 @@ class GenesisWrapper:
 
             outfile = run_genesis(self.__top_name, infiles, parameters,
                                   system_verilog=self.__system_verilog)
-            return m.DefineFromVerilogFile(outfile)[0]
+            return m.DefineFromVerilogFile(
+                outfile, type_map={"clk": m.In(m.Clock),
+                                   "reset": m.In(m.AsyncReset),
+                                   "config_en": m.In(m.Enable)}
+            )[0]
 
         return define_wrapper
 

--- a/common/testers.py
+++ b/common/testers.py
@@ -2,19 +2,26 @@ from fault.functional_tester import FunctionalTester
 
 
 class ResetTester(FunctionalTester):
+    def __init__(self, circuit, clock, functional_model, input_mapping=None,
+                 reset_port=None):
+        super().__init__(circuit, clock, functional_model, input_mapping)
+        if reset_port is None:
+            reset_port = circuit.reset
+        self.reset_port = reset_port
+
     def reset(self):
         self.functional_model.reset()
         self.expect_any_outputs()
-        self.poke(self.circuit.reset, 1)
+        self.poke(self.reset_port, 1)
         self.eval()
-        self.poke(self.circuit.reset, 0)
+        self.poke(self.reset_port, 0)
 
 
 class ConfigurationTester(FunctionalTester):
     def configure(self, addr, data):
         self.functional_model.configure(addr, data)
         self.poke(self.clock, 0)
-        self.poke(self.circuit.reset, 0)
+        self.poke(self.reset_port, 0)
         self.poke(self.circuit.config_addr, addr)
         self.poke(self.circuit.config_data, data)
         self.poke(self.circuit.config_en, 1)

--- a/memory_core/memory_core_genesis2.py
+++ b/memory_core/memory_core_genesis2.py
@@ -1,3 +1,4 @@
+import magma as m
 from common.genesis_wrapper import GenesisWrapper, default_type_map
 from common.generator_interface import GeneratorInterface
 
@@ -23,7 +24,9 @@ memory_core_wrapper = GenesisWrapper(
                                "memory_core/genesis/fifo_control.vp",
                                "memory_core/genesis/mem.vp",
                                "memory_core/genesis/memory_core.vp"],
-    type_map=default_type_map)
+    type_map={"clk_in", m.In(m.Clock),
+              "reset", m.In(m.AsyncReset),
+              "config_en", m.In(m.Enable)})
 
 param_mapping = {"data_width": "dwidth", "data_depth": "ddepth"}
 

--- a/memory_core/memory_core_genesis2.py
+++ b/memory_core/memory_core_genesis2.py
@@ -1,4 +1,4 @@
-from common.genesis_wrapper import GenesisWrapper
+from common.genesis_wrapper import GenesisWrapper, default_type_map
 from common.generator_interface import GeneratorInterface
 
 
@@ -22,7 +22,8 @@ memory_core_wrapper = GenesisWrapper(
                                "memory_core/genesis/linebuffer_control.vp",
                                "memory_core/genesis/fifo_control.vp",
                                "memory_core/genesis/mem.vp",
-                               "memory_core/genesis/memory_core.vp"])
+                               "memory_core/genesis/memory_core.vp"],
+    type_map=default_type_map)
 
 param_mapping = {"data_width": "dwidth", "data_depth": "ddepth"}
 

--- a/memory_core/memory_core_genesis2.py
+++ b/memory_core/memory_core_genesis2.py
@@ -24,9 +24,9 @@ memory_core_wrapper = GenesisWrapper(
                                "memory_core/genesis/fifo_control.vp",
                                "memory_core/genesis/mem.vp",
                                "memory_core/genesis/memory_core.vp"],
-    type_map={"clk_in", m.In(m.Clock),
-              "reset", m.In(m.AsyncReset),
-              "config_en", m.In(m.Enable)})
+    type_map={"clk_in": m.In(m.Clock),
+              "reset": m.In(m.AsyncReset),
+              "config_en": m.In(m.Enable)})
 
 param_mapping = {"data_width": "dwidth", "data_depth": "ddepth"}
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         # "mantle",
         "coreir==0.24a",
         "bit_vector==0.34a",
-        "fault==0.24"
+        "fault==0.25"
     ],
     python_requires='>=3.6'
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         # "mantle",
         "coreir==0.24a",
         "bit_vector==0.34a",
-        "fault==0.23"
+        "fault==0.24"
     ],
     python_requires='>=3.6'
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         # "mantle",
         "coreir==0.24a",
         "bit_vector==0.34a",
-        "fault==0.20"
+        "fault==0.23"
     ],
     python_requires='>=3.6'
 )

--- a/simple_cb/simple_cb_genesis2.py
+++ b/simple_cb/simple_cb_genesis2.py
@@ -1,4 +1,4 @@
-from common.genesis_wrapper import GenesisWrapper
+from common.genesis_wrapper import GenesisWrapper, default_type_map
 from common.generator_interface import GeneratorInterface
 
 
@@ -9,7 +9,8 @@ interface = GeneratorInterface()\
 simple_cb_wrapper = GenesisWrapper(
     interface,
     "simple_cb",
-    ["simple_cb/genesis/simple_cb.vp"])
+    ["simple_cb/genesis/simple_cb.vp"],
+    type_map=default_type_map)
 
 if __name__ == "__main__":
     # These functions are unit tested directly, so no need to cover them

--- a/test_cb/test_cb_genesis2.py
+++ b/test_cb/test_cb_genesis2.py
@@ -21,5 +21,5 @@ def test_cb_genesis2(capsys):
     out, _ = capsys.readouterr()
     assert out == f"""\
 Running genesis cmd 'Genesis2.pl -parse -generate -top cb -input cb/genesis/cb.vp -parameter cb.width='16' -parameter cb.num_tracks='10' -parameter cb.feedthrough_outputs='1111101111' -parameter cb.has_constant='1' -parameter cb.default_value='7''
-cb(clk: In(Bit), reset: In(Bit), in_0: In(Bits(16)), in_1: In(Bits(16)), in_2: In(Bits(16)), in_3: In(Bits(16)), in_4: In(Bits(16)), in_6: In(Bits(16)), in_7: In(Bits(16)), in_8: In(Bits(16)), in_9: In(Bits(16)), out: Out(Bits(16)), config_addr: In(Bits(32)), config_data: In(Bits(32)), config_en: In(Bit), read_data: Out(Bits(32)))
+cb(clk: In(Clock), reset: In(AsyncReset), in_0: In(Bits(16)), in_1: In(Bits(16)), in_2: In(Bits(16)), in_3: In(Bits(16)), in_4: In(Bits(16)), in_6: In(Bits(16)), in_7: In(Bits(16)), in_8: In(Bits(16)), in_9: In(Bits(16)), out: Out(Bits(16)), config_addr: In(Bits(32)), config_data: In(Bits(32)), config_en: In(Enable), read_data: Out(Bits(32)))
 """  # nopep8

--- a/test_cb/test_cb_regression.py
+++ b/test_cb/test_cb_regression.py
@@ -11,7 +11,7 @@ import magma as m
 
 import pytest
 
-from fault.test_vector_generator import generate_test_vectors_from_streams
+from fault.action_generators import generate_actions_from_streams
 from common.testers import ResetTester, ConfigurationTester
 from common.regression_test import check_interfaces
 from fault.random import random_bv
@@ -64,8 +64,8 @@ def test_regression(default_value, num_tracks, has_constant):
         tester.reset()
         tester.configure(config_addr, config_data)
 
-        tester.test_vectors += \
-            generate_test_vectors_from_streams(
+        tester.actions += \
+            generate_actions_from_streams(
                 # Interesting example of Python's dynamic scoping, observe how
                 # the following code is incorrect because of when the string
                 # argument to getattr is evaluated
@@ -80,7 +80,7 @@ def test_regression(default_value, num_tracks, has_constant):
                     for i in range(num_tracks) if feedthrough_outputs[i] == "1"
                 })
 
-    for cb in [genesis_cb, magma_cb]:
-        tester.circuit = cb
-        tester.compile_and_run(directory="test_cb/build", target="verilator",
-                               flags=["-Wno-fatal"])
+    for cb, output in [(genesis_cb, "verilog"), (magma_cb, "coreir-verilog")]:
+        tester.retarget(cb, cb.clk) \
+              .compile_and_run(directory="test_cb/build", target="verilator",
+                               flags=["-Wno-fatal"], magma_output=output)

--- a/test_memory_core/test_memory_core_genesis2.py
+++ b/test_memory_core/test_memory_core_genesis2.py
@@ -31,7 +31,7 @@ def test_main(capsys):
     out, _ = capsys.readouterr()
     assert out == f"""\
 Running genesis cmd 'Genesis2.pl -parse -generate -top memory_core -input memory_core/genesis/input_sr.vp memory_core/genesis/output_sr.vp memory_core/genesis/linebuffer_control.vp memory_core/genesis/fifo_control.vp memory_core/genesis/mem.vp memory_core/genesis/memory_core.vp -parameter memory_core.dwidth='16' -parameter memory_core.ddepth='1024''
-memory_core(clk_in: In(Bit), clk_en: In(Bit), reset: In(Bit), config_addr: In(Bits(32)), config_data: In(Bits(32)), config_read: In(Bit), config_write: In(Bit), config_en: In(Bit), config_en_sram: In(Bits(4)), config_en_linebuf: In(Bit), data_in: In(Bits(16)), data_out: Out(Bits(16)), wen_in: In(Bit), ren_in: In(Bit), valid_out: Out(Bit), chain_in: In(Bits(16)), chain_out: Out(Bits(16)), chain_wen_in: In(Bit), chain_valid_out: Out(Bit), almost_full: Out(Bit), almost_empty: Out(Bit), addr_in: In(Bits(16)), read_data: Out(Bits(32)), read_data_sram: Out(Bits(32)), read_data_linebuf: Out(Bits(32)), flush: In(Bit))
+memory_core(clk_in: In(Clock), clk_en: In(Bit), reset: In(AsyncReset), config_addr: In(Bits(32)), config_data: In(Bits(32)), config_read: In(Bit), config_write: In(Bit), config_en: In(Enable), config_en_sram: In(Bits(4)), config_en_linebuf: In(Bit), data_in: In(Bits(16)), data_out: Out(Bits(16)), wen_in: In(Bit), ren_in: In(Bit), valid_out: Out(Bit), chain_in: In(Bits(16)), chain_out: Out(Bits(16)), chain_wen_in: In(Bit), chain_valid_out: Out(Bit), almost_full: Out(Bit), almost_empty: Out(Bit), addr_in: In(Bits(16)), read_data: Out(Bits(32)), read_data_sram: Out(Bits(32)), read_data_linebuf: Out(Bits(32)), flush: In(Bit))
 """  # nopep8
 
 

--- a/test_simple_cb/test_simple_cb_genesis2.py
+++ b/test_simple_cb/test_simple_cb_genesis2.py
@@ -18,5 +18,5 @@ def test_simple_cb_genesis2(capsys):
     out, _ = capsys.readouterr()
     assert out == f"""\
 Running genesis cmd 'Genesis2.pl -parse -generate -top simple_cb -input simple_cb/genesis/simple_cb.vp -parameter simple_cb.width='16' -parameter simple_cb.num_tracks='10''
-simple_cb(clk: In(Bit), reset: In(Bit), in_0: In(Bits(16)), in_1: In(Bits(16)), in_2: In(Bits(16)), in_3: In(Bits(16)), in_4: In(Bits(16)), in_5: In(Bits(16)), in_6: In(Bits(16)), in_7: In(Bits(16)), in_8: In(Bits(16)), in_9: In(Bits(16)), out: Out(Bits(16)), config_addr: In(Bits(32)), config_data: In(Bits(32)), config_en: In(Bit), read_data: Out(Bits(32)))
+simple_cb(clk: In(Clock), reset: In(AsyncReset), in_0: In(Bits(16)), in_1: In(Bits(16)), in_2: In(Bits(16)), in_3: In(Bits(16)), in_4: In(Bits(16)), in_5: In(Bits(16)), in_6: In(Bits(16)), in_7: In(Bits(16)), in_8: In(Bits(16)), in_9: In(Bits(16)), out: Out(Bits(16)), config_addr: In(Bits(32)), config_data: In(Bits(32)), config_en: In(Enable), read_data: Out(Bits(32)))
 """  # nopep8

--- a/test_simple_cb/test_simple_cb_regression.py
+++ b/test_simple_cb/test_simple_cb_regression.py
@@ -88,4 +88,5 @@ def test_regression(num_tracks):
                     })
         tester.compile_and_run(target="verilator",
                                directory="test_simple_cb/build",
-                               flags=["-Wno-fatal"])
+                               flags=["-Wno-fatal"],
+                               magma_output="coreir-verilog")

--- a/test_simple_cb/test_simple_cb_regression.py
+++ b/test_simple_cb/test_simple_cb_regression.py
@@ -10,7 +10,7 @@ from simple_cb.simple_cb_genesis2 import simple_cb_wrapper
 import magma as m
 from common.testers import ResetTester, ConfigurationTester
 from common.regression_test import check_interfaces
-from fault.test_vector_generator import generate_test_vectors_from_streams
+from fault.action_generators import generate_actions_from_streams
 from fault.random import random_bv
 
 import pytest
@@ -80,8 +80,8 @@ def test_regression(num_tracks):
         for config_data in [BitVector(x, 32) for x in range(0, 1)]:
             tester.reset()
             tester.configure(BitVector(0, 32), config_data)
-            tester.test_vectors += \
-                generate_test_vectors_from_streams(
+            tester.actions += \
+                generate_actions_from_streams(
                     simple_cb, simple_cb_functional_model, {
                         f"in_{i}": lambda name, port: random_bv(len(port))
                         for i in range(num_tracks)

--- a/test_simple_pe/test_simple_pe_magma.py
+++ b/test_simple_pe/test_simple_pe_magma.py
@@ -108,7 +108,8 @@ def test_simple_pe(ops):
                     for i in range(2)
                 })
     tester.compile_and_run(directory="test_simple_pe/build",
-                           target="verilator", flags=["-Wno-fatal"])
+                           target="verilator", flags=["-Wno-fatal"],
+                           magma_output="coreir-verilog")
     opcode_width = m.bitutils.clog2(len(ops))
     op_strs = {
         operator.add: "+",

--- a/test_simple_pe/test_simple_pe_magma.py
+++ b/test_simple_pe/test_simple_pe_magma.py
@@ -3,7 +3,7 @@ from simple_pe.simple_pe_magma import define_pe, define_pe_core
 from simple_pe.simple_pe import gen_simple_pe
 from common.configurable_circuit import config_ets_template
 from common.testers import ResetTester, ConfigurationTester
-from fault.test_vector_generator import generate_test_vectors_from_streams
+from fault.action_generators import generate_actions_from_streams
 from fault.random import random_bv
 import operator
 import magma as m
@@ -101,8 +101,8 @@ def test_simple_pe(ops):
     for config_data in [BitVector(x, opcode_width) for x in range(0, len(ops))]:
         tester.reset()
         tester.configure(BitVector(0, config_addr_width), config_data)
-        tester.test_vectors += \
-            generate_test_vectors_from_streams(
+        tester.actions += \
+            generate_actions_from_streams(
                 pe, pe_functional_model, {
                     f"I{i}": lambda name, port: random_bv(len(port))
                     for i in range(2)


### PR DESCRIPTION
Depends on https://github.com/leonardt/fault/pull/33, https://github.com/leonardt/fault/pull/32, and https://github.com/leonardt/fault/pull/31.

Needed these changes to get the tests passing locally with the latest fault master branch. Once the above pulls are merged, we can do a release, and make sure the tests in this repo still pass with the latest changes.

Opening this PR to track this, but we'll need to wait for the fault merges before this passes.