### PR TITLE
Use archipelago for pnr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ mantle
 cosa
 fault
 hwtypes
+archipelago

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -96,7 +96,8 @@ def test_interconnect_line_buffer():
 
     # in this case we configure m0 as line buffer mode
     mem_x, mem_y = placement["m0"]
-    config_data.append((0x00000000 | (mem_x << 8 | mem_y), 0x00000004 | (depth << 3)))
+    config_data.append((0x00000000 | (mem_x << 8 | mem_y),
+                        0x00000004 | (depth << 3)))
     # then p0 is configured as add
     pe_x, pe_y = placement["p0"]
     config_data.append((0xFF000000 | (pe_x << 8 | pe_y), 0x000AF000))


### PR DESCRIPTION
`archipelago` is a python interface for two native Python bindings:
1. `pythunder` for placement: https://pypi.org/project/pythunder/
2. `pycyclone` for route: https://pypi.org/project/pycyclone/

`archipelago` is written purely in Python and can be installed via
```
pip install archipelago
```

This PR mainly replace all the manual routes with the automatic pnr function call.
```
placement, routing = pnr(interconnect, (netlist, bus))
```