### PR TITLE
Use docker container to run the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,13 @@ install:
 
     - git clone https://github.com/StanfordVLSI/Genesis2.git
     - rm -rf Genesis2/Genesis2Tools/PerlLibs/ExtrasForOldPerlDistributions/Compress
-    - docker cp Genesis2 garnet:/
+    - docker cp Genesis2 garnet:/Genesis2
     # Set env variables for genesis (installed earlier)
-    - docker exec -i garnet bash -c "export GENESIS_HOME=/Genesis2/Genesis2Tools"
-    - docker exec -i garnet bash -c "export PATH=$GENESIS_HOME/bin:$GENESIS_HOME/gui/bin:$PATH"
-    - docker exec -i garnet bash -c "export PERL5LIB=$GENESIS_HOME/PerlLibs/ExtrasForOldPerlDistributions:$PERL5LIB"
+    - docker exec -i garnet bash -c 'source /garnet/.travis/genesis_env.sh'
 
 script:
-    - docker exec -i garnet bash -c "cd /garnet/ && pytest --codestyle
+    - docker exec -i garnet bash -c "source /garnet/.travis/genesis_env.sh && \
+                                     cd /garnet/ && pytest --codestyle
                                      --cov global_controller
                                      --cov io_core
                                      --cov memory_core

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ install:
     - docker run -d -it --name garnet keyiz/garnet-flow bash
     - docker cp ../garnet garnet:/
     - docker exec -i garnet bash -c "pip install -r /garnet/requirements.txt" 
-    - docker exec -i garnet bash -c "pip install pytest python-coveralls pytest-cov pytest-codestyle z3-solver" 
+    - docker exec -i garnet bash -c "pip install pytest python-coveralls"
+    - docker exec -i garnet bash -c "pip install pytest-cov pytest-codestyle z3-solver" 
     # check CoSA dependencies
     - docker exec -i garnet bash -c "pysmt-install --check"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,9 @@ install:
     - git clone https://github.com/StanfordVLSI/Genesis2.git
     - rm -rf Genesis2/Genesis2Tools/PerlLibs/ExtrasForOldPerlDistributions/Compress
     - docker cp Genesis2 garnet:/Genesis2
-    # Set env variables for genesis (installed earlier)
-    - docker exec -i garnet bash -c 'source /garnet/.travis/genesis_env.sh'
 
 script:
-    - docker exec -i garnet bash -c "source /garnet/.travis/genesis_env.sh && \
-                                     cd /garnet/ && pytest --codestyle
-                                     --cov global_controller
-                                     --cov io_core
-                                     --cov memory_core
-                                     --ignore=filecmp.py
-                                     --ignore=Genesis2/
-                                     -v --cov-report term-missing tests"
+    - docker exec -i garnet bash -c "/garnet/.travis/run.sh"
 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,57 +1,33 @@
-language: python
-addons:
-  apt:
-    packages:
-    - verilator
-    - verilog
-# python:
-#     - "3.6"
+dist: xenial
+language: minimal
+service: docker
 
 install:
-    # install conda for py 3.7
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b -p $TRAVIS_BUILD_DIR/miniconda
-    - export PATH=$TRAVIS_BUILD_DIR/miniconda/bin:$PATH
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    - conda create -q -n test-env python=3.7
-    - source activate test-env
-    - conda install pip
-    # End install conda
-
-    - pip install -r requirements.txt
-    - pip install pytest
-    - pip install python-coveralls
-    - pip install pytest-cov pytest-codestyle
-    # NOTE(rsetaluri): We no longer need to install this directory.
-    #- pip install -e .
-
-    # Begin setup CoSA dependencies
-    - pysmt-install --z3 --confirm-agreement
-    - export PYTHONPATH="/home/travis/.smt_solvers/python-bindings-3.6:${PYTHONPATH}"
-    - export LD_LIBRARY_PATH="/home/travis/.smt_solvers/python-bindings-3.6:${LD_LIBRARY_PATH}"
-    - pysmt-install --check
-    # End setup CoSA dependencies
-
+    - docker pull keyiz/garnet-flow
+    - docker run -d -it --name garnet keyiz/garnet-flow bash
+    - docker cp ../garnet garnet:/
+    - docker exec -i garnet bash -c "pip install -r /garnet/requirements.txt" 
+    - docker exec -i garnet bash -c "pip install pytest python-coveralls pytest-dov pytest-codestyle z3-solver" 
+    # check CoSA dependencies
+    - docker exec -i garnet bash -c "pysmt-install --check"
 
     - git clone https://github.com/StanfordVLSI/Genesis2.git
     - rm -rf Genesis2/Genesis2Tools/PerlLibs/ExtrasForOldPerlDistributions/Compress
