### PR TITLE
Refactor repr based tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+
+# dist xenial and sudo true required for python 3.7
+dist: xenial
+sudo: true
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 # dist xenial and sudo true required for python 3.7
+# See https://github.com/travis-ci/travis-ci/issues/9815
 dist: xenial
 sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
 language: python
-
-# dist xenial and sudo true required for python 3.7
-# See https://github.com/travis-ci/travis-ci/issues/9815
-dist: xenial
-sudo: true
-
 addons:
   apt:
     packages:
@@ -12,7 +6,6 @@ addons:
     - verilog
 python:
     - "3.6"
-    - "3.7"
 
 install:
     # Convenience script for installing coreir on travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     - verilog
 python:
     - "3.6"
+    - "3.7"
 
 install:
     # Convenience script for installing coreir on travis

--- a/test_common/test_configurable_model.py
+++ b/test_common/test_configurable_model.py
@@ -1,7 +1,6 @@
 import random
 from bit_vector import BitVector
 from common.configurable_model import ConfigurableModel
-import sys
 
 
 def test_configurable_model_smoke():

--- a/test_common/test_configurable_model.py
+++ b/test_common/test_configurable_model.py
@@ -1,10 +1,14 @@
 import random
 from bit_vector import BitVector
 from common.configurable_model import ConfigurableModel
+import sys
 
 
 def test_configurable_model_smoke():
-    EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class _ConfigurableModel with abstract methods __call__\",)"  # nopep8
+    if sys.version_info >= (3,7):
+        EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class _ConfigurableModel with abstract methods __call__\")"  # nopep8
+    else:
+        EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class _ConfigurableModel with abstract methods __call__\",)"  # nopep8
     has_type_error = False
     try:
         my_model = ConfigurableModel(32, 32)()
@@ -41,7 +45,10 @@ def test_configurable_model_subclass():
         f.config[addr] = data
         assert False
     except ValueError as e:
-        assert e.__repr__() == "ValueError('Expected addr to be of width 32',)"
+        if sys.version_info >= (3,7):
+            assert e.__repr__() == "ValueError('Expected addr to be of width 32')"
+        else:
+            assert e.__repr__() == "ValueError('Expected addr to be of width 32',)"
 
     # Check that reading a non-existent address raises a key error. We clear the
     # config by re-initializing foo.
@@ -51,4 +58,7 @@ def test_configurable_model_subclass():
         print(f.config[addr])
         assert False
     except KeyError as e:
-        assert e.__repr__() == "KeyError(0,)"
+        if sys.version_info >= (3,7):
+            assert e.__repr__() == "KeyError(0)"
+        else:
+            assert e.__repr__() == "KeyError(0,)"

--- a/test_common/test_configurable_model.py
+++ b/test_common/test_configurable_model.py
@@ -5,10 +5,7 @@ import sys
 
 
 def test_configurable_model_smoke():
-    if sys.version_info >= (3,7):
-        EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class _ConfigurableModel with abstract methods __call__\")"  # nopep8
-    else:
-        EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class _ConfigurableModel with abstract methods __call__\",)"  # nopep8
+    EXPECTED_MSG = repr(TypeError("Can't instantiate abstract class _ConfigurableModel with abstract methods __call__"))  # nopep8
     has_type_error = False
     try:
         my_model = ConfigurableModel(32, 32)()
@@ -45,10 +42,7 @@ def test_configurable_model_subclass():
         f.config[addr] = data
         assert False
     except ValueError as e:
-        if sys.version_info >= (3,7):
-            assert e.__repr__() == "ValueError('Expected addr to be of width 32')"
-        else:
-            assert e.__repr__() == "ValueError('Expected addr to be of width 32',)"
+        assert repr(e) == repr(ValueError("Expected addr to be of width 32"))
 
     # Check that reading a non-existent address raises a key error. We clear the
     # config by re-initializing foo.
@@ -58,7 +52,4 @@ def test_configurable_model_subclass():
         print(f.config[addr])
         assert False
     except KeyError as e:
-        if sys.version_info >= (3,7):
-            assert e.__repr__() == "KeyError(0)"
-        else:
-            assert e.__repr__() == "KeyError(0,)"
+        assert repr(e) == repr(KeyError(0))

--- a/test_common/test_model.py
+++ b/test_common/test_model.py
@@ -1,12 +1,8 @@
 from common.model import Model
-import sys
 
 
 def test_model():
-    if sys.version_info >= (3,7):
-        EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class Model with abstract methods __call__, __init__\")"  # nopep8
-    else:
-        EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class Model with abstract methods __call__, __init__\",)"  # nopep8
+    EXPECTED_MSG = repr(TypeError("Can't instantiate abstract class Model with abstract methods __call__, __init__"))  # nopep8
     has_type_error = False
     try:
         my_model = Model()

--- a/test_common/test_model.py
+++ b/test_common/test_model.py
@@ -1,8 +1,12 @@
 from common.model import Model
+import sys
 
 
 def test_model():
-    EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class Model with abstract methods __call__, __init__\",)"  # nopep8
+    if sys.version_info >= (3,7):
+        EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class Model with abstract methods __call__, __init__\")"  # nopep8
+    else:
+        EXPECTED_MSG = "TypeError(\"Can't instantiate abstract class Model with abstract methods __call__, __init__\",)"  # nopep8
     has_type_error = False
     try:
         my_model = Model()


### PR DESCRIPTION
I updated to Python 3.7 locally and ran into some minor issues in the tests.

I tried adding Python 3.7 to the travis script, but there were some issues that I didn't think were worth pushing on. Mainly, https://github.com/travis-ci/travis-ci/issues/9815 says that it's not supported in the default configuration, so we can wait to enable the python 3.7 tests until Travis supports them directly. If we'd want to use it now, we have to enable sudo and use the xenial distribution, which I think may cause issues with various Ubuntu installed dependencies that will have to be worked out.

Instead, here's a change to the tests that maintains compatibility with python 3.6, but allows the tests to pass locally for me on 3.7.

The `repr` string for Error messages has changed (dropped the trailing comma). This refactors the tests in a way to abstract away the actual `repr` string generated for the error message checks by calling `repr` on the expect error object (so this should work regardless of python version).