### PR TITLE
Change DeclareFromVerilog to DefineFromVerilog

### DIFF
--- a/generator/from_verilog.py
+++ b/generator/from_verilog.py
@@ -4,5 +4,5 @@ from generator.from_magma import FromMagma
 
 class FromVerilog(FromMagma):
     def __init__(self, filename):
-        underlying = magma.DeclareFromVerilogFile(filename)[0]
+        underlying = magma.DefineFromVerilogFile(filename)[0]
         super().__init__(underlying)


### PR DESCRIPTION
Since the CoreIR backend can now include verilog completely we can
use DefineFromVerilog instead of DeclareFromVerilog.