### PR TITLE
Global signal column

### DIFF
--- a/column/column_magma.py
+++ b/column/column_magma.py
@@ -86,6 +86,12 @@ class ColumnMeso(ColumnBase):
                     self.wire(tile.ports[output_name],
                               self.tiles[i + 1].ports[input_name])
 
+    def combine_read_data_outputs(self):
+        self.read_data_OR = FromMagma(mantle.DefineOr(self.height, 32))
+        self.wire(self.read_data_OR.ports.O, self.ports.read_config_data)
+        for i, tile in enumerate(self.tiles):
+            self.wire(tile.ports.read_config_data,
+                      self.read_data_OR.ports[f"I{i}"])
 
 # Column that simply fans out all global signals to tiles
 class ColumnFanout(ColumnBase):

--- a/column/column_magma.py
+++ b/column/column_magma.py
@@ -93,6 +93,7 @@ class ColumnMeso(ColumnBase):
             self.wire(tile.ports.read_config_data,
                       self.read_data_OR.ports[f"I{i}"])
 
+
 # Column that simply fans out all global signals to tiles
 class ColumnFanout(ColumnBase):
     def wire_global_signals(self):

--- a/column/column_magma.py
+++ b/column/column_magma.py
@@ -71,9 +71,13 @@ class ColumnMeso(ColumnBase):
             for global_signal in self.globals():
                 input_name = global_signal.qualified_name()
                 output_name = input_name + "_out"
+                # Add output port to pass global signal through
                 tile.add_port(output_name,
                               magma.Out(global_signal.base_type()))
+                # Make pass-through connection
+                tile.wire(tile.ports[input_name], tile.ports[output_name])
                 if i < len(self.tiles)-1:
+                    # Connect output port to input port of next tile
                     self.wire(tile.ports[output_name],
                               self.tiles[i + 1].ports[input_name])
 

--- a/column/column_magma.py
+++ b/column/column_magma.py
@@ -75,16 +75,10 @@ class ColumnMeso(ColumnBase):
         for i, tile in enumerate(self.tiles):
             for global_signal in self.globals():
                 input_name = global_signal.qualified_name()
-                output_name = input_name + "_out"
-                # Add output port to pass global signal through
-                tile.add_port(output_name,
-                              magma.Out(global_signal.base_type()))
-                # Make pass-through connection
-                tile.wire(tile.ports[input_name], tile.ports[output_name])
+                output_port = tile.pass_signal_through(input_name)
                 if i < len(self.tiles)-1:
                     # Connect output port to input port of next tile
-                    self.wire(tile.ports[output_name],
-                              self.tiles[i + 1].ports[input_name])
+                    self.wire(output_port, self.tiles[i + 1].ports[input_name])
 
     def combine_read_data_outputs(self):
         self.read_data_OR = FromMagma(mantle.DefineOr(self.height, 32))

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -26,15 +26,16 @@ class Generator(ABC):
     def wire(self, port0, port1):
         assert isinstance(port0, PortReferenceBase)
         assert isinstance(port1, PortReferenceBase)
-        self.wires.append((port0, port1))
+        connection = (max(port0, port1), min(port0, port1))
+        if connection not in self.wires:
+            self.wires.append(connection)
 
     def remove_wire(self, port0, port1):
         assert isinstance(port0, PortReferenceBase)
         assert isinstance(port1, PortReferenceBase)
-        if (port0, port1) in self.wires:
-            self.wires.remove((port0, port1))
-        elif (port1, port0) in self.wires:
-            self.wires.remove((port1, port0))
+        connection = (max(port0, port1), min(port0, port1))
+        if connection in self.wires:
+            self.wires.remove(connection)
 
     def decl(self):
         io = []

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -31,8 +31,9 @@ class Generator(ABC):
         if connection not in self.wires:
             self.wires.append(connection)
         else:
