### PR TITLE
Add config enable

### DIFF
--- a/generator/configurable.py
+++ b/generator/configurable.py
@@ -22,7 +22,7 @@ class Configurable(generator.Generator):
     def add_config(self, name, width):
         if name in self.registers:
             raise ValueError(f"{name} is already a register")
-        register = ConfigRegister(width, False)
+        register = ConfigRegister(width, True)
         self.registers[name] = register
 
     def add_configs(self, **kwargs):

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -29,7 +29,8 @@ class MemCore(Core):
         wrapper = memory_core_genesis2.memory_core_wrapper
         param_mapping = memory_core_genesis2.param_mapping
         generator = wrapper.generator(param_mapping, mode="declare")
-        circ = generator(data_width=self.data_width, data_depth=self.data_depth)
+        circ = generator(data_width=self.data_width,
+                         data_depth=self.data_depth)
         self.underlying = FromMagma(circ)
 
         self.wire(self.ports.data_in, self.underlying.ports.data_in)
@@ -39,13 +40,13 @@ class MemCore(Core):
                   self.underlying.ports.config_addr[24:32])
         self.wire(self.ports.config.config_data,
                   self.underlying.ports.config_data)
+        self.wire(self.ports.config.write[0], self.underlying.ports.config_en)
         self.wire(self.underlying.ports.read_data, self.ports.read_config_data)
         self.wire(self.ports.reset, self.underlying.ports.reset)
 
         # TODO(rsetaluri): Actually wire these inputs.
         signals = (
             ("clk_en", 1),
-            ("config_en", 1),
             ("config_en_sram", 4),
             ("config_en_linebuf", 1),
             ("wen_in", 1),

--- a/pe_core/pe_core_magma.py
+++ b/pe_core/pe_core_magma.py
@@ -48,6 +48,7 @@ class PECore(Core):
         self.wire(self.ports.config.config_addr, self.underlying.ports.cfg_a)
         self.wire(self.ports.config.config_data,
                   self.underlying.ports.cfg_d)
+        self.wire(self.ports.config.write[0], self.underlying.ports.cfg_en)
         self.wire(self.underlying.ports.read_data, self.ports.read_config_data)
         # TODO(alexcarsello): Invert for active-low reset in pe core genesis.
         self.wire(self.ports.reset, self.underlying.ports.rst_n)
@@ -55,7 +56,6 @@ class PECore(Core):
         # TODO(rsetaluri): Actually wire these inputs.
         signals = (
             ("clk_en", 1),
-            ("cfg_en", 1),
         )
         for name, width in signals:
             val = magma.bits(0, width) if width > 1 else magma.bit(0)

--- a/simple_cb/simple_cb_magma.py
+++ b/simple_cb/simple_cb_magma.py
@@ -41,15 +41,12 @@ class CB(Configurable):
                 self.wire(reg.ports.O, self.read_config_data_mux.ports.I[idx])
                 # Wire up config register resets
                 self.wire(reg.ports.reset, self.ports.reset)
-                # Connect config_en for each config reg
-                self.wire(reg.ports.config_en, self.ports.config.write[0])
         # If we only have 1 config register, we don't need a mux
         # Wire sole config register directly to read_config_data_output
         else:
             reg = list(self.registers.values())[0]
             zext = ZextWrapper(reg.width, 32)
             self.wire(reg.ports.O, zext.ports.I)
-            self.wire(reg.ports.config_en, self.ports.config.write[0])
             zext_out = zext.ports.O
             self.wire(zext_out, self.ports.read_config_data)
 
@@ -63,6 +60,8 @@ class CB(Configurable):
             reg.set_data_width(32)
             self.wire(self.ports.config.config_addr, reg.ports.config_addr)
             self.wire(self.ports.config.config_data, reg.ports.config_data)
+            # Connect config_en for each config reg
+            self.wire(reg.ports.config_en, self.ports.config.write[0])
 
     def name(self):
         return f"CB_{self.num_tracks}_{self.width}"

--- a/simple_cb/simple_cb_magma.py
+++ b/simple_cb/simple_cb_magma.py
@@ -41,12 +41,15 @@ class CB(Configurable):
                 self.wire(reg.ports.O, self.read_config_data_mux.ports.I[idx])
                 # Wire up config register resets
                 self.wire(reg.ports.reset, self.ports.reset)
+                # Connect config_en for each config reg
+                self.wire(reg.ports.config_en, self.ports.config.write[0])
         # If we only have 1 config register, we don't need a mux
         # Wire sole config register directly to read_config_data_output
         else:
             reg = list(self.registers.values())[0]
             zext = ZextWrapper(reg.width, 32)
             self.wire(reg.ports.O, zext.ports.I)
+            self.wire(reg.ports.config_en, self.ports.config.write[0])
             zext_out = zext.ports.O
             self.wire(zext_out, self.ports.read_config_data)
 

--- a/simple_sb/simple_sb_magma.py
+++ b/simple_sb/simple_sb_magma.py
@@ -66,6 +66,7 @@ class SB(Configurable):
             reg.set_data_width(32)
             self.wire(self.ports.config.config_addr, reg.ports.config_addr)
             self.wire(self.ports.config.config_data, reg.ports.config_data)
+            self.wire(self.ports.config.write[0], reg.ports.config_en)
             self.wire(self.ports.reset, reg.ports.reset)
 
         # read_config_data output

--- a/test_simple_cb/test_simple_cb_magma.py
+++ b/test_simple_cb/test_simple_cb_magma.py
@@ -31,7 +31,7 @@ def test_regression(num_tracks):
     # garnet. This also requires bringing in the functional model that exists in
     # simple_cb/simple_cb.py (see test_simple_cb/test_simple_cb_regression.py).
 
-    def configure(addr, data):
+    def configure(addr, data, assert_wr=True):
         tester.poke(simple_cb_circuit.clk, 0)
         tester.poke(simple_cb_circuit.reset, 0)
         tester.poke(simple_cb_circuit.config.config_addr, addr)
@@ -40,9 +40,13 @@ def test_regression(num_tracks):
         # TODO(alexcarsello): Once config.write logic is enabled, check that
         # leaving write=0 does not perform a reconfiguration, ala:
         #
-        #   tester.poke(simple_cb_circuit.config.write, 1)
+        if(assert_wr):
+            tester.poke(simple_cb_circuit.config.write, 1)
+        else:
+            tester.poke(simple_cb_circuit.config.write, 0)
         #
         tester.step(2)
+        tester.poke(simple_cb_circuit.config.write, 0)
 
     def config_read(addr):
         tester.poke(simple_cb_circuit.clk, 0)

--- a/test_simple_cb/test_simple_cb_magma.py
+++ b/test_simple_cb/test_simple_cb_magma.py
@@ -37,9 +37,8 @@ def test_regression(num_tracks):
         tester.poke(simple_cb_circuit.config.config_addr, addr)
         tester.poke(simple_cb_circuit.config.config_data, data)
         tester.poke(simple_cb_circuit.config.read, 0)
-        # We can use this switch to check that
-        # leaving write=0 does not perform a reconfiguration, ala:
-        #
+        # We can use assert_wr switch to check that no reconfiguration
+        # occurs when write = 0
         if(assert_wr):
             tester.poke(simple_cb_circuit.config.write, 1)
         else:

--- a/test_simple_cb/test_simple_cb_magma.py
+++ b/test_simple_cb/test_simple_cb_magma.py
@@ -37,7 +37,7 @@ def test_regression(num_tracks):
         tester.poke(simple_cb_circuit.config.config_addr, addr)
         tester.poke(simple_cb_circuit.config.config_data, data)
         tester.poke(simple_cb_circuit.config.read, 0)
-        # TODO(alexcarsello): Once config.write logic is enabled, check that
+        # We can use this switch to check that
         # leaving write=0 does not perform a reconfiguration, ala:
         #
         if(assert_wr):
@@ -59,6 +59,7 @@ def test_regression(num_tracks):
     for config_data in [BitVector(x, 32) for x in range(num_tracks)]:
         reset()
         configure(BitVector(0, 8), config_data)
+        configure(BitVector(0, 8), config_data + 1, False)
         config_read(BitVector(0, 8))
         tester.eval()
         tester.expect(simple_cb_circuit.read_config_data, config_data)

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -60,27 +60,46 @@ class Tile(generator.Generator):
             self.wire(self.ports.config.config_data,
                       feature.ports.config.config_data)
             self.wire(self.ports.config.read, feature.ports.config.read)
-            self.wire(self.ports.config.write, feature.ports.config.write)
+            # this is lumped in with config_en logic below
+            # self.wire(self.ports.config.write, feature.ports.config.write)
 
         # read_data mux
         num_mux_inputs = len(self.features())
         self.read_data_mux = MuxWithDefaultWrapper(num_mux_inputs, 32, 8, 0)
-        for i, feat in enumerate(self.features()):
-            self.wire(feat.ports.read_config_data,
-                      self.read_data_mux.ports.I[i])
         # Connect S input to config_addr[feature].
         self.wire(self.ports.config.config_addr[16:24],
                   self.read_data_mux.ports.S)
         self.wire(self.read_data_mux.ports.O, self.ports.read_config_data)
-        self.and2 = FromMagma(mantle.DefineAnd(2))
-        self.eq = FromMagma(mantle.DefineEQ(16))
+        self.read_and_tile = FromMagma(mantle.DefineAnd(2))
+        self.write_and_tile = FromMagma(mantle.DefineAnd(2))
+        self.eq_tile = FromMagma(mantle.DefineEQ(16))
         # config_addr[tile_id] == self.tile_id?
-        self.wire(self.ports.tile_id, self.eq.ports.I0)
-        self.wire(self.ports.config.config_addr[0:16], self.eq.ports.I1)
+        self.wire(self.ports.tile_id, self.eq_tile.ports.I0)
+        self.wire(self.ports.config.config_addr[0:16], self.eq_tile.ports.I1)
         # Connect EN input to (config_addr[tile_id] == self.tile_id & READ)
-        self.wire(self.and2.ports.I0, self.eq.ports.O)
-        self.wire(self.and2.ports.I1, self.ports.config.read[0])
-        self.wire(self.and2.ports.O, self.read_data_mux.ports.EN[0])
+        self.wire(self.read_and_tile.ports.I0, self.eq_tile.ports.O)
+        self.wire(self.read_and_tile.ports.I1, self.ports.config.read[0])
+        self.wire(self.read_and_tile.ports.O, self.read_data_mux.ports.EN[0])
+        # Config_en_tile = (config_addr[tile_id] == self.tile_id & WRITE)
+        self.wire(self.write_and_tile.ports.I0, self.eq_tile.ports.O)
+        self.wire(self.write_and_tile.ports.I1, self.ports.config.write[0])
+        for i, feat in enumerate(self.features()):
+            # wire each feature's read_data output to
+            # read_data_mux inputs
+            self.wire(feat.ports.read_config_data,
+                      self.read_data_mux.ports.I[i])
+            # for each feature,
+            # config_en = (config_addr[feat] == feature_num) & config_en_tile
+            self.decode_feat[i] = FromMagma(mantle.Decode(i, 8))
+            self.feat_and_config_en_tile[i] = FromMagma(mantle.DefineAnd(2))
+            self.wire(self.decode_feat[i].ports.I,
+                      self.ports.config.config_addr)
+            self.wire(self.decode_feat[i].ports.O,
+                      self.feat_and_config_en_tile[i].ports.I0)
+            self.wire(self.write_and_tile.ports.O,
+                      self.feat_and_config_en_tile[i].ports.I1)
+            self.wire(self.feat_and_config_en_tile[i].ports.O,
+                      feat.ports.config.write)
 
     def __wire_cb(self, side, cb):
         if cb.width == 1:

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -69,8 +69,8 @@ class Tile(generator.Generator):
         self.wire(self.ports.config.config_addr[16:24],
                   self.read_data_mux.ports.S)
         self.wire(self.read_data_mux.ports.O, self.ports.read_config_data)
-        
-        # read_data_mux.EN = (config_addr.tile_id == self.tile_id) & READ
+
+        # Logic to generate EN input for read_data_mux
         self.read_and_tile = FromMagma(mantle.DefineAnd(2))
         self.eq_tile = FromMagma(mantle.DefineEQ(16))
         # config_addr.tile_id == self.tile_id?
@@ -79,9 +79,9 @@ class Tile(generator.Generator):
         # (config_addr.tile_id == self.tile_id) & READ
         self.wire(self.read_and_tile.ports.I0, self.eq_tile.ports.O)
         self.wire(self.read_and_tile.ports.I1, self.ports.config.read[0])
-        # Connect read_data_mux.EN to (config_addr.tile_id == self.tile_id & READ)
+        # read_data_mux.EN = (config_addr.tile_id == self.tile_id) & READ
         self.wire(self.read_and_tile.ports.O, self.read_data_mux.ports.EN[0])
-        
+
         # Logic for writing to config registers
         # Config_en_tile = (config_addr.tile_id == self.tile_id & WRITE)
         self.write_and_tile = FromMagma(mantle.DefineAnd(2))

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -83,6 +83,8 @@ class Tile(generator.Generator):
         # Config_en_tile = (config_addr[tile_id] == self.tile_id & WRITE)
         self.wire(self.write_and_tile.ports.I0, self.eq_tile.ports.O)
         self.wire(self.write_and_tile.ports.I1, self.ports.config.write[0])
+        self.decode_feat = []
+        self.feat_and_config_en_tile = []
         for i, feat in enumerate(self.features()):
             # wire each feature's read_data output to
             # read_data_mux inputs
@@ -90,16 +92,16 @@ class Tile(generator.Generator):
                       self.read_data_mux.ports.I[i])
             # for each feature,
             # config_en = (config_addr[feat] == feature_num) & config_en_tile
