### PR TITLE
Interconnect feature

### DIFF
--- a/generator/interconnect_configurable.py
+++ b/generator/interconnect_configurable.py
@@ -1,0 +1,67 @@
+from common.mux_wrapper import MuxWrapper
+from .configurable import Configurable
+from common.zext_wrapper import ZextWrapper
+import magma
+from abc import abstractmethod
+
+
+class InterconnectConfigurable(Configurable):
+    def __init__(self, config_addr_width: int, config_data_width: int):
+        super().__init__()
+        self.config_addr_width = config_addr_width
+        self.config_data_width = config_data_width
+
+        self.read_config_data_mux: MuxWrapper = None
+
+        # ports for reconfiguration
+        self.add_ports(
+            clk=magma.In(magma.Clock),
+            reset=magma.In(magma.AsyncReset),
+        )
+
+    def _setup_config(self):
+        # sort the registers by it's name. this will be the order of config
+        # addr index
+        config_names = list(self.registers.keys())
+        config_names.sort()
+        for idx, config_name in enumerate(config_names):
+            reg = self.registers[config_name]
+            # set the configuration registers
+            reg.set_addr(idx)
+            reg.set_addr_width(self.config_addr_width)
+            reg.set_data_width(self.config_data_width)
+
+            self.wire(self.ports.config.config_addr, reg.ports.config_addr)
+            self.wire(self.ports.config.config_data, reg.ports.config_data)
+            self.wire(self.ports.config.write[0], reg.ports.config_en)
+            self.wire(self.ports.reset, reg.ports.reset)
+
+        # read_config_data output
+        num_config_reg = len(config_names)
+        if num_config_reg > 1:
+            self.read_config_data_mux = MuxWrapper(num_config_reg,
+                                                   self.config_data_width)
+            sel_bits = self.read_config_data_mux.sel_bits
+            # Wire up config_addr to select input of read_data MUX
+            self.wire(self.ports.config.config_addr[:sel_bits],
+                      self.read_config_data_mux.ports.S)
+            self.wire(self.read_config_data_mux.ports.O,
+                      self.ports.read_config_data)
+
+            for idx, config_name in enumerate(config_names):
+                reg = self.registers[config_name]
+                zext = ZextWrapper(reg.width, self.config_data_width)
+                self.wire(reg.ports.O, zext.ports.I)
+                zext_out = zext.ports.O
+                self.wire(zext_out, self.read_config_data_mux.ports.I[idx])
+        elif num_config_reg == 1:
+            config_name = config_names[0]
+            reg = self.registers[config_name]
+            zext = ZextWrapper(reg.width, self.config_data_width)
+            self.wire(reg.ports.O, zext.ports.I)
+            zext_out = zext.ports.O
+            self.wire(zext_out, self.ports.read_config_data)
+
+    @abstractmethod
+    def name(self):
+        pass

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -508,26 +508,25 @@ class TileCircuit(generator.Generator):
     def __add_stall(self, stall_signal_width: int):
         # automatically add stall signal and connect it to the features if the
         # feature supports it
+        self.add_ports(stall=magma.In(magma.Bits(stall_signal_width)))
         stall_ports = []
         for feature in self.features():
             if "stall" in feature.ports.keys():
                 stall_ports.append(feature.ports.stall)
-        if len(stall_ports) > 0:
-            self.add_ports(stall=magma.In(magma.Bits(stall_signal_width)))
-            for stall_port in stall_ports:
-                self.wire(self.ports.stall, stall_port)
+        for stall_port in stall_ports:
+            self.wire(self.ports.stall, stall_port)
 
     def __add_reset(self):
         # automatically add reset signal and connect it to the features if the
         # feature supports it
+        self.add_ports(reset=magma.In(magma.AsyncReset))
         reset_ports = []
         for feature in self.features():
             if "reset" in feature.ports.keys():
                 reset_ports.append(feature.ports.reset)
-        if len(reset_ports):
-            self.add_ports(reset=magma.In(magma.AsyncReset))
-            for reset_port in reset_ports:
-                self.wire(self.ports.reset, reset_port)
+
+        for reset_port in reset_ports:
+            self.wire(self.ports.reset, reset_port)
 
     def __should_add_config(self):
         # a introspection on itself to determine whether to add config

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -45,9 +45,6 @@ def create_mux(node: Node):
     return mux
 
 
-
-
-
 class CB(InterconnectConfigurable):
     def __init__(self, node: PortNode,
                  config_addr_width: int, config_data_width: int):

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -3,19 +3,17 @@ This is a layer build on top of Cyclone
 """
 from common.core import Core
 from common.mux_with_default import MuxWithDefaultWrapper
-from common.zext_wrapper import ZextWrapper
-from generator.configurable import Configurable, ConfigurationType
+from generator.configurable import  ConfigurationType
 from .cyclone import Node, PortNode, Tile, SwitchBoxNode, SwitchBoxIO, \
     SwitchBox, InterconnectCore, RegisterNode, RegisterMuxNode
 import mantle
 from common.mux_wrapper import MuxWrapper
 import magma
 from typing import Dict, Tuple, List
-from abc import abstractmethod
 import generator.generator as generator
 from generator.from_magma import FromMagma
 from mantle import DefineRegister
-from common.core import CoreFeature
+from generator.interconnect_configurable import InterconnectConfigurable
 
 
 def create_name(name: str):
@@ -47,66 +45,7 @@ def create_mux(node: Node):
     return mux
 
 
-class InterconnectConfigurable(Configurable):
-    def __init__(self, config_addr_width: int, config_data_width: int):
-        super().__init__()
-        self.config_addr_width = config_addr_width
-        self.config_data_width = config_data_width
 
-        self.read_config_data_mux: MuxWrapper = None
-
-        # ports for reconfiguration
-        self.add_ports(
-            clk=magma.In(magma.Clock),
-            reset=magma.In(magma.AsyncReset),
-        )
-
-    def _setup_config(self):
-        # sort the registers by it's name. this will be the order of config
-        # addr index
-        config_names = list(self.registers.keys())
-        config_names.sort()
-        for idx, config_name in enumerate(config_names):
-            reg = self.registers[config_name]
-            # set the configuration registers
-            reg.set_addr(idx)
-            reg.set_addr_width(self.config_addr_width)
-            reg.set_data_width(self.config_data_width)
-
-            self.wire(self.ports.config.config_addr, reg.ports.config_addr)
-            self.wire(self.ports.config.config_data, reg.ports.config_data)
-            self.wire(self.ports.config.write[0], reg.ports.config_en)
-            self.wire(self.ports.reset, reg.ports.reset)
-
-        # read_config_data output
-        num_config_reg = len(config_names)
-        if num_config_reg > 1:
-            self.read_config_data_mux = MuxWrapper(num_config_reg,
-                                                   self.config_data_width)
-            sel_bits = self.read_config_data_mux.sel_bits
-            # Wire up config_addr to select input of read_data MUX
-            self.wire(self.ports.config.config_addr[:sel_bits],
-                      self.read_config_data_mux.ports.S)
-            self.wire(self.read_config_data_mux.ports.O,
-                      self.ports.read_config_data)
-
-            for idx, config_name in enumerate(config_names):
-                reg = self.registers[config_name]
-                zext = ZextWrapper(reg.width, self.config_data_width)
-                self.wire(reg.ports.O, zext.ports.I)
-                zext_out = zext.ports.O
-                self.wire(zext_out, self.read_config_data_mux.ports.I[idx])
-        elif num_config_reg == 1:
-            config_name = config_names[0]
-            reg = self.registers[config_name]
-            zext = ZextWrapper(reg.width, self.config_data_width)
-            self.wire(reg.ports.O, zext.ports.I)
-            zext_out = zext.ports.O
-            self.wire(zext_out, self.ports.read_config_data)
-
-    @abstractmethod
-    def name(self):
-        pass
 
 
 class CB(InterconnectConfigurable):

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -3,7 +3,7 @@ This is a layer build on top of Cyclone
 """
 from common.core import Core
 from common.mux_with_default import MuxWithDefaultWrapper
