### PR TITLE
Interconnect Rename

### DIFF
--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -241,8 +241,7 @@ class SB(InterconnectConfigurable):
             self.regs[reg_name] = reg_node, reg
 
     def name(self):
-        return create_name(str(self.switchbox)) + \
-            f"{self.switchbox.x}_{self.switchbox.y}"
+        return create_name(str(self.switchbox))
 
     def __connect_sbs(self):
         # the principle is that it only connects to the nodes within
@@ -561,7 +560,7 @@ class TileCircuit(generator.Generator):
         return config_names.index(mux_sel_name)
 
     def name(self):
-        return create_name(f"TILE {self.x} {self.y}")
+        return "Tile"
 
 
 class CoreInterface(InterconnectCore):

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -241,7 +241,8 @@ class SB(InterconnectConfigurable):
             self.regs[reg_name] = reg_node, reg
 
     def name(self):
-        return create_name(str(self.switchbox))
+        return f"SB_ID{self.switchbox.id}_{self.switchbox.num_track}TRACKS_" \
+            f"B{self.switchbox.width}"
 
     def __connect_sbs(self):
         # the principle is that it only connects to the nodes within
@@ -560,7 +561,7 @@ class TileCircuit(generator.Generator):
         return config_names.index(mux_sel_name)
 
     def name(self):
-        return "Tile"
+        return f"Tile_{self.core.name()}"
 
 
 class CoreInterface(InterconnectCore):

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -178,8 +178,11 @@ class Interconnect(generator.Generator):
                 for sb_node in working_set:
                     sb_name = create_name(str(sb_node))
                     sb_port = tile.ports[sb_name]
-                    self.add_port(sb_name, sb_port.base_type())
-                    self.wire(self.ports[sb_name], sb_port)
+                    # because the lifted port will conflict with each other
+                    # we need to add x and y to the sb_name to avoid conflict
+                    new_sb_name = sb_name + f"_X{sb_node.x}_Y{sb_node.y}"
+                    self.add_port(new_sb_name, sb_port.base_type())
+                    self.wire(self.ports[new_sb_name], sb_port)
 
     def __fan_out_config(self):
         self.add_ports(

--- a/test_interconnect/test_interconnect.py
+++ b/test_interconnect/test_interconnect.py
@@ -141,8 +141,10 @@ def test_interconnect(num_tracks: int, chip_size: int, reg_mode: bool):
                     assert src_node is not None and dst_node is not None
                     config_data.append(config_entry)
                     value = fault.random.random_bv(bit_width)
-                    src_name = create_name(str(src_node))
-                    dst_name = create_name(str(dst_node))
+                    src_name = create_name(str(src_node)) + \
+                        f"_X{src_node.x}_Y{src_node.y}"
+                    dst_name = create_name(str(dst_node)) + \
+                        f"_X{dst_node.x}_Y{dst_node.y}"
                     test_data.append((circuit.interface[src_name],
                                       circuit.interface[dst_name],
                                       value))
@@ -174,8 +176,10 @@ def test_interconnect(num_tracks: int, chip_size: int, reg_mode: bool):
                     assert src_node is not None and dst_node is not None
                     config_data.append(config_entry)
                     value = fault.random.random_bv(bit_width)
-                    src_name = create_name(str(src_node))
-                    dst_name = create_name(str(dst_node))
+                    src_name = create_name(str(src_node)) + \
+                        f"_X{src_node.x}_Y{src_node.y}"
+                    dst_name = create_name(str(dst_node)) + \
+                        f"_X{dst_node.x}_Y{dst_node.y}"
                     test_data.append((circuit.interface[src_name],
                                       circuit.interface[dst_name],
                                       value))


### PR DESCRIPTION
This PR adjusts the module names to make the produced verilog more readable. Previously it relied on the cryptic annotation that only my PnR tools understands.

Since the unification is fixed, I also removed the hack that changed the module name to avoid conflicts.

That being said, there is still a long way to go to produce more readable verilog. 