-            self.decode_feat[i] = FromMagma(mantle.Decode(i, 8))
-            self.feat_and_config_en_tile[i] = FromMagma(mantle.DefineAnd(2))
+            self.decode_feat.append(FromMagma(mantle.DefineDecode(i, 8)))
+            self.feat_and_config_en_tile.append(FromMagma(mantle.DefineAnd(2)))
             self.wire(self.decode_feat[i].ports.I,
-                      self.ports.config.config_addr)
+                      self.ports.config.config_addr[16:24])
             self.wire(self.decode_feat[i].ports.O,
                       self.feat_and_config_en_tile[i].ports.I0)
             self.wire(self.write_and_tile.ports.O,
                       self.feat_and_config_en_tile[i].ports.I1)
             self.wire(self.feat_and_config_en_tile[i].ports.O,
-                      feat.ports.config.write)
+                      feat.ports.config.write[0])
 
     def __wire_cb(self, side, cb):
         if cb.width == 1:

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -60,27 +60,25 @@ class Tile(generator.Generator):
             self.wire(self.ports.config.config_data,
                       feature.ports.config.config_data)
             self.wire(self.ports.config.read, feature.ports.config.read)
-            # this is lumped in with config_en logic below
-            # self.wire(self.ports.config.write, feature.ports.config.write)
 
         # read_data mux
         num_mux_inputs = len(self.features())
         self.read_data_mux = MuxWithDefaultWrapper(num_mux_inputs, 32, 8, 0)