-            warnings.warn("skipping duplicate connection: {port0.name}, "
-                          "{port1.name}")
+            warnings.warn(f"skipping duplicate connection: "
+                          f"{port0.qualified_name()}, "
+                          f"{port1.qualified_name()}")
 
     def remove_wire(self, port0, port1):
         assert isinstance(port0, PortReferenceBase)

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -3,6 +3,7 @@ from ordered_set import OrderedSet
 import magma
 from common.collections import DotDict
 from generator.port_reference import PortReference, PortReferenceBase
+import warnings
 
 
 class Generator(ABC):
@@ -26,14 +27,17 @@ class Generator(ABC):
     def wire(self, port0, port1):
         assert isinstance(port0, PortReferenceBase)
         assert isinstance(port1, PortReferenceBase)
-        connection = (max(port0, port1), min(port0, port1))
+        connection = self.__sort_ports(port0, port1)
         if connection not in self.wires:
             self.wires.append(connection)
+        else:
+            warnings.warn("skipping duplicate connection: {port0.name}, "
+                          "{port1.name}")
 
     def remove_wire(self, port0, port1):
         assert isinstance(port0, PortReferenceBase)
         assert isinstance(port1, PortReferenceBase)
-        connection = (max(port0, port1), min(port0, port1))
+        connection = self.__sort_ports(port0, port1)
         if connection in self.wires:
             self.wires.remove(connection)
 
@@ -76,3 +80,9 @@ class Generator(ABC):
                     magma.wire(wire0, wire1)
 
         return _Circ
+
+    def __sort_ports(self, port0, port1):
+        if id(port0) < id(port1):
+            return (port0, port1)
+        else:
+            return (port1, port0)

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -28,6 +28,14 @@ class Generator(ABC):
         assert isinstance(port1, PortReferenceBase)
         self.wires.append((port0, port1))
 
+    def remove_wire(self, port0, port1):
+        assert isinstance(port0, PortReferenceBase)
+        assert isinstance(port1, PortReferenceBase)
+        if (port0, port1) in self.wires:
+            self.wires.remove((port0, port1))
+        elif (port1, port0) in self.wires:
+            self.wires.remove((port1, port0))
+
     def decl(self):
         io = []
         for name, port in self.ports.items():

--- a/global_controller/global_controller_magma.py
+++ b/global_controller/global_controller_magma.py
@@ -24,6 +24,8 @@ class GlobalController(generator.Generator):
             reset_in=magma.In(magma.AsyncReset),
             clk_out=magma.Out(magma.Clock),
             reset_out=magma.Out(magma.AsyncReset),
+            # TODO: make number of stall domains a param
+            stall=magma.Out(magma.Bits(4))
         )
 
         wrapper = global_controller_genesis2.gc_wrapper
@@ -46,6 +48,7 @@ class GlobalController(generator.Generator):
         self.wire(self.underlying.ports.write, self.ports.config.write[0])
         self.wire(self.underlying.ports.clk_out, self.ports.clk_out)
         self.wire(self.underlying.ports.reset_out, self.ports.reset_out)
+        self.wire(self.underlying.ports.cgra_stalled, self.ports.stall)
 
         self.wire(self.ports.read_data_in, self.underlying.ports.config_data_in)
 

--- a/interconnect/interconnect_magma.py
+++ b/interconnect/interconnect_magma.py
@@ -33,11 +33,14 @@ class Interconnect(generator.Generator):
             clk=magma.In(magma.Clock),
             reset=magma.In(magma.AsyncReset),
             read_config_data=magma.Out(magma.Bits(32)),
+            # TODO: make number of stall domains a param
+            stall=magma.In(magma.Bits(4))
         )
 
         for column in self.columns:
             self.wire(self.ports.config, column.ports.config)
             self.wire(self.ports.reset, column.ports.reset)
+            self.wire(self.ports.stall, column.ports.stall)
         self.wire(self.ports.west, self.columns[0].ports.west)
         self.wire(self.ports.east, self.columns[-1].ports.east)
         for i, column in enumerate(self.columns):

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -1,4 +1,5 @@
 import magma
