### PR TITLE
Interconnect global signal

### DIFF
--- a/common/transform.py
+++ b/common/transform.py
@@ -1,0 +1,43 @@
+from generator.from_magma import FromMagma
+from generator.generator import Generator
+import magma
+import mantle
+
+
+def pass_signal_through(gen: Generator, signal):
+    """Takes in an existing input of the tile and creates and output
+       to pass the signal through
+       returns the new output port reference
+    """
+    pass_through = None
+    if signal in gen.ports.values():
+        pass_through = signal
+    elif signal in gen.ports.keys():
+        pass_through = gen.ports[signal]
+    assert pass_through is not None, "Cannot find " + pass_through
+    # Create output port for pass through
+    output_name = pass_through.qualified_name() + "_out"
+    gen.add_port(output_name, magma.Out(pass_through.base_type()))
+    # Actually make the pass through connection
+    gen.wire(pass_through, gen.ports[output_name])
+    return gen.ports[output_name]
+
+
+def read_data_reduction(gen):
+    """Embeds read_data reduction network in tile by accepting a read_data
+       input from another tile and ORing it with the origin read_data
+       output of this tile to create a new read_data output
+    """
+    pass_through = gen.ports.read_config_data
+    input_name = pass_through.qualified_name() + "_in"
+    # Create input port for pass through read_data reduction
+    gen.add_port(input_name, magma.In(pass_through.base_type()))
+    # Remove the current connection to the read_data output
+    gen.remove_wire(gen.read_data_mux.ports.O, pass_through)
+    gen.read_data_reduce_or = FromMagma(mantle.DefineOr(2, 32))
+    # OR previous read_data output with read_data input to create NEW
+    # read_data output
+    gen.wire(gen.read_data_mux.ports.O,
+             gen.read_data_reduce_or.ports.I0)
+    gen.wire(gen.ports[input_name], gen.read_data_reduce_or.ports.I1)
+    gen.wire(gen.read_data_reduce_or.ports.O, pass_through)

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -212,7 +212,8 @@ class TileCircuit(generator.Generator):
     def __init__(self, tiles: Dict[int, Tile],
                  config_addr_width: int, config_data_width: int,
                  tile_id_width: int = 16,
-                 full_config_addr_width: int = 32):
+                 full_config_addr_width: int = 32,
+                 stall_signal_width: int = 4):
         super().__init__()
 
         self.tiles = tiles
@@ -353,6 +354,13 @@ class TileCircuit(generator.Generator):
         # we can't use the InterconnectConfigurable because the tile class
         # doesn't have any mux
         self.__add_config()
