### PR TITLE
fix pe inputs outputs ordering

### DIFF
--- a/peak_core/peak_core.py
+++ b/peak_core/peak_core.py
@@ -131,10 +131,16 @@ class PeakCore(ConfigurableCore):
         return self.wrapper.instruction_type()
 
     def inputs(self):
-        return [self.ports[name] for name in self.wrapper.inputs()]
+        names = [name for name in self.wrapper.inputs()]
+        names.sort()
+        result = [self.ports[name] for name in names]
+        return result
 
     def outputs(self):
-        return [self.ports[name] for name in self.wrapper.outputs()]
+        names = [name for name in self.wrapper.outputs()]
+        names.sort()
+        result = [self.ports[name] for name in names]
+        return result
 
     def pnr_info(self):
         # PE has highest priority


### PR DESCRIPTION
For some reason peak gives the interconnect inconsistent ordering of ports during multiple runs. In Python 3.7 `dict` should be in order by default. I'm guessing there is a bug either in Python or the peak logic that prevent this in-order logic. The dictionary is created from function decorator, which may cause this bug:

https://github.com/phanrahan/peak/blob/810cbad3a817e82afdaf4ada4fa5030c80be040f/peak/peak.py#L8

https://github.com/phanrahan/peak/blob/49e415e7e1e0358361db9d3cfd884576c91b150e/peak/alu/sim.py#L25