### PR TITLE
Interconnect feature

### DIFF
--- a/common/core.py
+++ b/common/core.py
@@ -23,30 +23,11 @@ class Core(Configurable):
 class CoreFeature(Generator):
     def __init__(self,
                  parent_core: "Core",
-                 index: int,
-                 config_addr_width: int = 8,
-                 config_data_width: int = 32):
+                 index: int):
         super().__init__()
-        self.add_ports(
-            config=magma.In(ConfigurationType(config_addr_width,
-                                              config_data_width)),
-            read_config_data=magma.Out(magma.Bits(config_data_width)),
-            read_config_data_in=magma.In(magma.Bits(config_data_width)),
-            config_en=magma.Out(magma.Bit),
-            config_out=magma.Out(ConfigurationType(config_addr_width,
-                                                   config_data_width))
-        )
 
         self.__index = index
         self.__parent = parent_core
-        self.__or_gate = FromMagma(mantle.DefineOr(2, 1))
-        self.wire(self.__or_gate.ports.I0, self.ports.config.read)
-        self.wire(self.__or_gate.ports.I1, self.ports.config.write)
-        self.wire(self.ports.config_en, self.__or_gate.ports.O[0])
-        self.wire(self.ports.read_config_data_in, self.ports.read_config_data)
-
-        # pass through config
-        self.wire(self.ports.config, self.ports.config_out)
 
     def name(self):
         return f"{self.__parent.name()}_FEATURE_{self.__index}"

--- a/common/core.py
+++ b/common/core.py
@@ -1,8 +1,10 @@
 from abc import abstractmethod
 from generator.configurable import Configurable, ConfigurationType
+from generator.from_magma import FromMagma
 from generator.generator import Generator
 import magma
 from typing import List, Union
+import mantle
 
 
 class Core(Configurable):
@@ -20,7 +22,7 @@ class Core(Configurable):
 
 class CoreFeature(Generator):
     def __init__(self,
-                 core_name: str,
+                 parent_core: "Core",
                  index: int,
                  config_addr_width: int = 8,
                  config_data_width: int = 32):
@@ -29,10 +31,28 @@ class CoreFeature(Generator):
             config=magma.In(ConfigurationType(config_addr_width,
                                               config_data_width)),
             read_config_data=magma.Out(magma.Bits(config_data_width)),
-            config_en=magma.In)
+            read_config_data_in=magma.In(magma.Bits(config_data_width)),
+            config_en=magma.Out(magma.Bit),
+            config_out=magma.Out(ConfigurationType(config_addr_width,
+                                                   config_data_width))
+        )
 
         self.__index = index
-        self.__core_name = core_name
+        self.__parent = parent_core
+        self.__or_gate = FromMagma(mantle.DefineOr(2, 1))
+        self.wire(self.__or_gate.ports.I0, self.ports.config.read)
+        self.wire(self.__or_gate.ports.I1, self.ports.config.write)
+        self.wire(self.ports.config_en, self.__or_gate.ports.O[0])
+        self.wire(self.ports.read_config_data_in, self.ports.read_config_data)
+
+        # pass through config
+        self.wire(self.ports.config, self.ports.config_out)
 
     def name(self):
-        return f"{self.__core_name}_FEATURE_{self.__index}"
+        return f"{self.__parent.name()}_FEATURE_{self.__index}"
+
+    def parent(self):
+        return self.__parent
+
+    def index(self):
+        return self.__index

--- a/common/core.py
+++ b/common/core.py
@@ -1,5 +1,8 @@
 from abc import abstractmethod
-from generator.configurable import Configurable
+from generator.configurable import Configurable, ConfigurationType
+from generator.generator import Generator
+import magma
+from typing import List, Union
 
 
 class Core(Configurable):
@@ -10,3 +13,26 @@ class Core(Configurable):
     @abstractmethod
     def outputs(self):
         pass
+
+    def features(self) -> List[Union["Core", "CoreFeature"]]:
+        return [self]
+
+
+class CoreFeature(Generator):
+    def __init__(self,
+                 core_name: str,
+                 index: int,
+                 config_addr_width: int = 8,
+                 config_data_width: int = 32):
+        super().__init__()
+        self.add_ports(
+            config=magma.In(ConfigurationType(config_addr_width,
+                                              config_data_width)),
+            read_config_data=magma.Out(magma.Bits(config_data_width)),
+            config_en=magma.In)
+
+        self.__index = index
+        self.__core_name = core_name
+
+    def name(self):
+        return f"{self.__core_name}_FEATURE_{self.__index}"

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -578,7 +578,7 @@ class TileCircuit(generator.Generator):
         sb_widths = list(self.sbs.keys())
         sb_widths.sort()
         sb_features = [self.sbs[width] for width in sb_widths]