+        self.__add_stall(stall_signal_width)
+
+    def __add_stall(self, stall_signal_width: int):
+        # the tile class only cares about creating stall signal since it's not
+        # its concern to wire stall signal to internal components. it is not
+        # the interconnect's responsibility
+        self.add_ports(stall=magma.In(magma.Bits(stall_signal_width)))
 
     def __add_config(self):
         self.add_ports(

--- a/interconnect/global_signal.py
+++ b/interconnect/global_signal.py
@@ -52,20 +52,21 @@ def apply_global_meso_wiring(interconnect: Interconnect):
         column = interconnect.get_column(x)
         # wire global inputs to first tile in column
         for signal in global_ports:
-            interconnect.wire(signal,
-                              column[0].ports[signal.qualified_name()])
+            interconnect.wire(interconnect.ports[signal],
+                              column[0].ports[signal])
         # first pass to make signals pass through
-        pre_ports = []
+        pre_ports = {}
         for signal in global_ports:
+            pre_ports[signal] = []
             for tile in column:
                 # use the transform pass
                 pre_port = pass_signal_through(tile, signal)
-                pre_ports.append(pre_port)
+                pre_ports[signal].append(pre_port)
         # second pass to wire them up
         for i in range(len(column) - 1):
-            pre_port = pre_ports[i]
             next_tile = column[i + 1]
             for signal in global_ports:
+                pre_port = pre_ports[signal][i]
                 interconnect.wire(pre_port,
                                   next_tile.ports[signal])
 

--- a/interconnect/global_signal.py
+++ b/interconnect/global_signal.py
@@ -1,7 +1,7 @@
 """Useful pass on interconnect that doesn't deal with the routing network"""
 import magma
 import mantle
-from common.transform import pass_signal_through, mux_reduction
+from common.transform import pass_signal_through, or_reduction
 from generator.const import Const
 from generator.from_magma import FromMagma
 from .interconnect import Interconnect
@@ -55,6 +55,7 @@ def apply_global_meso_wiring(interconnect: Interconnect):
             interconnect.wire(interconnect.ports[signal],
                               column[0].ports[signal])
         # first pass to make signals pass through
+        # pre_ports keep track of ports created by pass_signal_through
         pre_ports = {}
         for signal in global_ports:
             pre_ports[signal] = []
@@ -74,10 +75,11 @@ def apply_global_meso_wiring(interconnect: Interconnect):
         # Call tile function that adds input for read_data,
         # along with OR gate to reduce input read_data with
         # that tile's read_data
+        # ports_in keep track of new ports created by or_reduction
         ports_in = []
         for tile in column:
-            port_in = mux_reduction(tile, "read_data_mux", "read_config_data",
-                                    interconnect.config_data_width)
+            port_in = or_reduction(tile, "read_data_mux", "read_config_data",
+                                   interconnect.config_data_width)
             ports_in.append(port_in)
 
         # Connect 0 to first tile's read_data input

--- a/interconnect/global_signal.py
+++ b/interconnect/global_signal.py
@@ -22,7 +22,6 @@ def apply_global_fanout_wiring(interconnect: Interconnect):
                       interconnect.config_data_width))
         for idx, tile in enumerate(column):
             for signal_name in global_ports:
-                # fanout
                 interconnect.wire(interconnect.ports[signal_name],
                                   tile.ports[signal_name])
             # connect the tile to the column read_data inputs
@@ -33,6 +32,10 @@ def apply_global_fanout_wiring(interconnect: Interconnect):
         idx = x - interconnect.x_min
         interconnect.wire(interconnect_read_data_or.ports[f"I{idx}"],
                           column_read_data_or.ports.O)
+
+    # wiring the read_config_data
+    interconnect.wire(interconnect.ports.read_config_data,
+                      interconnect_read_data_or.ports.O)
 
     return interconnect_read_data_or
 
@@ -77,7 +80,8 @@ def apply_global_meso_wiring(interconnect: Interconnect):
             ports_in.append(port_in)
 
         # Connect 0 to first tile's read_data input
-        interconnect.wire(ports_in[0], Const(magma.bits(0, 32)))
+        interconnect.wire(ports_in[0],
+                          Const(magma.bits(0, interconnect.config_data_width)))
 
         # connect each tile's read_data output to next tile's
         # read_data input
@@ -88,5 +92,9 @@ def apply_global_meso_wiring(interconnect: Interconnect):
         idx = x - interconnect.x_min
         interconnect.wire(interconnect_read_data_or.ports[f"I{idx}"],
                           column[-1].ports.read_config_data)
+
+    # wiring the read_config_data
+    interconnect.wire(interconnect.ports.read_config_data,
+                      interconnect_read_data_or.ports.O)
 
     return interconnect_read_data_or

