### PR TITLE
Speed up the garnet creation by 30%

### DIFF
--- a/power_domain/pd_pass.py
+++ b/power_domain/pd_pass.py
@@ -45,22 +45,44 @@ def add_power_domain(interconnect: Interconnect):
     for (x, y) in interconnect.tile_circuits:
         tile = interconnect.tile_circuits[(x, y)]
         for bit_width, sb in tile.sbs.items():
+            # we need more efficient implementation for a simple replacement
+            # pass. in other words, instead of an O(n^2) implementation, we
+            # hand-crafted an O(n) with smaller constants
             sb_muxs = sb.sb_muxs
+            mux_table = {}
             for _, (node, old_mux) in sb_muxs.items():
                 assert node.width == bit_width
                 new_mux = AOIMuxWrapper(old_mux.height, bit_width,
                                         AOIMuxType.Regular,
                                         old_mux.instance_name)
-                # replace it!
-                replace(sb, old_mux, new_mux)
+                mux_table[old_mux] = new_mux
+
             reg_mux = sb.reg_muxs
             for _, (node, old_mux) in reg_mux.items():
                 assert node.width == bit_width
                 new_mux = AOIMuxWrapper(old_mux.height, bit_width,
                                         AOIMuxType.Regular,
                                         old_mux.instance_name)
-                # replace it!
-                replace(sb, old_mux, new_mux)
+                mux_table[old_mux] = new_mux
+
+            assert len(mux_table) == len(sb_muxs) + len(reg_mux)
+            wires = set()
+            for conn1, conn2 in sb.wires:
+                if conn1.owner() in mux_table or conn2.owner() in mux_table:
+                    wires.add((conn1, conn2))
+            for conn1, conn2 in wires:
+                # avoid O(n) search to remove the wires. this is safe
+                # since we directly load these connection in sorted order
+                sb.wires.remove((conn1, conn2))
+
+            for conn1, conn2 in wires:
+                conn1_owner = conn1.owner()
+                conn2_owner = conn2.owner()
+                if conn1_owner in mux_table:
+                    conn1 = conn1.get_port(mux_table[conn1_owner].ports)
+                if conn2_owner in mux_table:
+                    conn2 = conn2.get_port(mux_table[conn2_owner].ports)
+                sb.wire(conn1, conn2)
         # cb is const aoi
         for _, cb in tile.cbs.items():
             old_mux = cb.mux


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6099149/57990274-ea1da480-7a59-11e9-8b36-8d903128fcd1.png)


After:
![image](https://user-images.githubusercontent.com/6099149/57990280-f30e7600-7a59-11e9-958f-72c670037676.png)

Due to the newly introduced hashing function on the `PortReference`, i.e. using owner names, the runtime to generate `32x16` is about 2.5 minutes. That is, we increase lots of overhead to ensure the caching is safe.

This PR along with the improvement in magma (https://github.com/phanrahan/magma/pull/397) will bring down the runtime to less than 2 minutes again.

What happened here:
- The `replace` itself is <img src="https://latex.codecogs.com/svg.latex?O%28n%29">, where `n` is the number of connections.
- Each mux in the switch box will be replaced using `replace`, which effectively makes it <img src="https://latex.codecogs.com/svg.latex?O%28n%5E2%29">, assuming each mux has a fixed number of connections.

How to fix them:
- By understanding how these muxes are created, we can effectively reduce the complexity back to <img src="https://latex.codecogs.com/svg.latex?O%28n%29">.
- However, this hard-crafted replacement algorithm does not apply to other more generic cases, in which I highly recommend to use `replace` pass.