-        return [self.core] + cb_features + sb_features
+        return self.core.features() + cb_features + sb_features
 
     def get_route_bitstream_config(self, src_node: Node, dst_node: Node):
         assert src_node.width == dst_node.width

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -522,15 +522,11 @@ class TileCircuit(generator.Generator):
         # most of the logic copied from tile_magma.py
         # remove all hardcoded values
         for feature in self.features():
-            if isinstance(feature, CoreFeature):
-                cfg_port = feature.parent().ports.config
-            else:
-                cfg_port = feature.ports.config
             self.wire(self.ports.config.config_addr[self.feature_config_slice],
-                      cfg_port.config_addr)
+                      feature.ports.config.config_addr)
             self.wire(self.ports.config.config_data,
-                      cfg_port.config_data)
-            self.wire(self.ports.config.read, cfg_port.read)
+                      feature.ports.config.config_data)
+            self.wire(self.ports.config.read, feature.ports.config.read)
 
         # Connect S input to config_addr.feature.
         self.wire(self.ports.config.config_addr[self.feature_addr_slice],
@@ -573,12 +569,8 @@ class TileCircuit(generator.Generator):
                       self.feat_and_config_en_tile[i].ports.I0)
             self.wire(self.write_and_tile.ports.O,
                       self.feat_and_config_en_tile[i].ports.I1)
-            if isinstance(feat, CoreFeature):
-                cfg_port = feat.parent().ports.config
-            else:
-                cfg_port = feat.ports.config
             self.wire(self.feat_and_config_en_tile[i].ports.O,
-                      cfg_port.write[0])
+                      feat.ports.config.write[0])
 
     def features(self) -> List[generator.Generator]:
         cb_names = list(self.cbs.keys())

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -15,6 +15,7 @@ from abc import abstractmethod
 import generator.generator as generator
 from generator.from_magma import FromMagma
 from mantle import DefineRegister
+from common.core import CoreFeature
 
 
 def create_name(name: str):
@@ -521,11 +522,15 @@ class TileCircuit(generator.Generator):
         # most of the logic copied from tile_magma.py
         # remove all hardcoded values
         for feature in self.features():
+            if isinstance(feature, CoreFeature):
+                cfg_port = feature.parent().ports.config
+            else:
+                cfg_port = feature.ports.config
             self.wire(self.ports.config.config_addr[self.feature_config_slice],
-                      feature.ports.config.config_addr)
+                      cfg_port.config_addr)
             self.wire(self.ports.config.config_data,
-                      feature.ports.config.config_data)
-            self.wire(self.ports.config.read, feature.ports.config.read)
+                      cfg_port.config_data)
+            self.wire(self.ports.config.read, cfg_port.read)
 
         # Connect S input to config_addr.feature.
         self.wire(self.ports.config.config_addr[self.feature_addr_slice],
@@ -568,8 +573,12 @@ class TileCircuit(generator.Generator):
                       self.feat_and_config_en_tile[i].ports.I0)
             self.wire(self.write_and_tile.ports.O,
                       self.feat_and_config_en_tile[i].ports.I1)
+            if isinstance(feat, CoreFeature):
+                cfg_port = feat.parent().ports.config
+            else:
+                cfg_port = feat.ports.config
             self.wire(self.feat_and_config_en_tile[i].ports.O,
-                      feat.ports.config.write[0])
+                      cfg_port.write[0])
 
     def features(self) -> List[generator.Generator]:
         cb_names = list(self.cbs.keys())

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -519,6 +519,7 @@ class TileCircuit(generator.Generator):
                                                    self.config_data_width,
                                                    self.config_addr_width,
                                                    0)
+        self.read_data_mux.instance_name = "read_data_mux"
         # most of the logic copied from tile_magma.py
         # remove all hardcoded values
         for feature in self.features():
@@ -562,7 +563,9 @@ class TileCircuit(generator.Generator):
             # config_en = (config_addr.feature == feature_num) & config_en_tile
             self.decode_feat.append(
                 FromMagma(mantle.DefineDecode(i, self.config_addr_width)))
+            self.decode_feat[-1].instance_name = f"DECODE_FEATURE_{i}"
             self.feat_and_config_en_tile.append(FromMagma(mantle.DefineAnd(2)))