--- a/interconnect/global_signal.py
+++ b/interconnect/global_signal.py
@@ -1,0 +1,92 @@
+"""Useful pass on interconnect that doesn't deal with the routing network"""
+import magma
+import mantle
+from common.transform import pass_signal_through, mux_reduction
+from generator.const import Const
+from generator.from_magma import FromMagma
+from .interconnect import Interconnect
+
+
+def apply_global_fanout_wiring(interconnect: Interconnect):
+    # straight-forward fanout for global signals
+    global_ports = interconnect.globals
+    interconnect_read_data_or = \
+        FromMagma(mantle.DefineOr(interconnect.x_max - interconnect.x_min + 1,
+                                  interconnect.config_data_width))
+    # this is connected on a per-column bases
+    for x in range(interconnect.x_min, interconnect.x_max + 1):
+        column = interconnect.get_column(x)
+        # handle the read config
+        column_read_data_or = \
+            FromMagma(mantle.DefineOr(len(column),
+                      interconnect.config_data_width))
+        for idx, tile in enumerate(column):
+            for signal_name in global_ports:
+                # fanout
+                interconnect.wire(interconnect.ports[signal_name],
+                                  tile.ports[signal_name])
+            # connect the tile to the column read_data inputs
+            interconnect.wire(column_read_data_or.ports[f"I{idx}"],
+                              tile.ports.read_config_data)
+
+        # wire it to the interconnect_read_data_or
+        idx = x - interconnect.x_min
+        interconnect.wire(interconnect_read_data_or.ports[f"I{idx}"],
+                          column_read_data_or.ports.O)
+
+    return interconnect_read_data_or
+
+
+def apply_global_meso_wiring(interconnect: Interconnect):
+    # "river routing" for global signal
+    global_ports = interconnect.globals
+    interconnect_read_data_or = \
+        FromMagma(mantle.DefineOr(interconnect.x_max - interconnect.x_min + 1,
+                                  interconnect.config_data_width))
+
+    # looping through on a per-column bases
+    for x in range(interconnect.x_min, interconnect.x_max + 1):
+        column = interconnect.get_column(x)
+        # wire global inputs to first tile in column
+        for signal in global_ports:
+            interconnect.wire(signal,
+                              column[0].ports[signal.qualified_name()])
+        # first pass to make signals pass through
+        pre_ports = []
+        for signal in global_ports:
+            for tile in column:
+                # use the transform pass
+                pre_port = pass_signal_through(tile, signal)
+                pre_ports.append(pre_port)
+        # second pass to wire them up
+        for i in range(len(column) - 1):
+            pre_port = pre_ports[i]
+            next_tile = column[i + 1]
+            for signal in global_ports:
+                interconnect.wire(pre_port,
+                                  next_tile.ports[signal])
+
+        # read_config_data
+        # Call tile function that adds input for read_data,
+        # along with OR gate to reduce input read_data with
+        # that tile's read_data
+        ports_in = []
+        for tile in column:
+            port_in = mux_reduction(tile, "read_data_mux", "read_config_data",
+                                    interconnect.config_data_width)
+            ports_in.append(port_in)
+
+        # Connect 0 to first tile's read_data input
+        interconnect.wire(ports_in[0], Const(magma.bits(0, 32)))
+
+        # connect each tile's read_data output to next tile's
+        # read_data input
+        for i, tile in enumerate(column[:-1]):
+            interconnect.wire(tile.ports.read_config_data,
+                              ports_in[i + 1])
+        # Connect the last tile's read_data output to the global OR
+        idx = x - interconnect.x_min
+        interconnect.wire(interconnect_read_data_or.ports[f"I{idx}"],
+                          column[-1].ports.read_config_data)
+
+    return interconnect_read_data_or

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -118,6 +118,9 @@ class Interconnect(generator.Generator):
         # global ports
         self.globals = self.__add_global_ports(stall_signal_width)
 
+        # add config
+        self.__add_red_config_data(config_data_width)
+
     def __get_tile_id(self, x: int, y: int):
         return x << (self.tile_id_width // 2) | y
 
@@ -185,10 +188,10 @@ class Interconnect(generator.Generator):
             reset=magma.In(magma.AsyncReset),
             stall=magma.In(magma.Bits(stall_signal_width)))
 
