### PR TITLE
make it so that jtag can control GC regardless of axi

### DIFF
--- a/global_controller/genesis/global_controller.svp
+++ b/global_controller/genesis/global_controller.svp
@@ -122,7 +122,7 @@ parameter cgra_start = `$cfg_op_width`'d20;
 parameter config_start = `$cfg_op_width`'d21;
 
 // jtag opcode has priority over axi opcode if they overlap
-assign op = ((op_axi != NOP) && (op_jtag != NOP)) ? op_jtag : op_axi;
+assign op = (op_jtag != NOP) ? op_jtag : op_axi;
 
 //STATES FOR IGNORING INCOMING INSTRUCTIONS
 parameter ready = 3'd0;


### PR DESCRIPTION
The fixes a bug in the recent modifications to the global controller. Logic was inserted to choose between instructions coming in over JTAG and those coming in through AXI. The old logic only accepted a JTAG instruction when an AXI instruction was also present, which is not correct. This fixes that.

@kong0329 also the op_axi wire is floating. What is it supposed to be connected to?