+            self.feat_and_config_en_tile[-1].instance_name = f"FEATURE_AND_{i}"
             self.wire(self.decode_feat[i].ports.I,
                       self.ports.config.config_addr[self.feature_addr_slice])
             self.wire(self.decode_feat[i].ports.O,
@@ -571,6 +574,9 @@ class TileCircuit(generator.Generator):
                       self.feat_and_config_en_tile[i].ports.I1)
             self.wire(self.feat_and_config_en_tile[i].ports.O,
                       feat.ports.config.write[0])
+            if "config_en" in feat.ports:
+                self.wire(feat.ports.config_en,
+                          self.feat_and_config_en_tile[i].ports.O)
 
     def features(self) -> List[generator.Generator]:
         cb_names = list(self.cbs.keys())

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -7,6 +7,7 @@ from generator.const import Const
 from generator.from_magma import FromMagma
 from generator.from_verilog import FromVerilog
 from memory_core import memory_core_genesis2
+from typing import List
 
 
 class MemCore(Core):
@@ -23,7 +24,6 @@ class MemCore(Core):
             addr_in=magma.In(TData),
             data_out=magma.Out(TData),
             clk=magma.In(magma.Clock),
-            config=magma.In(ConfigurationType(8, 32)),
             reset=magma.In(magma.AsyncReset),
             flush=magma.In(TBit),
             wen_in=magma.In(TBit),
@@ -41,7 +41,6 @@ class MemCore(Core):
         self.wire(self.ports.data_in, self.underlying.ports.data_in)
         self.wire(self.ports.addr_in, self.underlying.ports.addr_in)
         self.wire(self.ports.data_out, self.underlying.ports.data_out)
-
         self.wire(self.ports.reset, self.underlying.ports.reset)
         self.wire(self.ports.flush[0], self.underlying.ports.flush)
         self.wire(self.ports.wen_in[0], self.underlying.ports.wen_in)