-from generator.configurable import  ConfigurationType
+from generator.configurable import ConfigurationType
 from .cyclone import Node, PortNode, Tile, SwitchBoxNode, SwitchBoxIO, \
     SwitchBox, InterconnectCore, RegisterNode, RegisterMuxNode
 import mantle

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -709,8 +709,10 @@ class TileCircuit(generator.Generator):
         return config_names.index(mux_sel_name)
 
     def name(self):
-        return f"Tile_{self.core.name()}_{self.x}_{self.y}" if self.core is not None else \
-            "Tile_Empty"
+        if self.core is not None:
+            return f"Tile_{self.core.name()}"
+        else:
+            return "Tile_Empty"
 
 
 class CoreInterface(InterconnectCore):

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -137,6 +137,11 @@ class CB(InterconnectConfigurable):
             self.add_config(config_name, self.mux.sel_bits)
             self.wire(self.registers[config_name].ports.O,
                       self.mux.ports.S)
+        else:
+            # remove clk and reset ports from the base class since it's going
+            # to be a pass through wire anyway
+            self.ports.pop("clk")
+            self.ports.pop("reset")
 
         self._setup_config()
 
@@ -193,12 +198,17 @@ class SB(InterconnectConfigurable):
         self.__connect_sb_out()
         self.__connect_regs()
 
-        # set up the configuration registers
-        self.add_ports(
-            config=magma.In(ConfigurationType(config_addr_width,
-                                              config_data_width)),
-            read_config_data=magma.Out(magma.Bits(config_data_width)),
-        )
+        # set up the configuration registers, if needed
+        if len(self.sb_muxs) > 0:
+            self.add_ports(
+                config=magma.In(ConfigurationType(config_addr_width,
+                                                  config_data_width)),
+                read_config_data=magma.Out(magma.Bits(config_data_width)),
+            )
+        else:
+            # remove added ports since it's a empty switchbox
+            self.ports.pop("clk")
+            self.ports.pop("reset")
         for _, (sb, mux) in self.sb_muxs.items():
             config_name = get_mux_sel_name(sb)
             if mux.height > 1:
@@ -445,8 +455,9 @@ class TileCircuit(generator.Generator):
             conn_ins = cb.node.get_conn_in()
             for idx, node in enumerate(conn_ins):
                 assert isinstance(node, SwitchBoxNode)
-                assert node.x == self.x
-                assert node.y == self.y
+                # for IO tiles they have connections to other tiles
+                if node.x != self.x or node.y != self.y:
+                    continue
                 bit_width = node.width
                 sb_circuit = self.sbs[bit_width]
                 if node.io == SwitchBoxIO.SB_IN:
@@ -466,8 +477,9 @@ class TileCircuit(generator.Generator):
                     port_name = port_node.name
                     for sb_node in port_node:
                         assert isinstance(sb_node, SwitchBoxNode)
-                        assert sb_node.x == self.x
-                        assert sb_node.y == self.y
+                        # for IO tiles they have connections to other tiles
+                        if sb_node.x != self.x or sb_node.y != self.y:
+                            continue
                         idx = sb_node.get_conn_in().index(port_node)
                         sb_circuit = self.sbs[port_node.width]
                         # we need to find the actual mux
@@ -494,23 +506,53 @@ class TileCircuit(generator.Generator):
         self.instance_name = f"Tile_X{self.x:02X}_Y{self.y:02X}"
 
     def __add_stall(self, stall_signal_width: int):
-        # automatically add stall signal and connect it to the core if the
-        # core supports it
-        self.add_ports(stall=magma.In(magma.Bits(stall_signal_width)))
-        if "stall" in self.core.ports.keys():
-            self.wire(self.ports.stall, self.core.ports.stall)
+        # automatically add stall signal and connect it to the features if the
+        # feature supports it
+        stall_ports = []
+        for feature in self.features():
+            if "stall" in feature.ports.keys():
+                stall_ports.append(feature.ports.stall)
+        if len(stall_ports) > 0:
+            self.add_ports(stall=magma.In(magma.Bits(stall_signal_width)))
+            for stall_port in stall_ports:
+                self.wire(self.ports.stall, stall_port)
 
     def __add_reset(self):
-        if "reset" in self.core.ports.keys():
-            self.wire(self.ports.reset, self.core.ports.reset)
+        # automatically add reset signal and connect it to the features if the
+        # feature supports it
+        reset_ports = []
+        for feature in self.features():
+            if "reset" in feature.ports.keys():
+                reset_ports.append(feature.ports.reset)
+        if len(reset_ports):
+            self.add_ports(reset=magma.In(magma.AsyncReset))
+            for reset_port in reset_ports:
+                self.wire(self.ports.reset, reset_port)
+
+    def __should_add_config(self):
+        # a introspection on itself to determine whether to add config
+        # or not
+        for feature in self.features():
+            if "config" in feature.ports:
+                return True
+            else:
+                # if the feature doesn't have config port, it shouldn't have
+                # reset either, although the other way around may be true
+                # that is, a feature may have some internal states that need
+                # to reset, but not necessarily has config port
+                assert "reset" not in feature.ports
+        return False
 
     def __add_config(self):
