### PR TITLE
Use the new semantics of canal io creation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e git://github.com/phanrahan/pe.git#egg=pe
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git@new_io#egg=canal
+-e git://github.com/StanfordAHA/canal.git#egg=canal
 ordered_set
 magma-lang
 mantle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e git://github.com/phanrahan/pe.git#egg=pe
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git#egg=canal
+-e git://github.com/StanfordAHA/canal.git@new_io#egg=canal
 ordered_set
 magma-lang
 mantle

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -5,7 +5,7 @@ import os
 from gemstone.common.testers import BasicTester
 from canal.global_signal import apply_global_meso_wiring
 from canal.interconnect import Interconnect
-from canal.util import create_uniform_interconnect, SwitchBoxType
+from canal.util import create_uniform_interconnect, SwitchBoxType, IOSide
 from memory_core.memory_core_magma import MemCore
 from pe_core.pe_core_magma import PECore
 from canal.cyclone import SwitchBoxSide, SwitchBoxIO
@@ -32,7 +32,7 @@ def test_interconnect_point_wise(batch_size: int):
     }
     bus = {"e0": 16, "e1": 16, "e3": 16}
 
-    placement, routing = pnr(interconnect, (netlist, bus))
+    placement, routing = pnr(interconnect, (netlist, bus), cwd="temp")
     config_data = interconnect.get_route_bitstream(routing)
 
     x, y = placement["p0"]
@@ -227,6 +227,8 @@ def create_cgra(chip_size: int, add_io: bool = False):
     tile_id_width = 16
     track_length = 1
     margin = 0 if not add_io else 1
+    sides = (IOSide.North | IOSide.East | IOSide.South | IOSide.West) \
+        if add_io else IOSide.None_
     chip_size += 2 * margin
     # recalculate the margin
     # creates all the cores here
@@ -302,7 +304,7 @@ def create_cgra(chip_size: int, add_io: bool = False):
                                          {track_length: num_tracks},
                                          SwitchBoxType.Disjoint,
                                          pipeline_regs,
-                                         margin=margin,
+                                         io_sides=sides,
                                          io_conn=io_conn)
         ics[bit_width] = ic
 

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -32,7 +32,7 @@ def test_interconnect_point_wise(batch_size: int):
     }
     bus = {"e0": 16, "e1": 16, "e3": 16}
 
-    placement, routing = pnr(interconnect, (netlist, bus), cwd="temp")
+    placement, routing = pnr(interconnect, (netlist, bus))
     config_data = interconnect.get_route_bitstream(routing)
 
     x, y = placement["p0"]


### PR DESCRIPTION
Update the new IO semantics so that we can add IOs to the north side only. Need it to unblock Taeyoung.

I'll change `canal` remote once it gets approved there: https://github.com/StanfordAHA/canal/pull/3