+import mantle
 from generator.configurable import ConfigurationType
 from common.core import Core
 from common.coreir_wrap import CoreirWrap
@@ -15,6 +16,7 @@ class MemCore(Core):
         self.data_width = data_width
         self.data_depth = data_depth
         TData = magma.Bits(self.data_width)
+        TBit = magma.Bits(1)
 
         self.add_ports(
             data_in=magma.In(TData),
@@ -23,7 +25,11 @@ class MemCore(Core):
             clk=magma.In(magma.Clock),
             config=magma.In(ConfigurationType(8, 32)),
             read_config_data=magma.Out(magma.Bits(32)),
-            reset=magma.In(magma.AsyncReset)
+            reset=magma.In(magma.AsyncReset),
+            flush=magma.In(TBit),
+            wen_in=magma.In(TBit),
+            ren_in=magma.In(TBit),
+            stall=magma.In(magma.Bits(4))
         )
 
         wrapper = memory_core_genesis2.memory_core_wrapper
@@ -43,19 +49,23 @@ class MemCore(Core):
         self.wire(self.ports.config.write[0], self.underlying.ports.config_en)
         self.wire(self.underlying.ports.read_data, self.ports.read_config_data)
         self.wire(self.ports.reset, self.underlying.ports.reset)
+        self.wire(self.ports.flush[0], self.underlying.ports.flush)
+        self.wire(self.ports.wen_in[0], self.underlying.ports.wen_in)
+        self.wire(self.ports.ren_in[0], self.underlying.ports.ren_in)
+
+        # PE core uses clk_en (essentially active low stall)
+        self.stallInverter = FromMagma(mantle.DefineInvert(1))
+        self.wire(self.stallInverter.ports.I, self.ports.stall[0:1])
+        self.wire(self.stallInverter.ports.O[0], self.underlying.ports.clk_en)
 
         # TODO(rsetaluri): Actually wire these inputs.
         signals = (
-            ("clk_en", 1),
             ("config_en_sram", 4),
             ("config_en_linebuf", 1),
-            ("wen_in", 1),
-            ("ren_in", 1),
             ("chain_wen_in", 1),
             ("config_read", 1),
             ("config_write", 1),
             ("chain_in", self.data_width),
-            ("flush", 1),
         )
         for name, width in signals:
             val = magma.bits(0, width) if width > 1 else magma.bit(0)
@@ -64,7 +74,8 @@ class MemCore(Core):
                   self.underlying.ports.config_addr[0:24])
 
     def inputs(self):
-        return [self.ports.data_in, self.ports.addr_in]
+        return [self.ports.data_in, self.ports.addr_in, self.ports.flush,
+                self.ports.ren_in, self.ports.wen_in]
 
     def outputs(self):
         return [self.ports.data_out]

--- a/pe_core/pe_core_magma.py
+++ b/pe_core/pe_core_magma.py
@@ -52,8 +52,8 @@ class PECore(Core):
         self.wire(self.ports.config.write[0], self.underlying.ports.cfg_en)
         self.wire(self.underlying.ports.read_data, self.ports.read_config_data)
 
-        #TODO: Make PE core use active high reset
-        self.wire(self.ports.reset, self.underlying.ports.rst_n)   
+        # TODO: Make PE core use active high reset
+        self.wire(self.ports.reset, self.underlying.ports.rst_n)
 
         # PE core uses clk_en (essentially active low stall)
         self.stallInverter = FromMagma(mantle.DefineInvert(1))

--- a/pe_core/pe_core_magma.py
+++ b/pe_core/pe_core_magma.py
@@ -1,4 +1,5 @@
 import magma
+import mantle
 from common.core import Core
 from generator.configurable import ConfigurationType
 from generator.const import Const
@@ -34,6 +35,8 @@ class PECore(Core):
             reset=magma.In(magma.AsyncReset),
             config=magma.In(ConfigurationType(8, 32)),
             read_config_data=magma.Out(magma.Bits(32)),
+            # TODO: Make number of stall domains paramaterizable
+            stall=magma.In(magma.Bits(4))
         )
 
         self.wire(self.ports.data0, self.underlying.ports.data0)