+        # see if we really need to add config or not
+        if not self.__should_add_config():
+            return
+
         self.add_ports(
             config=magma.In(ConfigurationType(self.full_config_addr_width,
                                               self.config_data_width)),
             tile_id=magma.In(magma.Bits(self.tile_id_width)),
             clk=magma.In(magma.Clock),
-            reset=magma.In(magma.AsyncReset),
             read_config_data=magma.Out(magma.Bits(self.config_data_width)))
 
         features = self.features()

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -513,6 +513,10 @@ class TileCircuit(generator.Generator):
         for feature in self.features():
             if "stall" in feature.ports.keys():
                 stall_ports.append(feature.ports.stall)
+        # some core may not expose the port as features, such as mem cores
+        if "stall" in self.core.ports and \
+                self.core.ports.stall not in stall_ports:
+            stall_ports.append(self.core.ports.stall)
         for stall_port in stall_ports:
             self.wire(self.ports.stall, stall_port)
 
@@ -524,6 +528,10 @@ class TileCircuit(generator.Generator):
         for feature in self.features():
             if "reset" in feature.ports.keys():
                 reset_ports.append(feature.ports.reset)
+        # some core may not expose the port as features, such as mem cores
+        if "reset" in self.core.ports and \
+                self.core.ports.reset not in reset_ports:
+            reset_ports.append(self.core.ports.reset)
 
         for reset_port in reset_ports:
             self.wire(self.ports.reset, reset_port)

--- a/interconnect/circuit.py
+++ b/interconnect/circuit.py
@@ -470,7 +470,6 @@ class TileCircuit(generator.Generator):
         # placeholder for global signal wiring
         self.read_data_mux: MuxWithDefaultWrapper = None
 
-
     def __add_tile_id(self):
         self.add_port("tile_id",
                       magma.In(magma.Bits(self.tile_id_width)))

