### PR TITLE
Add a pass to extract all interconnect touchable registers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,5 @@ install:
 script:
     - docker exec -i garnet bash -c "/garnet/.travis/run.sh"
 
-
 after_success:
     - docker exec -i garnet bash -c "cd /garnet/ && coveralls"

--- a/collateral_pass/config_register.py
+++ b/collateral_pass/config_register.py
@@ -1,0 +1,63 @@
+from canal.circuit import get_mux_sel_name
+from canal.interconnect import Interconnect
+
+
+def get_interconnect_regs(interconnect: Interconnect):
+    """function to loop through every interconnect object and dump the
+    entire configuration space
+    """
+    result = []
+    for x, y in interconnect.tile_circuits:
+        tile = interconnect.tile_circuits[(x, y)]
+        # cb first
+        for cb_name, cb in tile.cbs.items():
+            # get the index
+            index = tile.features().index(cb)
+            # reg space is always 0 for CB
+            reg_addr = 0
+            # need to get range
+            # notice that we may already replace the mux with aoi + const
+            # so we need to get the height from the actual mux
+            mux = cb.mux
+            mux_range = mux.height
+            config_addr = interconnect.get_config_addr(reg_addr, index,
+                                                       x, y)
+            result.append({
+                "name": cb_name,
+                "addr": config_addr,
+                "range": mux_range
+            })
+
+        for switchbox in tile.sbs.values():
+            index = tile.features().index(switchbox)
+            # sort the reg names
+            reg_names = list(switchbox.registers.keys())
+            reg_names.sort()
+            for sb, sb_mux in switchbox.sb_muxs.values():
+                if sb_mux.height > 1:
+                    config_name = get_mux_sel_name(sb)
+                    assert config_name in reg_names
+                    reg_addr = reg_names.index(config_name)
+                    mux_range = sb_mux.height
+                    config_addr = interconnect.get_config_addr(reg_addr, index,
+                                                               x, y)
+                    result.append({
+                        "name": str(sb),
+                        "addr": config_addr,
+                        "range": mux_range
+                    })
+            for node, reg_mux in switchbox.reg_muxs.values():
+                if reg_mux.height > 1:
+                    config_name = get_mux_sel_name(node)
+                    assert config_name in reg_names
+                    reg_addr = reg_names.index(config_name)
+                    mux_range = reg_mux.height
+                    config_addr = interconnect.get_config_addr(reg_addr, index,
+                                                               x, y)
+                    result.append({
+                        "name": str(node),
+                        "addr": config_addr,
+                        "range": mux_range
+                    })
+
+        return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e git://github.com/phanrahan/pe.git#egg=pe
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git#egg=canal
+-e git://github.com/StanfordAHA/canal.git@unified_bitstream#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e git://github.com/phanrahan/pe.git#egg=pe
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git@unified_bitstream#egg=canal
+-e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper

--- a/tests/test_collateral_pass/test_config_reg.py
+++ b/tests/test_collateral_pass/test_config_reg.py
@@ -10,7 +10,6 @@ def test_config_register():
     ic = create_cgra(2, 2, sides, global_signal_wiring=GlobalSignalWiring.Meso)
 
     with tempfile.TemporaryDirectory() as tempdir:
-        tempdir = "temp"
         filename = os.path.join(tempdir, "config.json")
         result = get_interconnect_regs(ic)
         with open(filename, "w+") as f:

--- a/tests/test_collateral_pass/test_config_reg.py
+++ b/tests/test_collateral_pass/test_config_reg.py
@@ -1,0 +1,17 @@
+import tempfile
+import os
+import json
+from cgra.util import create_cgra, IOSide, GlobalSignalWiring
+from collateral_pass.config_register import get_interconnect_regs
+
+
+def test_config_register():
+    sides = IOSide.North
+    ic = create_cgra(2, 2, sides, global_signal_wiring=GlobalSignalWiring.Meso)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        tempdir = "temp"
+        filename = os.path.join(tempdir, "config.json")
+        result = get_interconnect_regs(ic)
+        with open(filename, "w+") as f:
+            json.dump(result, f)


### PR DESCRIPTION
Per @thenextged's request, this pass dumps all the touchable registers used in the interconnect. We will use this collateral pass to test soc and global controller.