@@ -48,16 +51,14 @@ class PECore(Core):
                   self.underlying.ports.cfg_d)
         self.wire(self.ports.config.write[0], self.underlying.ports.cfg_en)
         self.wire(self.underlying.ports.read_data, self.ports.read_config_data)
-        # TODO(alexcarsello): Invert for active-low reset in pe core genesis.
-        self.wire(self.ports.reset, self.underlying.ports.rst_n)
 
-        # TODO(rsetaluri): Actually wire these inputs.
-        signals = (
-            ("clk_en", 1),
-        )
-        for name, width in signals:
-            val = magma.bits(0, width) if width > 1 else magma.bit(0)
-            self.wire(Const(val), self.underlying.ports[name])
+        #TODO: Make PE core use active high reset
+        self.wire(self.ports.reset, self.underlying.ports.rst_n)   
+
+        # PE core uses clk_en (essentially active low stall)
+        self.stallInverter = FromMagma(mantle.DefineInvert(1))
+        self.wire(self.stallInverter.ports.I, self.ports.stall[0:1])
+        self.wire(self.stallInverter.ports.O[0], self.underlying.ports.clk_en)
 
     def inputs(self):
         return [self.ports.data0, self.ports.data1,

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -143,7 +143,7 @@ class Tile(generator.Generator):
     # input from another tile and ORing it with the origin read_data
     # output of this tile to create a new read_data output
     # TODO: Make some more generally useful form of this transformation
-    def read_data_reduction(self, signal):
+    def read_data_reduction(self):
         pass_through = self.ports.read_config_data
         input_name = pass_through.qualified_name() + "_in"
         # Create input port for pass through read_data reduction

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -44,6 +44,10 @@ class Tile(generator.Generator):
         self.wire(self.ports.south, self.sb.ports.south)
         self.wire(self.ports.east, self.sb.ports.east)
 
+        # this is hacky, but connect stall if the core has a stall input
+        if "stall" in self.core.ports:
+            self.wire(self.ports.stall, core.ports.stall)
+
         sides = (self.ports.north, self.ports.west)
         for i, cb in enumerate(self.cbs):
             side = sides[i % len(sides)]

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -126,16 +126,18 @@ class Tile(generator.Generator):
 
     # Takes in an existing input of the tile and creates and output
     # to pass the signal through
+    # returns the new output port reference
     def pass_signal_through(self, signal):
         if signal in self.ports.values():
             pass_through = signal
         elif signal in self.ports.keys():
             pass_through = self.ports[signal]
         # Create output port for pass through
-        output_name = signal.qualified_name() + "_out"
+        output_name = pass_through.qualified_name() + "_out"
         self.add_port(output_name, magma.Out(pass_through.base_type()))
         # Actually make the pass through connection
         self.wire(pass_through, self.ports[output_name])
+        return self.ports[output_name]
 
     def features(self):
         return (self.core, self.sb, *(cb for cb in self.cbs))

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -124,6 +124,19 @@ class Tile(generator.Generator):
         else:
             raise NotImplementedError(cb, cb.width)
 
+    # Takes in an existing input of the tile and creates and output
+    # to pass the signal through
+    def pass_signal_through(self, signal):
+        if signal in self.ports.values():
+            pass_through = signal
+        elif signal in self.ports.keys():
+            pass_through = self.ports[signal]
+        # Create output port for pass through
+        output_name = signal.qualified_name() + "_out"
+        self.add_port(output_name, magma.Out(pass_through.base_type()))
+        # Actually make the pass through connection
+        self.wire(pass_through, self.ports[output_name])
+
     def features(self):
         return (self.core, self.sb, *(cb for cb in self.cbs))
 

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -35,7 +35,8 @@ class Tile(generator.Generator):
             tile_id=magma.In(magma.Bits(16)),
             clk=magma.In(magma.Clock),
             reset=magma.In(magma.AsyncReset),
-            read_config_data=magma.Out(magma.Bits(32))
+            read_config_data=magma.Out(magma.Bits(32)),
+            stall=magma.In(magma.Bits(4))
         )
 
         self.wire(self.ports.north, self.sb.ports.north)