-        return (self.ports.config,
-                self.ports.clk,
-                self.ports.reset,
-                self.ports.stall)
+        return (self.ports.config.qualified_name(),
+                self.ports.clk.qualified_name(),
+                self.ports.reset.qualified_name(),
+                self.ports.stall.qualified_name())
 
     def get_route_bitstream_config(self, src_node: Node, dst_node: Node):
         # this is the complete one which includes the tile_id

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -22,8 +22,7 @@ class Interconnect(generator.Generator):
                  config_addr_width: int, config_data_width: int,
                  tile_id_width: int,
                  stall_signal_width: int = 4,
-                 lift_ports=True,
-                 fan_out_config=False):
+                 lift_ports=True):
         super().__init__()
 
         self.config_data_width = config_data_width
@@ -113,10 +112,6 @@ class Interconnect(generator.Generator):
         if lift_ports:
             self.__lift_ports()
 
-        self.has_fan_out_config = fan_out_config
-        if fan_out_config:
-            self.__fan_out_config()
-
         # set tile_id
         self.__set_tile_id()
 
@@ -194,18 +189,6 @@ class Interconnect(generator.Generator):
                 self.ports.clk,
                 self.ports.reset,
                 self.ports.stall)
-
-    def __fan_out_config(self):
-        self.add_ports(
-            config=magma.In(ConfigurationType(self.config_data_width,
-                                              self.config_data_width)),
-            clk=magma.In(magma.Clock),
-            reset=magma.In(magma.AsyncReset))
-
-        # fan out wires
-        for _, tile_circuit in self.tile_circuits.items():
-            self.wire(self.ports.config, tile_circuit.ports.config)
-            self.wire(self.ports.reset, tile_circuit.ports.reset)
 
     def get_route_bitstream_config(self, src_node: Node, dst_node: Node):
         # this is the complete one which includes the tile_id

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -8,17 +8,26 @@ import generator.generator as generator
 from .circuit import TileCircuit, create_name
 from generator.configurable import ConfigurationType
 from generator.const import Const
+import enum
+
+
+@enum.unique
+class GlobalSignalWiring(enum.Enum):
+    FanOut = enum.auto()
+    Meso = enum.auto()
 
 
 class Interconnect(generator.Generator):
     def __init__(self, interconnects: Dict[int, InterconnectGraph],
-                 addr_width: int, data_width: int, tile_id_width: int,
+                 config_addr_width: int, config_data_width: int,
+                 tile_id_width: int,
+                 stall_signal_width: int = 4,
                  lift_ports=True,
                  fan_out_config=False):
         super().__init__()
 
-        self.data_width = data_width
-        self.addr_width = addr_width
+        self.config_data_width = config_data_width
+        self.config_addr_width = config_addr_width
         self.tile_id_width = tile_id_width
         self.__graphs: Dict[int, InterconnectGraph] = interconnects
 
@@ -62,8 +71,10 @@ class Interconnect(generator.Generator):
 
         # create individual tile circuits
         for coord, tiles in self.__tiles.items():
-            self.tile_circuits[coord] = TileCircuit(tiles, addr_width,
-                                                    data_width)
+            self.tile_circuits[coord] = TileCircuit(tiles, config_addr_width,
+                                                    config_data_width,
+                                                    stall_signal_width=
+                                                    stall_signal_width)
 
         # we need to deal with inter-tile connections now
         # we only limit mesh
@@ -108,6 +119,9 @@ class Interconnect(generator.Generator):
 
         # set tile_id
         self.__set_tile_id()