@@ -54,7 +53,6 @@ class MemCore(Core):
 
         # TODO(rsetaluri): Actually wire these inputs.
         signals = (
-            # ("config_en_sram", 4),
             ("config_en_linebuf", 1),
             ("chain_wen_in", 1),
             ("config_read", 1),
@@ -66,63 +64,62 @@ class MemCore(Core):
             self.wire(Const(val), self.underlying.ports[name])
         self.wire(Const(magma.bits(0, 24)),
                   self.underlying.ports.config_addr[0:24])
-
-        config_addr_width = 8
-        config_data_width = 32
         # we have five features in total
         # 0:   LINEBUF
         # 1-4: SMEM
         # current setup is already in line buffer mode, so we pass self in
         # notice that config_en_linebuf is to change the address in the
         # line buffer mode, which is not used in practice
-        self.__features = [CoreFeature(self, 0,
-                                       config_addr_width,
-                                       config_data_width)]
-        # for the MEM config
-        self.wire(self.__features[0].ports.read_config_data_in,
-                  self.underlying.ports.read_data)
+        self.__features: List[CoreFeature] = [CoreFeature(self, 0)]
         for sram_index in range(4):
-            # one hot encoding
-            core_feature = CoreFeature(self, sram_index + 1,
-                                       config_addr_width,
-                                       config_data_width)
-            # wire read_config_data to 0 since the core doesn't support to
-            # read them
-            self.wire(core_feature.ports.read_config_data_in,
-                      self.underlying.ports.read_data_sram)
-            self.wire(core_feature.ports.config_en,
-                      self.underlying.ports.config_en_sram[sram_index])
+            core_feature = CoreFeature(self, sram_index + 1)
             self.__features.append(core_feature)
 
-        # these signals will be shared by all the features
-        # as a result we need to create a mux or fanout
-        # because we will won't select two features at the same time
-        # we can or them up to the underlying config_data
-        or_gate_config_data = FromMagma(mantle.DefineOr(5, config_data_width))
-        or_gate_config_addr = FromMagma(mantle.DefineOr(5, config_addr_width))
         for idx, core_feature in enumerate(self.__features):
-            self.wire(core_feature.ports.config_out.config_data,
-                              or_gate_config_data.ports[f"I{idx}"])
-            self.wire(core_feature.ports.config_out.config_addr,
-                              or_gate_config_addr.ports[f"I{idx}"])
-
-        self.wire(or_gate_config_data.ports.O,
-                  self.underlying.ports.config_data)
-        self.wire(or_gate_config_addr.ports.O,
+            self.add_port(f"config_{idx}", magma.In(ConfigurationType(8, 32)))
+            # port aliasing
+            core_feature.ports["config"] = self.ports[f"config_{idx}"]
+        # or the signal up
+        t = ConfigurationType(8, 32)
+        t_names = ["config_addr", "config_data", "read", "write"]
+        or_gates = {}
+        for t_name in t_names:
+            port_type = t[t_name]
+            or_gate = FromMagma(mantle.DefineOr(len(self.__features),
+                                                len(port_type)))
+            for idx, core_feature in enumerate(self.__features):
+                self.wire(or_gate.ports[f"I{idx}"],
+                          core_feature.ports.config[t_name])
+            or_gates[t_name] = or_gate
+        self.wire(or_gates["config_addr"].ports.O,
                   self.underlying.ports.config_addr[24:32])
-
-        or_gate_config_en = FromMagma(mantle.DefineOr(5, 1))
-        for idx, core_feature in enumerate(self.__features):
-            self.wire(core_feature.ports.config_out.write,
-                              or_gate_config_en.ports[f"I{idx}"])
-        self.wire(or_gate_config_en.ports.O[0],
+        self.wire(or_gates["config_data"].ports.O,
+                  self.underlying.ports.config_data)
+        self.wire(or_gates["write"].ports.O[0],
                   self.underlying.ports.config_en)
 
-        # need to lift up each config data in the core features
-        # otherwise magma will complain that it's not connected, thus
-        # fail to compile
+        # read data out
         for idx, core_feature in enumerate(self.__features):
-            self.wire(self.ports.config, core_feature.ports.config)
+            self.add_port(f"read_config_data_{idx}",
+                          magma.Out(magma.Bits(32)))
+            # port aliasing
+            core_feature.ports["read_config_data"] = \
+                self.ports[f"read_config_data_{idx}"]
+        # MEM config
+        self.wire(self.ports.read_config_data_0,
+                  self.underlying.ports.read_data)
+        # SRAM
+        for sram_index in range(4):
+            core_feature = self.__features[sram_index + 1]
+            self.wire(core_feature.ports.read_config_data,
+                      self.underlying.ports[f"read_data_sram_{sram_index}"])
+            # also need to wire the sram signal
+            # we or the read or write signal up
+            or_gate = FromMagma(mantle.DefineOr(2, 1))
+            self.wire(or_gate.ports.I0, core_feature.ports.config.read)
+            self.wire(or_gate.ports.I1, core_feature.ports.config.write)
+            self.wire(self.underlying.ports["config_en_sram"][sram_index],
+                      or_gate.ports.O[0])
 
     def inputs(self):
         return [self.ports.data_in, self.ports.addr_in, self.ports.flush,

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -87,7 +87,7 @@ class MemCore(Core):
             core_feature.ports["config"] = self.ports[f"config_{idx}"]
         # or the signal up
         t = ConfigurationType(8, 32)
-        t_names = ["config_addr", "config_data", "write"]
+        t_names = ["config_addr", "config_data"]
         or_gates = {}
         for t_name in t_names:
             port_type = t[t_name]
@@ -102,7 +102,8 @@ class MemCore(Core):
                   self.underlying.ports.config_addr[24:32])
         self.wire(or_gates["config_data"].ports.O,
                   self.underlying.ports.config_data)
-        self.wire(or_gates["write"].ports.O[0],
+        # only the first one has config_en
+        self.wire(self.__features[0].ports.config.write[0],
                   self.underlying.ports.config_en)
 
         # read data out

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -24,7 +24,6 @@ class MemCore(Core):
             data_out=magma.Out(TData),
             clk=magma.In(magma.Clock),
             config=magma.In(ConfigurationType(8, 32)),
-            read_config_data=magma.Out(magma.Bits(32)),
             reset=magma.In(magma.AsyncReset),
             flush=magma.In(TBit),
             wen_in=magma.In(TBit),
@@ -42,12 +41,7 @@ class MemCore(Core):
         self.wire(self.ports.data_in, self.underlying.ports.data_in)
         self.wire(self.ports.addr_in, self.underlying.ports.addr_in)
         self.wire(self.ports.data_out, self.underlying.ports.data_out)
-        self.wire(self.ports.config.config_addr,
-                  self.underlying.ports.config_addr[24:32])
-        self.wire(self.ports.config.config_data,
-                  self.underlying.ports.config_data)
-        self.wire(self.ports.config.write[0], self.underlying.ports.config_en)
-        self.wire(self.underlying.ports.read_data, self.ports.read_config_data)
+
         self.wire(self.ports.reset, self.underlying.ports.reset)
         self.wire(self.ports.flush[0], self.underlying.ports.flush)
         self.wire(self.ports.wen_in[0], self.underlying.ports.wen_in)
@@ -60,7 +54,7 @@ class MemCore(Core):
 
         # TODO(rsetaluri): Actually wire these inputs.
         signals = (
-            ("config_en_sram", 4),
+            # ("config_en_sram", 4),
             ("config_en_linebuf", 1),
             ("chain_wen_in", 1),
             ("config_read", 1),
@@ -72,33 +66,63 @@ class MemCore(Core):
             self.wire(Const(val), self.underlying.ports[name])
         self.wire(Const(magma.bits(0, 24)),
                   self.underlying.ports.config_addr[0:24])
+
+        config_addr_width = 8
+        config_data_width = 32
         # we have five features in total
         # 0:   LINEBUF
         # 1-4: SMEM
         # current setup is already in line buffer mode, so we pass self in
         # notice that config_en_linebuf is to change the address in the
         # line buffer mode, which is not used in practice
-        self.__features = [self]
-        return
-        # the code below is now working
-        config_addr_width = 8
-        config_data_width = 32
+        self.__features = [CoreFeature(self, 0,
+                                       config_addr_width,
+                                       config_data_width)]
+        # for the MEM config
+        self.wire(self.__features[0].ports.read_config_data_in,
+                  self.underlying.ports.read_data)
         for sram_index in range(4):
             # one hot encoding
-            core_feature = CoreFeature(self.name(), sram_index + 1,
+            core_feature = CoreFeature(self, sram_index + 1,
                                        config_addr_width,
                                        config_data_width)
-            self.wire(core_feature.ports.config, self.ports.config)
             # wire read_config_data to 0 since the core doesn't support to
             # read them
-            core_feature.wire(core_feature.ports.read_config_data,
-                              Const(magma.bits(0, 32)))
-            or_gate = FromMagma(mantle.DefineOr(2, 1))
-            self.wire(core_feature.ports.config.write, or_gate.ports.I0[0])
-            self.wire(core_feature.ports.config.read, or_gate.ports.I1[0])
-            self.wire(self.underlying.ports.config_en_sram[sram_index],
-                      or_gate.ports.O[0])
+            self.wire(core_feature.ports.read_config_data_in,
+                      self.underlying.ports.read_data_sram)
+            self.wire(core_feature.ports.config_en,
+                      self.underlying.ports.config_en_sram[sram_index])
             self.__features.append(core_feature)
+
+        # these signals will be shared by all the features
+        # as a result we need to create a mux or fanout
+        # because we will won't select two features at the same time
+        # we can or them up to the underlying config_data
+        or_gate_config_data = FromMagma(mantle.DefineOr(5, config_data_width))
+        or_gate_config_addr = FromMagma(mantle.DefineOr(5, config_addr_width))
+        for idx, core_feature in enumerate(self.__features):
+            self.wire(core_feature.ports.config_out.config_data,
+                              or_gate_config_data.ports[f"I{idx}"])
+            self.wire(core_feature.ports.config_out.config_addr,
+                              or_gate_config_addr.ports[f"I{idx}"])
+
+        self.wire(or_gate_config_data.ports.O,
+                  self.underlying.ports.config_data)
+        self.wire(or_gate_config_addr.ports.O,
+                  self.underlying.ports.config_addr[24:32])
+
+        or_gate_config_en = FromMagma(mantle.DefineOr(5, 1))
+        for idx, core_feature in enumerate(self.__features):
+            self.wire(core_feature.ports.config_out.write,
+                              or_gate_config_en.ports[f"I{idx}"])
+        self.wire(or_gate_config_en.ports.O[0],
+                  self.underlying.ports.config_en)
+
+        # need to lift up each config data in the core features
+        # otherwise magma will complain that it's not connected, thus
+        # fail to compile
+        for idx, core_feature in enumerate(self.__features):
+            self.wire(self.ports.config, core_feature.ports.config)
 
     def inputs(self):
         return [self.ports.data_in, self.ports.addr_in, self.ports.flush,


### PR DESCRIPTION
This PR supports multiple features in the Core object. It's achieved by "port aliasing" to unify the `config` and `read_config_data` access from the tile level. An example is shown below:
```Python
        for idx, core_feature in enumerate(self.__features):
            self.add_port(f"config_{idx}", magma.In(ConfigurationType(8, 32)))
            # port aliasing
            core_feature.ports["config"] = self.ports[f"config_{idx}"]
```
If you access `core_feature.ports.config` from the tile level, it's accessing the memory core top level port config_idx. This avoids the problem where a child generator has to be connect within the parent, not outside the parent.

An example can be seen in the memory wrapper. I've tested the memory with SRAM mode. The only problem is that `read_data_sram` doesn't work. This is due to the complicated implementation in the `memory_core`. I think this shouldn't be a high priority right now as we will have a new memory core in the future, where multiple core features should have their own `read_en` signal.