--- a/tile/tile_magma.py
+++ b/tile/tile_magma.py
@@ -153,7 +153,8 @@ class Tile(generator.Generator):
         self.read_data_reduce_or = FromMagma(mantle.DefineOr(2, 32))
         # OR previous read_data output with read_data input to create NEW
         # read_data output
-        self.wire(self.read_data_mux.O, self.read_data_reduce_or.ports.I0)
+        self.wire(self.read_data_mux.ports.O,
+                  self.read_data_reduce_or.ports.I0)
         self.wire(self.ports[input_name], self.read_data_reduce_or.ports.I1)
         self.wire(self.read_data_reduce_or.ports.O, pass_through)
 

--- a/top/top_magma.py
+++ b/top/top_magma.py
@@ -3,7 +3,7 @@ import mantle
 import generator.generator as generator
 from global_controller.global_controller_magma import GlobalController
 from interconnect.interconnect_magma import Interconnect
-from column.column_magma import ColumnFanout
+from column.column_magma import ColumnMeso
 from tile.tile_magma import Tile
 from pe_core.pe_core_magma import PECore
 from memory_core.memory_core_magma import MemCore
@@ -24,7 +24,7 @@ class CGRA(generator.Generator):
             for j in range(height):
                 core = MemCore(16, 1024) if (i % 2) else PECore()
                 tiles.append(Tile(core))
-            columns.append(ColumnFanout(tiles))
+            columns.append(ColumnMeso(tiles))
         self.interconnect = Interconnect(columns)
 
         side_type = self.interconnect.side_type

--- a/top/top_magma.py
+++ b/top/top_magma.py
@@ -53,6 +53,8 @@ class CGRA(generator.Generator):
                   self.interconnect.ports.clk)
         self.wire(self.global_controller.ports.reset_out,
                   self.interconnect.ports.reset)
+        self.wire(self.global_controller.ports.stall,
+                  self.interconnect.ports.stall)
 
         self.wire(self.interconnect.ports.read_config_data,
                   self.global_controller.ports.read_data_in)

--- a/top/top_magma.py
+++ b/top/top_magma.py
@@ -3,7 +3,7 @@ import mantle
 import generator.generator as generator
 from global_controller.global_controller_magma import GlobalController
 from interconnect.interconnect_magma import Interconnect
-from column.column_magma import Column
+from column.column_magma import ColumnFanout
 from tile.tile_magma import Tile
 from pe_core.pe_core_magma import PECore
 from memory_core.memory_core_magma import MemCore
@@ -24,7 +24,7 @@ class CGRA(generator.Generator):
             for j in range(height):
                 core = MemCore(16, 1024) if (i % 2) else PECore()
                 tiles.append(Tile(core))
-            columns.append(Column(tiles))
+            columns.append(ColumnFanout(tiles))
         self.interconnect = Interconnect(columns)
 
         side_type = self.interconnect.side_type


### PR DESCRIPTION
This PR primarily adds functions to column and tile to make the global signal management transformations.

There is now a column base class, with ColumnFanout and ColumnMeso classes that inherit from it to implement two different global signal distribution schemes.

I've also added a remove_wire function to the generator base class, as this was necessary to implement the transformations for combining the read_data signals down a column.

Additionally, in the pe and memory cores, there were many underlying signals that weren't connected (clk_en, wen_in, ren_in). I filled in some of those connections.

In Tile, I've added a function that takes in an input port adds a corresponding output port to pass an input signal through the tile. I've also added a function to do the read_data reduction in the tile. This function adds a read_data input, breaks the current connection to the tile's read_data output, ORs the tile's read_data with the input read_data, and finally connects the result of that OR to the tile's read_data output. 

It's currently failing the Travis tests (test_config_register) because of a problem in master, not any of the changes in this PR.