+
+        # global ports
+        self.globals = self.__add_global_ports(stall_signal_width)
 
     def __get_tile_id(self, x: int, y: int):
         return x << (self.tile_id_width // 2) | y
@@ -164,10 +178,27 @@ class Interconnect(generator.Generator):
                     self.add_port(sb_name, sb_port.base_type())
                     self.wire(self.ports[sb_name], sb_port)
 
+    def __add_red_config_data(self, config_data_width: int):
+        self.add_port("read_config_data",
+                      magma.Out(magma.Bits(config_data_width)))
+
+    def __add_global_ports(self, stall_signal_width: int):
+        self.add_ports(
+            config=magma.In(ConfigurationType(self.config_data_width,
+                                              self.config_data_width)),
+            clk=magma.In(magma.Clock),
+            reset=magma.In(magma.AsyncReset),
+            stall=magma.In(magma.Bits(stall_signal_width)))
+
+        return (self.ports.config,
+                self.ports.clk,
+                self.ports.reset,
+                self.ports.stall)
+
     def __fan_out_config(self):
         self.add_ports(
-            config=magma.In(ConfigurationType(self.data_width,
-                                              self.data_width)),
+            config=magma.In(ConfigurationType(self.config_data_width,
+                                              self.config_data_width)),
             clk=magma.In(magma.Clock),
             reset=magma.In(magma.AsyncReset))
 

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -202,5 +202,15 @@ class Interconnect(generator.Generator):
             graph_config_str = " ".join(graph_configs)
             f.write(f"graph={graph_config_str}\n")
 
+    def get_column(self, x: int):
+        # obtain a list of columns sorted by y
+        result = []
+        for y in range(self.y_min, self.y_max + 1):  # y_max is inclusive
+            if (x, y) in self.tile_circuits:
+                # if it exists
+                tile = self.tile_circuits[(x, y)]
+                result.append(tile)
+        return result
+
     def name(self):
         return "Interconnect"

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -135,7 +135,7 @@ class Interconnect(generator.Generator):
         self.globals = self.__add_global_ports(stall_signal_width)
 
         # add config
-        self.__add_red_config_data(config_data_width)
+        self.__add_read_config_data(config_data_width)
 
     def __get_tile_id(self, x: int, y: int):
         return x << (self.tile_id_width // 2) | y
@@ -192,7 +192,7 @@ class Interconnect(generator.Generator):
                     self.add_port(sb_name, sb_port.base_type())
                     self.wire(self.ports[sb_name], sb_port)
 
-    def __add_red_config_data(self, config_data_width: int):
+    def __add_read_config_data(self, config_data_width: int):
         self.add_port("read_config_data",
                       magma.Out(magma.Bits(config_data_width)))
 

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -70,10 +70,9 @@ class Interconnect(generator.Generator):
 
         # create individual tile circuits
         for coord, tiles in self.__tiles.items():
-            self.tile_circuits[coord] = TileCircuit(tiles, config_addr_width,
-                                                    config_data_width,
-                                                    stall_signal_width=
-                                                    stall_signal_width)
+            self.tile_circuits[coord] =\
+                TileCircuit(tiles, config_addr_width, config_data_width,
+                            stall_signal_width=stall_signal_width)
 
         # we need to deal with inter-tile connections now
         # we only limit mesh

--- a/test_interconnect/test_interconnect.py
+++ b/test_interconnect/test_interconnect.py
@@ -6,6 +6,7 @@ import tempfile
 import fault
 import fault.random
 from interconnect.util import create_uniform_interconnect, SwitchBoxType
+from interconnect.global_signal import apply_global_fanout_wiring
 import pytest
 
 
@@ -62,7 +63,9 @@ def test_interconnect(num_tracks: int, chip_size: int):
         ics[bit_width] = ic
 
     interconnect = Interconnect(ics, addr_width, data_width, tile_id_width,
-                                lift_ports=True, fan_out_config=True)
+                                lift_ports=True)
+    # fanout wiring
+    apply_global_fanout_wiring(interconnect)
 
     # assert tile coordinates
     for (x, y), tile_circuit in interconnect.tile_circuits.items():
@@ -225,7 +228,7 @@ def test_dump_pnr():
         ics[bit_width] = ic
 
     interconnect = Interconnect(ics, addr_width, data_width, tile_id_width,
-                                lift_ports=True, fan_out_config=True)
+                                lift_ports=True)
 
     design_name = "test"
     with tempfile.TemporaryDirectory() as tempdir:
