### PR TITLE
Switch msat to z3 for CoSA test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     - pip install -e .
 
     # Begin setup CoSA dependencies
-    - pysmt-install --msat --confirm-agreement
+    - pysmt-install --z3 --confirm-agreement
     - export PYTHONPATH="/home/travis/.smt_solvers/python-bindings-3.6:${PYTHONPATH}"
     - export LD_LIBRARY_PATH="/home/travis/.smt_solvers/python-bindings-3.6:${LD_LIBRARY_PATH}"
     - pysmt-install --check

--- a/README.md
+++ b/README.md
@@ -14,29 +14,25 @@ $ make install -j  # Use sudo on linux
 ```
 
 
-## Install CoSA
-```
-# $ pip install cosa==0.2.5
-# Install CoSA from source to avoid https://github.com/cristian-mattarei/CoSA/issues/41
-$ git clone https://github.com/cristian-mattarei/CoSA.git
-$ cd CoSA
-$ pip install -e .
-$ cd ..
-$ pysmt-install --msat  # Agree to license
-$ pysmt-install --env   # Run the commands in the output and add them to your shell configuration file, travis example below
-export PYTHONPATH="/home/travis/.smt_solvers/python-bindings-3.6:${PYTHONPATH}"
-export LD_LIBRARY_PATH="/home/travis/.smt_solvers/python-bindings-3.6:${LD_LIBRARY_PATH}"
-❯ pysmt-install --check # Should see msat installed and in Python's path
-Installed Solvers:
-  msat      True (5.5.1)
-
-```
-
 ## Install python dependencies
 ```
 $ pip install -r requirements.txt  # install python dependencies
 $ pip install pytest
 $ pip install -e .
+```
+
+## Install SMT Solver
+Replace `--z3` with solver of choice (e.g. `--msat` for mathsat).
+```
+$ pysmt-install --z3  # Agree to license
+$ pysmt-install --env   # Run the commands in the output and add them to your shell configuration file, travis example below
+export PYTHONPATH="/home/travis/.smt_solvers/python-bindings-3.6:${PYTHONPATH}"
+export LD_LIBRARY_PATH="/home/travis/.smt_solvers/python-bindings-3.6:${LD_LIBRARY_PATH}"
+❯ pysmt-install --check # Should see z3 installed and in Python's path
+Installed Solvers:
+  ...
+  z3        True (4.6.0)
+  ...
 ```
 
 ## Verify functionality

--- a/test_simple_pe/test_simple_pe_magma.py
+++ b/test_simple_pe/test_simple_pe_magma.py
@@ -70,7 +70,7 @@ expected: FALSE
     with open("test_simple_pe/build/problem_pe_core.txt", "w") as f:
         f.write(problem)
     assert not os.system(
-        "CoSA --problem test_simple_pe/build/problem_pe_core.txt")
+        "CoSA --problem test_simple_pe/build/problem_pe_core.txt --solver z3")
 
 
 @pytest.mark.skip("Broken becausd CoSA errors parsing the generated ets file")
@@ -150,4 +150,4 @@ expected: TRUE
         with open(problem_file, "w") as f:
             f.write(problem)
         assert not os.system(
-            f"CoSA --problem {problem_file}")
+            f"CoSA --problem {problem_file} --solver z3")


### PR DESCRIPTION
`z3` was easier to install on CentOS which we are using for ee272. I don't think anyone cares about which solver is used (let me know otherwise), so this changes the CoSA related tests to use the `z3` solver. It also updates the README with the setup instructions.