-        # Connect S input to config_addr[feature].
+        # Connect S input to config_addr.feature.
         self.wire(self.ports.config.config_addr[16:24],
                   self.read_data_mux.ports.S)
         self.wire(self.read_data_mux.ports.O, self.ports.read_config_data)
         self.read_and_tile = FromMagma(mantle.DefineAnd(2))
         self.write_and_tile = FromMagma(mantle.DefineAnd(2))
         self.eq_tile = FromMagma(mantle.DefineEQ(16))
-        # config_addr[tile_id] == self.tile_id?
+        # config_addr.tile_id == self.tile_id?
         self.wire(self.ports.tile_id, self.eq_tile.ports.I0)
         self.wire(self.ports.config.config_addr[0:16], self.eq_tile.ports.I1)
-        # Connect EN input to (config_addr[tile_id] == self.tile_id & READ)
+        # Connect EN input to (config_addr.tile_id == self.tile_id & READ)
         self.wire(self.read_and_tile.ports.I0, self.eq_tile.ports.O)
         self.wire(self.read_and_tile.ports.I1, self.ports.config.read[0])
         self.wire(self.read_and_tile.ports.O, self.read_data_mux.ports.EN[0])
-        # Config_en_tile = (config_addr[tile_id] == self.tile_id & WRITE)
+        # Config_en_tile = (config_addr.tile_id == self.tile_id & WRITE)
         self.wire(self.write_and_tile.ports.I0, self.eq_tile.ports.O)
         self.wire(self.write_and_tile.ports.I1, self.ports.config.write[0])
         self.decode_feat = []
@@ -91,7 +89,7 @@ class Tile(generator.Generator):
             self.wire(feat.ports.read_config_data,
                       self.read_data_mux.ports.I[i])
             # for each feature,
-            # config_en = (config_addr[feat] == feature_num) & config_en_tile
+            # config_en = (config_addr.feature == feature_num) & config_en_tile
             self.decode_feat.append(FromMagma(mantle.DefineDecode(i, 8)))
             self.feat_and_config_en_tile.append(FromMagma(mantle.DefineAnd(2)))
             self.wire(self.decode_feat[i].ports.I,


### PR DESCRIPTION
-Adds config_en/feature address decode logic in tile to allow for writing to config regs
-Connects config_en to write port of each config register

Still TODO:
SRAMs not yet R/W-able over config bus. To make this happen, we'll need to add a way for cores to have "extra" features and communicate this information to the tile.