@@ -272,7 +275,7 @@ def test_get_column():
         ics[bit_width] = ic
 
     interconnect = Interconnect(ics, addr_width, data_width, tile_id_width,
-                                lift_ports=True, fan_out_config=True)
+                                lift_ports=True)
 
     for x in range(chip_size):
         column = interconnect.get_column(x)

--- a/test_interconnect/test_interconnect.py
+++ b/test_interconnect/test_interconnect.py
@@ -234,3 +234,49 @@ def test_dump_pnr():
         assert os.path.isfile(os.path.join(tempdir, f"{design_name}.info"))
         assert os.path.isfile(os.path.join(tempdir, "1.graph"))
         assert os.path.isfile(os.path.join(tempdir, "16.graph"))
+
+
+def test_get_column():
+    num_tracks = 2
+    addr_width = 8
+    data_width = 32
+    bit_widths = [1, 16]
+
+    tile_id_width = 16
+
+    chip_size = 2
+    track_length = 1
+
+    cores = {}
+    for x in range(chip_size):
+        for y in range(chip_size):
+            cores[(x, y)] = DummyCore()
+
+    def create_core(xx: int, yy: int):
+        return cores[(xx, yy)]
+
+    in_conn = []
+    out_conn = []
+    for side in SwitchBoxSide:
+        in_conn.append((side, SwitchBoxIO.SB_IN))
+        out_conn.append((side, SwitchBoxIO.SB_OUT))
+
+    ics = {}
+    for bit_width in bit_widths:
+        ic = create_uniform_interconnect(chip_size, chip_size, bit_width,
+                                         create_core,
+                                         {f"data_in_{bit_width}b": in_conn,
+                                          f"data_out_{bit_width}b": out_conn},
+                                         {track_length: num_tracks},
+                                         SwitchBoxType.Disjoint)
+        ics[bit_width] = ic
+
+    interconnect = Interconnect(ics, addr_width, data_width, tile_id_width,
+                                lift_ports=True, fan_out_config=True)
+
+    for x in range(chip_size):
+        column = interconnect.get_column(x)
+        # making sure that the columns returned is correct
+        for y in range(chip_size):
+            tile = column[y]
+            assert tile.x == x and tile.y == y

--- a/test_interconnect/test_interconnect.py
+++ b/test_interconnect/test_interconnect.py
@@ -35,7 +35,8 @@ class GlobalSignalWiring(enum.Enum):
 
 @pytest.mark.parametrize("num_tracks", [2, 4])
 @pytest.mark.parametrize("chip_size", [2, 4])
-@pytest.mark.parametrize("wiring", [GlobalSignalWiring.Fanout])
+@pytest.mark.parametrize("wiring", [GlobalSignalWiring.Fanout,
+                                    GlobalSignalWiring.Meso])
 def test_interconnect(num_tracks: int, chip_size: int,
                       wiring: GlobalSignalWiring):
     addr_width = 8


### PR DESCRIPTION
This PR mainly deals with global signal wiring:
1. Introduce refactored version of signal transformations (`common/transform.py`). Previously it was nested in the `tile/tile_magma.py` . The new functions introduced allow more generic version of passes through garnet infrastructure.
2. Create different pass functions, namely `apply_global_fanout_wiring`, and `apply_global_fanout_wiring`, that take `Interconnect` object and connect global signals within the interconnect object. An example is shown in the test:
https://github.com/StanfordAHA/garnet/blob/4bae028704c3c986db55f5eddd56d3b431b204c4/test_interconnect/test_interconnect.py#L91-L98

Both `Fanout` and `Meso` are tested with various interconnect configuration.

I will start to clean out deprecated old once the interconnect is fully integrated into garnet, but that would be a different PR later on.