### PR TITLE
Improve circuit instance names for better debugging

### DIFF
--- a/common/mux_wrapper.py
+++ b/common/mux_wrapper.py
@@ -5,8 +5,8 @@ from generator.from_magma import FromMagma
 
 
 class MuxWrapper(generator.Generator):
-    def __init__(self, height, width):
-        super().__init__()
+    def __init__(self, height, width, name=None):
+        super().__init__(name)
 
         self.height = height
         self.width = width


### PR DESCRIPTION
This PR renames mux, registers, and tile level instance names so that it's easier to debug. Notice that there are still some circuits' name not readable, notably decode. Since I don't directly interact with these decode modules, I just leave them as it is.