--- a/interconnect/cyclone.py
+++ b/interconnect/cyclone.py
@@ -691,7 +691,7 @@ class InterconnectGraph:
                     the expected_length. it is safe but may leave some tiles
                     unconnected
         """
-        if x1 - expected_length <= x0 or y1 - expected_length <= y0:
+        if x1 - expected_length < x0 or y1 - expected_length < y0:
             raise ValueError("the region has to be bigger than expected "
                              "length")
 

--- a/interconnect/global_signal.py
+++ b/interconnect/global_signal.py
@@ -32,7 +32,7 @@ def apply_global_fanout_wiring(interconnect: Interconnect, margin: int = 0):
                               tile.ports.read_config_data)
 
         # wire it to the interconnect_read_data_or
-        idx = x - interconnect.x_min
+        idx = x - (interconnect.x_min + margin)
         interconnect.wire(interconnect_read_data_or.ports[f"I{idx}"],
                           column_read_data_or.ports.O)
 
@@ -51,7 +51,8 @@ def apply_global_meso_wiring(interconnect: Interconnect, margin: int = 0):
         FromMagma(mantle.DefineOr(cgra_width, interconnect.config_data_width))
 
     # looping through on a per-column bases
-    for x in range(interconnect.x_min, interconnect.x_max + 1):
+    for x in range(interconnect.x_min + margin,
+                   interconnect.x_max + 1 - margin):
         column = interconnect.get_column(x)
         # skip the margin
         column = column[margin:len(column) - margin]
@@ -97,7 +98,7 @@ def apply_global_meso_wiring(interconnect: Interconnect, margin: int = 0):
             interconnect.wire(tile.ports.read_config_data,
                               ports_in[i + 1])
         # Connect the last tile's read_data output to the global OR
-        idx = x - interconnect.x_min
+        idx = x - (interconnect.x_min + margin)
         interconnect.wire(interconnect_read_data_or.ports[f"I{idx}"],
                           column[-1].ports.read_config_data)
 

--- a/interconnect/global_signal.py
+++ b/interconnect/global_signal.py
@@ -7,15 +7,18 @@ from generator.from_magma import FromMagma
 from .interconnect import Interconnect
 
 
-def apply_global_fanout_wiring(interconnect: Interconnect):
+def apply_global_fanout_wiring(interconnect: Interconnect, margin: int = 0):
     # straight-forward fanout for global signals
     global_ports = interconnect.globals
     interconnect_read_data_or = \
         FromMagma(mantle.DefineOr(interconnect.x_max - interconnect.x_min + 1,
                                   interconnect.config_data_width))
     # this is connected on a per-column bases
-    for x in range(interconnect.x_min, interconnect.x_max + 1):
+    for x in range(interconnect.x_min + margin,
+                   interconnect.x_max + 1 - margin):
         column = interconnect.get_column(x)
+        # skip the margin
+        column = column[margin:len(column) - margin]
         # handle the read config
         column_read_data_or = \
             FromMagma(mantle.DefineOr(len(column),
@@ -40,7 +43,7 @@ def apply_global_fanout_wiring(interconnect: Interconnect):
     return interconnect_read_data_or
 
 
-def apply_global_meso_wiring(interconnect: Interconnect):
+def apply_global_meso_wiring(interconnect: Interconnect, margin: int = 0):
     # FIXME:
     # once IO tiles are added, we need to compute the top of the column
     # as the first tile will be empty IO
@@ -56,6 +59,8 @@ def apply_global_meso_wiring(interconnect: Interconnect):
     # looping through on a per-column bases
     for x in range(interconnect.x_min, interconnect.x_max + 1):
         column = interconnect.get_column(x)
+        # skip the margin
+        column = column[margin:len(column) - margin]
         # wire global inputs to first tile in column
         for signal in global_ports:
             interconnect.wire(interconnect.ports[signal],

--- a/interconnect/global_signal.py
+++ b/interconnect/global_signal.py
@@ -41,6 +41,12 @@ def apply_global_fanout_wiring(interconnect: Interconnect):
 
 
 def apply_global_meso_wiring(interconnect: Interconnect):
+    # FIXME:
+    # once IO tiles are added, we need to compute the top of the column
+    # as the first tile will be empty IO
+    # also some optimization passes at the tile level may remove the global
+    # signal if not used. Need to take care of that as well
+
     # "river routing" for global signal
     global_ports = interconnect.globals
     interconnect_read_data_or = \

--- a/interconnect/global_signal.py
+++ b/interconnect/global_signal.py
@@ -10,9 +10,9 @@ from .interconnect import Interconnect
 def apply_global_fanout_wiring(interconnect: Interconnect, margin: int = 0):
     # straight-forward fanout for global signals
     global_ports = interconnect.globals
+    cgra_width = interconnect.x_max - interconnect.x_min + 1 - 2 * margin
     interconnect_read_data_or = \
-        FromMagma(mantle.DefineOr(interconnect.x_max - interconnect.x_min + 1,
-                                  interconnect.config_data_width))
+        FromMagma(mantle.DefineOr(cgra_width, interconnect.config_data_width))
     # this is connected on a per-column bases
     for x in range(interconnect.x_min + margin,
                    interconnect.x_max + 1 - margin):
@@ -44,17 +44,11 @@ def apply_global_fanout_wiring(interconnect: Interconnect, margin: int = 0):
 
 
 def apply_global_meso_wiring(interconnect: Interconnect, margin: int = 0):
-    # FIXME:
-    # once IO tiles are added, we need to compute the top of the column
-    # as the first tile will be empty IO
-    # also some optimization passes at the tile level may remove the global
-    # signal if not used. Need to take care of that as well
-
     # "river routing" for global signal
     global_ports = interconnect.globals
+    cgra_width = interconnect.x_max - interconnect.x_min + 1 - 2 * margin
     interconnect_read_data_or = \
-        FromMagma(mantle.DefineOr(interconnect.x_max - interconnect.x_min + 1,
-                                  interconnect.config_data_width))
+        FromMagma(mantle.DefineOr(cgra_width, interconnect.config_data_width))
 
     # looping through on a per-column bases
     for x in range(interconnect.x_min, interconnect.x_max + 1):

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -133,23 +133,27 @@ class Interconnect(generator.Generator):
             # ground them up
             self.__ground_ports()
 
-        # set tile_id
-        self.__set_tile_id()
-
         # global ports
         self.globals = self.__add_global_ports(stall_signal_width)
 
         # add config
         self.__add_read_config_data(config_data_width)
 
+        # clean up empty tiles
+        self.__cleanup_tiles()
+
+        # set tile_id
+        self.__set_tile_id()
+
     def __get_tile_id(self, x: int, y: int):
         return x << (self.tile_id_width // 2) | y
 
     def __set_tile_id(self):
         for (x, y), tile in self.tile_circuits.items():
-            tile_id = self.__get_tile_id(x, y)
-            self.wire(tile.ports.tile_id,
-                      Const(magma.bits(tile_id, self.tile_id_width)))
+            if "tile_id" in tile.ports:
+                tile_id = self.__get_tile_id(x, y)
+                self.wire(tile.ports.tile_id,
+                          Const(magma.bits(tile_id, self.tile_id_width)))
 
     def __lift_ports(self):
         # we assume it's a rectangular grid
@@ -205,24 +209,45 @@ class Interconnect(generator.Generator):
         # margin tiles have empty switchbox
         for coord, tile_dict in self.__tiles.items():
             for bit_width, tile in tile_dict.items():
-                if tile.switchbox.num_track > 0:
+                if tile.switchbox.num_track > 0 or tile.core is None:
                     continue
                 for port_name, port_node in tile.ports.items():
                     tile_port = self.tile_circuits[coord].ports[port_name]
                     if len(port_node) == 0 and \
                             len(port_node.get_conn_in()) == 0:
                         # lift this port up
-                        self.add_port(port_name, tile_port.base_type())
-                        self.wire(self.ports[port_name], tile_port)
+                        x, y = coord
+                        new_port_name = f"{port_name}_X{x}_Y{y}"
+                        self.add_port(new_port_name, tile_port.base_type())
+                        self.wire(self.ports[new_port_name], tile_port)
                     else:
                         # connect them to the internal fabric
                         nodes = list(port_node) + port_node.get_conn_in()[:]
                         for sb_node in nodes:
-                            assert isinstance(sb_node, SwitchBoxNode)
                             next_coord = sb_node.x, sb_node.y
-                            sb_name = create_name(str(sb_node))
+                            # depends on whether there is a pipeline register
+                            # or not, we need to be very careful
+                            if isinstance(sb_node, SwitchBoxNode):
+                                sb_name = create_name(str(sb_node))
+                            else:
+                                assert isinstance(sb_node, RegisterMuxNode)
+                                # because margin tiles won't connect to
+                                # reg mux node, they can only be connected
+                                # from
+                                nodes = sb_node.get_conn_in()[:]
+                                nodes = [x for x in nodes if
+                                         isinstance(x, SwitchBoxNode)]
+                                assert len(nodes) == 1
+                                sb_node = nodes[0]
+                                sb_name = create_name(str(sb_node))
+
                             next_port = \
                                 self.tile_circuits[next_coord].ports[sb_name]
+                            if sb_node.io == SwitchBoxIO.SB_IN:
+                                next_port = next_port[0]
+                            else:
+                                tile_port = tile_port[0]
+
                             self.wire(tile_port, next_port)
 
     def __ground_ports(self):
@@ -238,7 +263,33 @@ class Interconnect(generator.Generator):
                     # no connection to that sb port, ground it
                     sb_name = create_name(str(sb))
                     sb_port = self.tile_circuits[coord].ports[sb_name]
-                    self.wire(ground, sb_port)
+                    self.wire(ground, sb_port[0])
+
+    def __cleanup_tiles(self):
+        tiles_to_remove = set()
+        for coord, tile in self.tile_circuits.items():
+            tile_circuit = self.tile_circuits[coord]
+            if tile.core is None:
+                tiles_to_remove.add(coord)
+            else:
+                core_tile = False
+                for _, sb in tile_circuit.sbs.items():
+                    if len(sb.wires) > 0:
+                        core_tile = True
+                        break
+                if core_tile:
+                    continue
+
+            # remove all the global signals
+            for signal in self.globals:
+                if signal in tile_circuit.ports:
+                    tile_circuit.ports.pop(signal)
+        # remove empty tiles
+        for coord in tiles_to_remove:
+            # remove the tile id as well
+            tile_circuit = self.tile_circuits[coord]
+            tile_circuit.ports.pop("tile_id")
+            self.tile_circuits.pop(coord)
 
     def __add_read_config_data(self, config_data_width: int):
         self.add_port("read_config_data",

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -80,7 +80,6 @@ class Interconnect(generator.Generator):
         for (x, y), tile in self.tile_circuits.items():
             for bit_width, switch_box in tile.sbs.items():
                 all_sbs = switch_box.switchbox.get_all_sbs()
-                # TODO: change the search logic once we add pipeline registers
                 for sb in all_sbs:
                     if sb.io != SwitchBoxIO.SB_OUT:
                         continue

--- a/interconnect/interconnect.py
+++ b/interconnect/interconnect.py
@@ -308,6 +308,15 @@ class Interconnect(generator.Generator):
                 self.ports.reset.qualified_name(),
                 self.ports.stall.qualified_name())
 
+    def finalize(self):
+        # finalize the design. after this, users are not able to add
+        # features to the tiles any more
+        # clean up first
+        self.__cleanup_tiles()
+        # finalize individual tiles first
+        for _, tile in self.tile_circuits.items():
+            tile.finalize()
+
     def get_route_bitstream_config(self, src_node: Node, dst_node: Node):
         # this is the complete one which includes the tile_id
         x, y = dst_node.x, dst_node.y

--- a/interconnect/util.py
+++ b/interconnect/util.py
@@ -41,7 +41,8 @@ def create_uniform_interconnect(width: int,
                                 sb_type: SwitchBoxType,
                                 pipeline_reg:
                                 List[Tuple[int, SwitchBoxSide]] = None,
-                                margin: int = 0
+                                margin: int = 0,
+                                io_conn: Dict[str, Dict[str, List[int]]] = None
                                 ) -> InterconnectGraph:
     """Create a uniform interconnect with column-based design. We will use
     disjoint switch for now. Configurable parameters in terms of interconnect