+    - docker cp Genesis2 garnet:/
     # Set env variables for genesis (installed earlier)
-    - export GENESIS_HOME=`pwd`/Genesis2/Genesis2Tools
-    - export PATH=$GENESIS_HOME/bin:$GENESIS_HOME/gui/bin:$PATH
-    - export PERL5LIB=$GENESIS_HOME/PerlLibs/ExtrasForOldPerlDistributions:$PERL5LIB
+    - docker exec -i garnet bash -c "export GENESIS_HOME=/Genesis2/Genesis2Tools"
+    - docker exec -i garnet bash -c "export PATH=$GENESIS_HOME/bin:$GENESIS_HOME/gui/bin:$PATH"
+    - docker exec -i garnet bash -c "export PERL5LIB=$GENESIS_HOME/PerlLibs/ExtrasForOldPerlDistributions:$PERL5LIB"
 
 script:
-    - pytest --codestyle
-             --cov global_controller
-             --cov io_core
-             --cov memory_core
-             --ignore=filecmp.py
-             --ignore=Genesis2/
-             -v --cov-report term-missing tests
+    - docker exec -i garnet bash -c "cd /garnet/ && pytest --codestyle
+                                     --cov global_controller
+                                     --cov io_core
+                                     --cov memory_core
+                                     --ignore=filecmp.py
+                                     --ignore=Genesis2/
+                                     -v --cov-report term-missing tests"
 
 
 after_success:
-    - coveralls
+    - docker exec -i garnet bash -c "cd /garnet/ && coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - docker run -d -it --name garnet keyiz/garnet-flow bash
     - docker cp ../garnet garnet:/
     - docker exec -i garnet bash -c "pip install -r /garnet/requirements.txt" 
-    - docker exec -i garnet bash -c "pip install pytest python-coveralls pytest-dov pytest-codestyle z3-solver" 
+    - docker exec -i garnet bash -c "pip install pytest python-coveralls pytest-cov pytest-codestyle z3-solver" 
     # check CoSA dependencies
     - docker exec -i garnet bash -c "pysmt-install --check"
 

--- a/.travis/genesis_env.sh
+++ b/.travis/genesis_env.sh
@@ -1,4 +1,0 @@
-# add Genesis to the path
-export GENESIS_HOME=/Genesis2/Genesis2Tools
-export PATH=$GENESIS_HOME/bin:$GENESIS_HOME/gui/bin:$PATH
-export PERL5LIB=$GENESIS_HOME/PerlLibs/ExtrasForOldPerlDistributions:$PERL5LIB

--- a/.travis/genesis_env.sh
+++ b/.travis/genesis_env.sh
@@ -1,0 +1,4 @@
+# add Genesis to the path
+export GENESIS_HOME=/Genesis2/Genesis2Tools
+export PATH=$GENESIS_HOME/bin:$GENESIS_HOME/gui/bin:$PATH
+export PERL5LIB=$GENESIS_HOME/PerlLibs/ExtrasForOldPerlDistributions:$PERL5LIB

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,14 @@
+# add Genesis to the path
+export GENESIS_HOME=/Genesis2/Genesis2Tools
+export PATH=$GENESIS_HOME/bin:$GENESIS_HOME/gui/bin:$PATH
+export PERL5LIB=$GENESIS_HOME/PerlLibs/ExtrasForOldPerlDistributions:$PERL5LIB
+
+cd /garnet/
+
+pytest --codestyle          \
+    --cov global_controller \
+    --cov io_core           \
+    --cov memory_core       \
+    --ignore=filecmp.py     \
+    --ignore=Genesis2/      \
+    -v --cov-report term-missing tests

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,6 +3,9 @@ export GENESIS_HOME=/Genesis2/Genesis2Tools
 export PATH=$GENESIS_HOME/bin:$GENESIS_HOME/gui/bin:$PATH
 export PERL5LIB=$GENESIS_HOME/PerlLibs/ExtrasForOldPerlDistributions:$PERL5LIB
 
+# force color
+export PYTEST_ADDOPTS="--color=yes"
+
 cd /garnet/
 
 pytest --codestyle          \


### PR DESCRIPTION
Pros:
1. Same environment as `GarnetFlow`
2. Latest `Python` (3.7.3), `verilator` (4.010), `gcc` (8.3). No need to resort to `miniconda` or other ppa to have latest `verilator`.
3. Easy to reproduce locally since it's the same environment.

Cons:
Can't think of any.

This will also unblock @kong0329 to merge in global controller tests. See: https://github.com/StanfordAHA/garnet/issues/241.