### PR TITLE
Readme and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+# -u means just give me the name, don't create anything
+# TMDIR := $(shell mktemp -u old_design_XXX)
+
+# E.g. CLEANDIR=
+TIMESTAMP := $(shell date +%y%m%d_%H%M)
+CLEANDIR  := old_design_$(TIMESTAMP)
+
+
+GENESIS_CORE_FILES := \
+    genesis.log \
+    genesis_work/ \
+    genesis_raw/ \
+    genesis_verif/ \
+    genesis_synth/ \
+    genesis_vlog.vf \
+    genesis_vlog.synth.vf \
+    genesis_vlog.verif.vf \
+    genesis_clean.cmd
+
+GENESIS_ADJUNCT_FILES := \
+    MEMmemory_core \
+    PEtest_pe \
+    PECOMPtest_pe_comp_unq1 \
+    REGMODEtest_opt_reg_file \
+    REGMODEtest_opt_reg
+
+GARNET_FILES := \
+    garnet.v \
+    garnet.json \
+    __pycache__/ \
+    parser.out \
+    parsetab.py
+
+clean:
+	@echo Building cleanup dir $(CLEANDIR)...
+	mkdir $(CLEANDIR)
+	@echo ""
+
+	@echo Moving core Genesis files...
+	@echo mv $(GENESIS_CORE_FILES) $(CLEANDIR)/ | fold -s | sed 's/^/  /'
+	@mv $(GENESIS_CORE_FILES) $(CLEANDIR)/
+	@echo ""
+
+	@echo Moving build-specific Genesis files...
+	@echo mv $(GENESIS_ADJUNCT_FILES) $(CLEANDIR)/ | fold -s | sed 's/^/  /'
+	@mv $(GENESIS_ADJUNCT_FILES) $(CLEANDIR)/
+	@echo ""
+
+	@echo Moving Garnet files...
+	@echo mv $(GARNET_FILES) $(CLEANDIR)/ | fold -s | sed 's/^/  /'
+	mv $(GARNET_FILES) $(CLEANDIR)/
+	@echo ""
+
+	ls -l $(CLEANDIR)
+
+test:
+	pytest
+
+pytest:
+	pytest
+
+build:
+	@echo "Example build:"
+	@echo "  python garnet.py --width 2 --height 2"
+	@echo ""
+
+help:
+	@echo "For help do this:"
+	@echo "  python garnet.py --help"
+	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: test help build
 # -u means just give me the name, don't create anything
 # TMDIR := $(shell mktemp -u old_design_XXX)
 
-# E.g. CLEANDIR=
+# E.g. CLEANDIR="old_design_190422_0858/"
 TIMESTAMP := $(shell date +%y%m%d_%H%M)
 CLEANDIR  := old_design_$(TIMESTAMP)
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: test help build
+
 # -u means just give me the name, don't create anything
 # TMDIR := $(shell mktemp -u old_design_XXX)
 
@@ -48,16 +50,16 @@ clean:
 
 	@echo Moving Garnet files...
 	@echo mv $(GARNET_FILES) $(CLEANDIR)/ | fold -s | sed 's/^/  /'
-	mv $(GARNET_FILES) $(CLEANDIR)/
+	@mv $(GARNET_FILES) $(CLEANDIR)/
 	@echo ""
 
 	ls -l $(CLEANDIR)
 
+pytest: test
 test:
-	pytest
-
-pytest:
-	pytest
+	@echo "To test your installation simply do:"
+	@echo "  pytest"
+	@echo ""
 
 build:
 	@echo "Example build:"

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ build:
 	@echo "Example build:"
 	@echo "  python garnet.py --width 2 --height 2"
 	@echo ""
+	@echo "To clean up after building a design (moves the entire design to a subdirectory)"
+	@echo "  make clean"
+	@echo ""
 
 help:
 	@echo "For help do this:"

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ build:
 	@echo "Example build:"
 	@echo "  python garnet.py --width 2 --height 2"
 	@echo ""
-	@echo "To clean up after building a design (moves the entire design to a subdirectory)"
+	@echo "To clean up after building a design (moves the entire design to a subdirectory):"
 	@echo "  make clean"
 	@echo ""
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 The main purpose of this repo is to investigate and experiment with implementing our CGRA using new generator infrastructure. You will find in this repo: the original Genesis2 source for top level modules, functional models, and testing infrastructure. Also, you will find common generator patterns abstracted away to make designing, testing, and programming the CGRA faster.
 
 # Usage
-Once garnet is installed, you can build it simply by doing e.g.
-```$ python garnet.py --width 2 --height 2```
+Once garnet is installed, you can build e.g. a 2x2 design simply by doing
+```
+$ python garnet.py --width 2 --height 2
+```
 
 For installation instructions, read on.
-
 If you're using the Kiwi machine, see [this wiki page](https://github.com/rsetaluri/magma_cgra/wiki/Kiwi-Environment) for info on getting your python environment setup. If you use the shared Python environment, you do not need to run the pip install command.
 
 ## Install CoreIR

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 The main purpose of this repo is to investigate and experiment with implementing our CGRA using new generator infrastructure. You will find in this repo: the original Genesis2 source for top level modules, functional models, and testing infrastructure. Also, you will find common generator patterns abstracted away to make designing, testing, and programming the CGRA faster.
 
 # Usage
-Once garnet is installed, you can build e.g. a 2x2 design simply by doing
+Once garnet is installed, you can build e.g. a 2x2 CGRA simply by doing
 ```
+$ python garnet.py --help
 $ python garnet.py --width 2 --height 2
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 The main purpose of this repo is to investigate and experiment with implementing our CGRA using new generator infrastructure. You will find in this repo: the original Genesis2 source for top level modules, functional models, and testing infrastructure. Also, you will find common generator patterns abstracted away to make designing, testing, and programming the CGRA faster.
 
 # Usage
+Once garnet is installed, you can build it simply by doing e.g.
+```$ python garnet.py --width 2 --height 2```
+
+For installation instructions, read on.
+
 If you're using the Kiwi machine, see [this wiki page](https://github.com/rsetaluri/magma_cgra/wiki/Kiwi-Environment) for info on getting your python environment setup. If you use the shared Python environment, you do not need to run the pip install command.
 
 ## Install CoreIR


### PR DESCRIPTION
For your consideration:
* I added a couple of lines to the README, see diff for details
* I wanted a "make clean" so I built a Makefile; and then since I already had the makefile I added rudimentary targets for test, pytest, build and help.

Default "make" command with no args does this:
```
$ make
To test your installation simply do:
  pytest

For help do this:
  python garnet.py --help

Example build:
  python garnet.py --width 2 --height 2
```

"make clean" does this:
```
$ make clean
Building cleanup dir old_design_190422_0858/...

Moving core Genesis files...
  mv genesis.log genesis_work/ genesis_raw/ genesis_verif/ genesis_synth/ 
  genesis_vlog.vf genesis_vlog.synth.vf genesis_vlog.verif.vf genesis_clean.cmd 
  old_design_190422_0858/

Moving build-specific Genesis files...
  mv MEMmemory_core PEtest_pe PECOMPtest_pe_comp_unq1 REGMODEtest_opt_reg_file 
  REGMODEtest_opt_reg old_design_190422_0858/

Moving Garnet files...
  mv garnet.v garnet.json __pycache__/ parser.out parsetab.py 
  old_design_190422_0858/
```