### PR TITLE
Add pipeline registers

### DIFF
--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -5,9 +5,8 @@ from common.core import Core
 from common.mux_with_default import MuxWithDefaultWrapper
 from common.zext_wrapper import ZextWrapper
 from generator.configurable import Configurable, ConfigurationType
-from .cyclone import Node, PortNode, Tile, SwitchBoxNode, SwitchBoxIO
-from .cyclone import SwitchBox, InterconnectCore, RegisterNode
-from .cyclone import RegisterMuxNode
+from .cyclone import Node, PortNode, Tile, SwitchBoxNode, SwitchBoxIO, \
+    SwitchBox, InterconnectCore, RegisterNode, RegisterMuxNode
 import mantle
 from common.mux_wrapper import MuxWrapper
 import magma

--- a/test_interconnect/test_cyclone.py
+++ b/test_interconnect/test_cyclone.py
@@ -199,7 +199,7 @@ def assert_tile_coordinate(tile: Tile, x: int, y: int):
         assert_coordinate(sb, x, y)
     for _, node in tile.ports.items():
         assert_coordinate(node, x, y)
-    for _, node in tile.registers:
+    for _, node in tile.switchbox.registers:
         assert_coordinate(node, x, y)
 
 


### PR DESCRIPTION
This PR add a pass to the interconnect graph to insert pipeline registers. Per Mark's request, the pass interface allows user to insert pipeline registers on a particular side and track of a SB. This ability reduces the routing area if registers are not inserted everywhere.

Test:
Sequential poke and peak at different clock cycles to test the register mux selection.