@@ -64,19 +65,21 @@ def create_uniform_interconnect(width: int,
     :parameter pipeline_reg: specifies which track and which side to insert
                              pipeline registers
     :parameter margin: PE/MEM margin, can only be 0 or 1
+    :parameter io_conn: Specify the IO connections. only valid when margin is
+                        set to 1
 
     :return configured Interconnect object
     """
     assert margin in (0, 1), "margin can either be 0 or 1"
+    if margin == 0 or io_conn is None:
+        io_conn = {"in": {}, "out": {}}
     tile_height = 1
-    x_offset = margin
-    y_offset = margin
     interconnect = InterconnectGraph(track_width)
     # create tiles and set cores
-    for x in range(x_offset, width - x_offset + margin):
-        for y in range(y_offset, height - y_offset, tile_height + margin):
+    for x in range(margin, width - margin):
+        for y in range(margin, height - margin, tile_height):
             # compute the number of tracks
-            num_track = compute_num_tracks(x_offset, y_offset,
+            num_track = compute_num_tracks(margin, margin,
                                            x, y, track_info)
             # create switch based on the type passed in
             if sb_type == SwitchBoxType.Disjoint:
@@ -95,17 +98,16 @@ def create_uniform_interconnect(width: int,
             interconnect.set_core(x, y, core_interface)
 
     # create tiles without SB
-    for x in range(width + 2 * margin):
-        for y in range(height + 2 * margin):
+    for x in range(width):
+        for y in range(height):
             # skip if the tiles is already created
             tile = interconnect.get_tile(x, y)
             if tile is not None:
                 continue
-            # empty switch box
+            core = column_core_fn(x, y)
             sb = SwitchBox(x, y, 0, track_width, [])
             tile_circuit = Tile(x, y, track_width, sb, tile_height)
             interconnect.add_tile(tile_circuit)
-            core = column_core_fn(x, y)
             core_interface = CoreInterface(core)
             interconnect.set_core(x, y, core_interface)
 
@@ -119,12 +121,15 @@ def create_uniform_interconnect(width: int,
     current_track = 0
     for track_len in track_lens:
         for _ in range(track_info[track_len]):
-            interconnect.connect_switchbox(x_offset, y_offset, width + x_offset,
-                                           height + y_offset,
+            interconnect.connect_switchbox(margin, margin, width - margin - 1,
+                                           height - margin - 1,
                                            track_len,
                                            current_track,
                                            InterconnectPolicy.Ignore)
             current_track += 1
+
+    # insert io
+    connect_io(interconnect, io_conn["in"], io_conn["out"])
 
     # insert pipeline register
     if pipeline_reg is None:
@@ -132,6 +137,8 @@ def create_uniform_interconnect(width: int,
     for track, side in pipeline_reg:
         for coord in interconnect:
             tile = interconnect[coord]
+            if tile.switchbox is None or tile.switchbox.num_track == 0:
+                continue
             if track < tile.switchbox.num_track:
                 tile.switchbox.add_pipeline_register(side, track)
 
@@ -147,11 +154,13 @@ def connect_io(interconnect: InterconnectGraph,
     # compute tiles and sides
     for x in range(x_max):
         for y in range(y_max):
-            if x in range(margin, x_max - margin) or \
+            if x in range(margin, x_max - margin) and \
                     y in range(margin, y_max - margin):
                 continue
             # make sure that these margins tiles have empty switch boxes
             tile = interconnect[(x, y)]
+            if tile.core.core is None:
+                continue
             assert tile.switchbox.num_track == 0
             # compute the nearby tile
             if x in range(0, margin):
@@ -168,16 +177,17 @@ def connect_io(interconnect: InterconnectGraph,
                 next_tile = interconnect[(x, y - 1)]
                 side = SwitchBoxSide.SOUTH
             for input_port, conn in input_port_conn.items():
-                # input is one to all connection
+                # input is from fabric to IO
                 if input_port in tile.ports:
                     port_node = tile.ports[input_port]
                     for track in conn:
                         # to be conservative when connecting the nodes
                         if track < next_tile.switchbox.num_track:
                             sb_node = next_tile.get_sb(side, track,
-                                                       SwitchBoxIO.SB_IN)
-                            port_node.add_edge(sb_node)
+                                                       SwitchBoxIO.SB_OUT)
+                            sb_node.add_edge(port_node)
             for output_port, conn in output_port_conn.items():
+                # output is IO to fabric
                 if output_port in tile.ports:
                     port_node = tile.ports[output_port]
                     for track in conn:

--- a/interconnect/util.py
+++ b/interconnect/util.py
@@ -129,7 +129,8 @@ def create_uniform_interconnect(width: int,
             current_track += 1
 
     # insert io
-    connect_io(interconnect, io_conn["in"], io_conn["out"])
+    if margin > 0:
+        connect_io(interconnect, io_conn["in"], io_conn["out"])
 
     # insert pipeline register
     if pipeline_reg is None:

--- a/interconnect/util.py
+++ b/interconnect/util.py
@@ -1,8 +1,8 @@
 from common.core import Core
 from typing import Tuple, List, Dict, Callable
-from .cyclone import SwitchBoxSide, SwitchBoxIO, InterconnectPolicy
-from .cyclone import InterconnectGraph, DisjointSwitchBox, WiltonSwitchBox
-from .cyclone import ImranSwitchBox, Tile
+from .cyclone import SwitchBoxSide, SwitchBoxIO, InterconnectPolicy, \
+    InterconnectGraph, DisjointSwitchBox, WiltonSwitchBox, \
+    ImranSwitchBox, Tile, SwitchBox
 from .circuit import CoreInterface
 import enum
 
@@ -40,7 +40,8 @@ def create_uniform_interconnect(width: int,
                                 track_info: Dict[int, int],
                                 sb_type: SwitchBoxType,
                                 pipeline_reg:
-                                List[Tuple[int, SwitchBoxSide]] = None
+                                List[Tuple[int, SwitchBoxSide]] = None,
+                                margin: int = 0
                                 ) -> InterconnectGraph:
     """Create a uniform interconnect with column-based design. We will use
     disjoint switch for now. Configurable parameters in terms of interconnect
@@ -62,16 +63,18 @@ def create_uniform_interconnect(width: int,
     :parameter sb_type: Switch box type.
     :parameter pipeline_reg: specifies which track and which side to insert
                              pipeline registers
+    :parameter margin: PE/MEM margin, can only be 0 or 1
 
     :return configured Interconnect object
     """
+    assert margin in (0, 1), "margin can either be 0 or 1"
     tile_height = 1
-    x_offset = 0
-    y_offset = 0
+    x_offset = margin
+    y_offset = margin
     interconnect = InterconnectGraph(track_width)
     # create tiles and set cores
-    for x in range(x_offset, width - x_offset):
-        for y in range(y_offset, height - y_offset, tile_height):
+    for x in range(x_offset, width - x_offset + margin):
+        for y in range(y_offset, height - y_offset, tile_height + margin):
             # compute the number of tracks
             num_track = compute_num_tracks(x_offset, y_offset,
                                            x, y, track_info)
@@ -90,6 +93,22 @@ def create_uniform_interconnect(width: int,
             core = column_core_fn(x, y)
             core_interface = CoreInterface(core)
             interconnect.set_core(x, y, core_interface)
+
+    # create tiles without SB
+    for x in range(width + 2 * margin):
+        for y in range(height + 2 * margin):
+            # skip if the tiles is already created
+            tile = interconnect.get_tile(x, y)
+            if tile is not None:
+                continue
+            # empty switch box
+            sb = SwitchBox(x, y, 0, track_width, [])
+            tile_circuit = Tile(x, y, track_width, sb, tile_height)
+            interconnect.add_tile(tile_circuit)
+            core = column_core_fn(x, y)
+            core_interface = CoreInterface(core)
+            interconnect.set_core(x, y, core_interface)
+
     # set port connections
     for port_name, conns in port_connections.items():
         interconnect.set_core_connection_all(port_name, conns)
@@ -100,7 +119,8 @@ def create_uniform_interconnect(width: int,
     current_track = 0
     for track_len in track_lens:
         for _ in range(track_info[track_len]):
-            interconnect.connect_switchbox(x_offset, y_offset, width, height,
+            interconnect.connect_switchbox(x_offset, y_offset, width + x_offset,
+                                           height + y_offset,
                                            track_len,
                                            current_track,
                                            InterconnectPolicy.Ignore)
@@ -116,3 +136,51 @@ def create_uniform_interconnect(width: int,
                 tile.switchbox.add_pipeline_register(side, track)
 
     return interconnect
+
+
+def connect_io(interconnect: InterconnectGraph,
+               input_port_conn: Dict[str, List[int]],
+               output_port_conn: Dict[str, int]):
+    """connect tiles on the margin"""
+    margin = 1
+    x_max, y_max = interconnect.get_size()
+    # compute tiles and sides
+    for x in range(x_max):
+        for y in range(y_max):
+            if x in range(margin, x_max - margin) or \
+                    y in range(margin, y_max - margin):
+                continue
+            # make sure that these margins tiles have empty switch boxes
+            tile = interconnect[(x, y)]
+            assert tile.switchbox.num_track == 0
+            # compute the nearby tile
+            if x in range(0, margin):
+                next_tile = interconnect[(x + 1, y)]
+                side = SwitchBoxSide.WEST
+            elif x in range(x_max - margin, x_max):
+                next_tile = interconnect[(x - 1, y)]
+                side = SwitchBoxSide.EAST
+            elif y in range(0, margin):
+                next_tile = interconnect[(x, y + 1)]
+                side = SwitchBoxSide.NORTH
+            else:
+                assert y in range(y_max - margin, y_max)
+                next_tile = interconnect[(x, y - 1)]
+                side = SwitchBoxSide.SOUTH
+            for input_port, conn in input_port_conn.items():
+                # input is one to all connection
+                if input_port in tile.ports:
+                    port_node = tile.ports[input_port]
+                    for track in conn:
+                        # to be conservative when connecting the nodes
+                        if track < next_tile.switchbox.num_track:
+                            sb_node = next_tile.get_sb(side, track,
+                                                       SwitchBoxIO.SB_IN)
+                            port_node.add_edge(sb_node)
+            for output_port, track in output_port_conn.items():
+                if output_port in tile.ports:
+                    port_node = tile.ports[output_port]
+                    if track < next_tile.switchbox.num_track:
+                        sb_node = next_tile.get_sb(side, track,
+                                                   SwitchBoxIO.SB_IN)
+                        port_node.add_edge(sb_node)

--- a/interconnect/util.py
+++ b/interconnect/util.py
@@ -181,6 +181,8 @@ def connect_io(interconnect: InterconnectGraph,
                 # input is from fabric to IO
                 if input_port in tile.ports:
                     port_node = tile.ports[input_port]
+                    if port_node.width != interconnect.bit_width:
+                        continue
                     for track in conn:
                         # to be conservative when connecting the nodes
                         if track < next_tile.switchbox.num_track:
@@ -191,6 +193,8 @@ def connect_io(interconnect: InterconnectGraph,
                 # output is IO to fabric
                 if output_port in tile.ports:
                     port_node = tile.ports[output_port]
+                    if port_node.width != interconnect.bit_width:
+                        continue
                     for track in conn:
                         if track < next_tile.switchbox.num_track:
                             sb_node = next_tile.get_sb(side, track,

--- a/interconnect/util.py
+++ b/interconnect/util.py
@@ -140,7 +140,7 @@ def create_uniform_interconnect(width: int,
 
 def connect_io(interconnect: InterconnectGraph,
                input_port_conn: Dict[str, List[int]],
-               output_port_conn: Dict[str, int]):
+               output_port_conn: Dict[str, List[int]]):
     """connect tiles on the margin"""
     margin = 1
     x_max, y_max = interconnect.get_size()
@@ -177,10 +177,11 @@ def connect_io(interconnect: InterconnectGraph,
                             sb_node = next_tile.get_sb(side, track,
                                                        SwitchBoxIO.SB_IN)
                             port_node.add_edge(sb_node)
-            for output_port, track in output_port_conn.items():
+            for output_port, conn in output_port_conn.items():
                 if output_port in tile.ports:
                     port_node = tile.ports[output_port]
-                    if track < next_tile.switchbox.num_track:
-                        sb_node = next_tile.get_sb(side, track,
-                                                   SwitchBoxIO.SB_IN)
-                        port_node.add_edge(sb_node)
+                    for track in conn:
+                        if track < next_tile.switchbox.num_track:
+                            sb_node = next_tile.get_sb(side, track,
+                                                       SwitchBoxIO.SB_IN)
+                            port_node.add_edge(sb_node)

--- a/io_core/io16bit_magma.py
+++ b/io_core/io16bit_magma.py
@@ -10,18 +10,18 @@ class IO16bit(Core):
         self.add_ports(
             glb2io=magma.In(TBit),
             io2glb=magma.Out(TBit),
-            io2f=magma.Out(TBit),
-            f2io=magma.In(TBit)
+            io2f_16=magma.Out(TBit),
+            f2io_16=magma.In(TBit)
         )
 
-        self.wire(self.ports.glb2io, self.ports.io2f)
-        self.wire(self.ports.f2io, self.ports.io2glb)
+        self.wire(self.ports.glb2io, self.ports.io2f_16)
+        self.wire(self.ports.f2io_16, self.ports.io2glb)
 
     def inputs(self):
-        return [self.ports.glb2io, self.ports.f2io]
+        return [self.ports.glb2io, self.ports.f2io_16]
 
     def outputs(self):
-        return [self.ports.io2glb, self.ports.io2f]
+        return [self.ports.io2glb, self.ports.io2f_16]
 
     def name(self):
         return "io16bit"

--- a/io_core/io1bit_magma.py
+++ b/io_core/io1bit_magma.py
@@ -10,17 +10,17 @@ class IO1bit(Core):
         self.add_ports(
             glb2io=magma.In(TBit),
             io2glb=magma.Out(TBit),
-            io2f=magma.Out(TBit),
-            f2io=magma.In(TBit)
+            io2f_1=magma.Out(TBit),
+            f2io_1=magma.In(TBit)
         )
-        self.wire(self.ports.glb2io, self.ports.io2f)
-        self.wire(self.ports.f2io, self.ports.io2glb)
+        self.wire(self.ports.glb2io, self.ports.io2f_1)
+        self.wire(self.ports.f2io_1, self.ports.io2glb)
 
     def inputs(self):
-        return [self.ports.glb2io, self.ports.f2io]
+        return [self.ports.glb2io, self.ports.f2io_1]
 
     def outputs(self):
-        return [self.ports.io2glb, self.ports.io2f]
+        return [self.ports.io2glb, self.ports.io2f_1]
 
     def name(self):
         return "io1bit"

--- a/test_interconnect/test_circuit.py
+++ b/test_interconnect/test_circuit.py
@@ -233,6 +233,8 @@ def test_tile(num_tracks: int):
 
     tile_circuit = TileCircuit(tiles, addr_width, data_width,
                                tile_id_width=tile_id_width)
+    # finalize it
+    tile_circuit.finalize()
 
     circuit = tile_circuit.circuit()
 

--- a/test_interconnect/test_interconnect.py
+++ b/test_interconnect/test_interconnect.py
@@ -85,6 +85,8 @@ def test_interconnect(num_tracks: int, chip_size: int,
 
     interconnect = Interconnect(ics, addr_width, data_width, tile_id_width,
                                 lift_ports=True)
+    # finalize the design
+    interconnect.finalize()
     # wiring
     if wiring == GlobalSignalWiring.Fanout:
         apply_global_fanout_wiring(interconnect)

--- a/test_interconnect/test_interconnect_cgra.py
+++ b/test_interconnect/test_interconnect_cgra.py
@@ -49,7 +49,7 @@ def test_interconnect_point_wise(batch_size: int):
 
     next_node = None
     # route all the way to the end
-    for x in range(1, chip_size + 1):
+    for x in range(2, chip_size + 1):
         pre_node = graph_16[x, 1].get_sb(SwitchBoxSide.WEST,
                                          0,
                                          SwitchBoxIO.SB_IN)

--- a/test_interconnect/test_interconnect_cgra.py
+++ b/test_interconnect/test_interconnect_cgra.py
@@ -219,7 +219,7 @@ def test_interconnect_sram():
                                                                ren_port))
     sram_data = []
     # add SRAM data
-    for i in range(1024, 4):
+    for i in range(0, 1024, 4):
         feat_addr = i // 256 + 1
         mem_addr = i % 256
         sram_data.append((0x00000100 | mem_addr << 24 | feat_addr << 16,
@@ -250,7 +250,7 @@ def test_interconnect_sram():
     tester.poke(circuit.interface[ren], 1)
     tester.eval()
 
-    for i in range(1024, 4):
+    for i in range(0, 1024, 4):
         tester.poke(circuit.interface[src], i)
         tester.eval()
         tester.step(2)

--- a/test_interconnect/test_interconnect_cgra.py
+++ b/test_interconnect/test_interconnect_cgra.py
@@ -362,5 +362,7 @@ def create_cgra(chip_size: int, add_io: bool = False):
     lift_ports = margin == 0
     interconnect = Interconnect(ics, addr_width, data_width, tile_id_width,
                                 lift_ports=lift_ports)
+    # finalize the design
+    interconnect.finalize()
     apply_global_meso_wiring(interconnect, margin=margin)
     return interconnect

--- a/test_interconnect/test_io_tile.py
+++ b/test_interconnect/test_io_tile.py
@@ -1,0 +1,72 @@
+from fault.tester import Tester
+from interconnect.cyclone import *
+from interconnect.circuit import *
+from io_core.io1bit_magma import *
+from io_core.io16bit_magma import *
+import tempfile
+import fault
+import fault.random
+import pytest
+
+
+@pytest.mark.parametrize("bit_width", [1, 16])
+def test_io_tile(bit_width: int):
+    addr_width = 8
+    data_width = 32
+
+    tile_id_width = 16
+    x = 0
+    y = 0
+    num_tests = 100
+
+    if bit_width == 1:
+        io_core = IO1bit()
+    else:
+        assert bit_width == 16
+        io_core = IO16bit()
+    core = CoreInterface(io_core)
+
+    tiles: Dict[int, Tile] = {}
+
+    switchbox = SwitchBox(x, y, 0, bit_width, [])
+    tile = Tile(x, y, bit_width, switchbox)
+    tile.set_core(core)
+    tiles[bit_width] = tile
+
+    # fake the connections from other tiles's switchbox
+    sb_node_out = SwitchBoxNode(0, 1, 0, bit_width, SwitchBoxSide.NORTH,
+                                SwitchBoxIO.SB_OUT)
+    sb_node_in = SwitchBoxNode(0, 1, 0, bit_width, SwitchBoxSide.NORTH,
+                               SwitchBoxIO.SB_IN)
+    input_port_f = tile.ports["f2io"]
+    output_port_f = tile.ports["io2f"]
+    # add the connection
+    sb_node_out.add_edge(input_port_f)
+    output_port_f.add_edge(sb_node_in)
+
+    tile_circuit = TileCircuit(tiles, addr_width, data_width,
+                               tile_id_width=tile_id_width)
+
+    circuit = tile_circuit.circuit()
+    tile_id = fault.random.random_bv(tile_id_width)
+
+    # actual tests
+    tester = Tester(circuit)
+    tester.poke(circuit.tile_id, tile_id)
+    input_ports = [circuit.glb2io, circuit.f2io]
+    output_ports = [circuit.io2f, circuit.io2glb]
+
+    for i in range(num_tests):
+        for idx in range(2):
+            input_port = input_ports[idx]
+            output_port = output_ports[idx]
+            value = fault.random.random_bv(bit_width)
+            tester.poke(input_port, value)
+            tester.eval()
+            tester.expect(output_port, value)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        tester.compile_and_run(target="verilator",
+                               magma_output="coreir-verilog",
+                               directory=tempdir,
+                               flags=["-Wno-fatal"])

--- a/test_interconnect/test_io_tile.py
+++ b/test_interconnect/test_io_tile.py
@@ -38,8 +38,8 @@ def test_io_tile(bit_width: int):
                                 SwitchBoxIO.SB_OUT)
     sb_node_in = SwitchBoxNode(0, 1, 0, bit_width, SwitchBoxSide.NORTH,
                                SwitchBoxIO.SB_IN)
-    input_port_f = tile.ports["f2io"]
-    output_port_f = tile.ports["io2f"]
+    input_port_f = tile.ports[f"f2io_{bit_width}"]
+    output_port_f = tile.ports[f"io2f_{bit_width}"]
     # add the connection
     sb_node_out.add_edge(input_port_f)
     output_port_f.add_edge(sb_node_in)
@@ -53,8 +53,8 @@ def test_io_tile(bit_width: int):
     # actual tests
     tester = Tester(circuit)
     tester.poke(circuit.tile_id, tile_id)
-    input_ports = [circuit.glb2io, circuit.f2io]
-    output_ports = [circuit.io2f, circuit.io2glb]
+    input_ports = [circuit.glb2io, circuit.interface[f"f2io_{bit_width}"]]
+    output_ports = [circuit.interface[f"io2f_{bit_width}"], circuit.io2glb]
 
     for i in range(num_tests):
         for idx in range(2):

--- a/test_io_core/test_io16bit_magma.py
+++ b/test_io_core/test_io16bit_magma.py
@@ -12,10 +12,10 @@ def test_regression():
 
     for _glb2io, _f2io in [(random_bv(16), random_bv(16)) for _ in range(100)]:
         tester.poke(io16bit_circuit.glb2io, _glb2io)
-        tester.poke(io16bit_circuit.f2io, _f2io)
+        tester.poke(io16bit_circuit.f2io_16, _f2io)
         tester.eval()
         tester.expect(io16bit_circuit.io2glb, _f2io)
-        tester.expect(io16bit_circuit.io2f, _glb2io)
+        tester.expect(io16bit_circuit.io2f_16, _glb2io)
 
     with tempfile.TemporaryDirectory() as tempdir:
         tester.compile_and_run(target="verilator",

--- a/test_io_core/test_io1bit_magma.py
+++ b/test_io_core/test_io1bit_magma.py
@@ -13,10 +13,10 @@ def test_regression():
     for _glb2io in [BitVector(x, 1) for x in range(2**1)]:
         for _f2io in [BitVector(x, 1) for x in range(2**1)]:
             tester.poke(io1bit_circuit.glb2io, _glb2io)
-            tester.poke(io1bit_circuit.f2io, _f2io)
+            tester.poke(io1bit_circuit.f2io_1, _f2io)
             tester.eval()
             tester.expect(io1bit_circuit.io2glb, _f2io)
-            tester.expect(io1bit_circuit.io2f, _glb2io)
+            tester.expect(io1bit_circuit.io2f_1, _glb2io)
 
     with tempfile.TemporaryDirectory() as tempdir:
         tester.compile_and_run(target="verilator",

--- a/top/top_magma.py
+++ b/top/top_magma.py
@@ -56,6 +56,10 @@ class CGRA(generator.Generator):
         self.interconnect = Interconnect(ic_graphs, config_addr_width,
                                          config_data_width, tile_id_width,
                                          lift_ports=True)
+        # NOTE:
+        # add more passes before finalize the interconnect
+        # finalize the design
+        self.interconnect.finalize()
         # apply global wiring
         apply_global_meso_wiring(self.interconnect)
 


### PR DESCRIPTION
Built on top of #184. 

This PR refactor the feature code in such way that users can add extra features to the tile independently. The `TileCircuit` class is going to handle all the feature address allocation and wiring.

However, due to the nature of hardware creation, such flexibility requires a final function call to finalize the feature allocation. To do so, users need to call `tile.finalize()` to create the hardware wiring all the features.

An example can be seen in `pd-feature` branch.