### PR TITLE
Add pe caching

### DIFF
--- a/peak_core/peak_core.py
+++ b/peak_core/peak_core.py
@@ -20,14 +20,21 @@ def _convert_type(typ):
 
 
 class _PeakWrapper:
+    pe = None
+    circuit = None
+
     def __init__(self, peak_generator):
-        pe = peak_generator(hwtypes.BitVector.get_family())
+        if _PeakWrapper.pe is None:
+            _PeakWrapper.pe = peak_generator(hwtypes.BitVector.get_family())
+        pe = _PeakWrapper.pe
         assert issubclass(pe, peak.Peak)
         pe = pe.__call__
         (self.__instr_name, self.__instr_type) = pe._peak_isa_
         self.__inputs = pe._peak_inputs_
         self.__outputs = pe._peak_outputs_
-        circuit = peak_generator(magma.get_family())
+        if _PeakWrapper.circuit is None:
+            _PeakWrapper.circuit = peak_generator(magma.get_family())
+        circuit = _PeakWrapper.circuit
         self.__asm, disasm, self.__instr_width, layout = \
             peak.auto_assembler.generate_assembler(self.__instr_type)
         instr_magma_type = type(circuit.interface.ports[self.__instr_name])

--- a/peak_core/peak_core.py
+++ b/peak_core/peak_core.py
@@ -20,21 +20,14 @@ def _convert_type(typ):
 
 
 class _PeakWrapper:
-    pe = None
-    circuit = None
-
     def __init__(self, peak_generator):
-        if _PeakWrapper.pe is None:
-            _PeakWrapper.pe = peak_generator(hwtypes.BitVector.get_family())
-        pe = _PeakWrapper.pe
+        pe = peak_generator(hwtypes.BitVector.get_family())
         assert issubclass(pe, peak.Peak)
         pe = pe.__call__
         (self.__instr_name, self.__instr_type) = pe._peak_isa_
         self.__inputs = pe._peak_inputs_
         self.__outputs = pe._peak_outputs_
-        if _PeakWrapper.circuit is None:
-            _PeakWrapper.circuit = peak_generator(magma.get_family())
-        circuit = _PeakWrapper.circuit
+        circuit = peak_generator(magma.get_family())
         self.__asm, disasm, self.__instr_width, layout = \
             peak.auto_assembler.generate_assembler(self.__instr_type)
         instr_magma_type = type(circuit.interface.ports[self.__instr_name])

--- a/peak_core/peak_core.py
+++ b/peak_core/peak_core.py
@@ -19,7 +19,19 @@ def _convert_type(typ):
     return magma.Bits[typ.size]
 
 
-class _PeakWrapper:
+class _PeakWrapperMeta(type):
+    _cache = {}
+
+    def __call__(cls, peak_generator):
+        key = id(peak_generator)
+        if key in _PeakWrapperMeta._cache:
+            return _PeakWrapperMeta._cache[key]
+        self = super().__call__(peak_generator)
+        _PeakWrapperMeta._cache[key] = self
+        return self
+
+
+class _PeakWrapper(metaclass=_PeakWrapperMeta):
     def __init__(self, peak_generator):
         pe = peak_generator(hwtypes.BitVector.get_family())
         assert issubclass(pe, peak.Peak)


### PR DESCRIPTION
This is a quick and dirty way to cache all the PE and magma circuit generation from peak. In the long run this should be handled in lassen.