### PR TITLE
Verilog pointers for Fault tests

### DIFF
--- a/tests/AN2D0BWP16P90.sv
+++ b/tests/AN2D0BWP16P90.sv
@@ -1,0 +1,6 @@
+module AN2D0BWP16P90 ( 
+input logic  A1, 
+input logic  A2, 
+output logic  Z); 
+assign Z = (A1 & A2); 
+endmodule  

--- a/tests/AO22D0BWP16P90.sv
+++ b/tests/AO22D0BWP16P90.sv
@@ -1,0 +1,9 @@
+module AO22D0BWP16P90 ( 
+input logic  A1,
+input logic  A2, 
+input logic  B1, 
+input logic  B2, 
+output logic  Z);  
+assign Z = ((A1 & A2) | (B1 & B2)); 
+endmodule 
+

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -93,7 +93,7 @@ def test_interconnect_point_wise(batch_size: int, cw_files, add_pd, io_sides):
                                  "sram_stub.v"),
                     os.path.join(tempdir, "sram_512w_16b.v"))
         for aoi_mux in glob.glob("tests/*.sv"):
-            shutil.copy(aoi_mux, tempdir) 
+            shutil.copy(aoi_mux, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -92,6 +92,8 @@ def test_interconnect_point_wise(batch_size: int, cw_files, add_pd, io_sides):
         shutil.copy(os.path.join("tests", "test_memory_core",
                                  "sram_stub.v"),
                     os.path.join(tempdir, "sram_512w_16b.v"))
+        for aoi_mux in glob.glob("tests/*.sv"):
+            shutil.copy(aoi_mux, tempdir) 
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,
@@ -168,6 +170,8 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
         shutil.copy(os.path.join("tests", "test_memory_core",
                                  "sram_stub.v"),
                     os.path.join(tempdir, "sram_512w_16b.v"))
+        for aoi_mux in glob.glob("tests/*.sv"):
+            shutil.copy(aoi_mux, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,
@@ -249,6 +253,8 @@ def test_interconnect_sram(cw_files, add_pd, io_sides):
         shutil.copy(os.path.join("tests", "test_memory_core",
                                  "sram_stub.v"),
                     os.path.join(tempdir, "sram_512w_16b.v"))
+        for aoi_mux in glob.glob("tests/*.sv"):
+            shutil.copy(aoi_mux, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,

--- a/tests/test_interconnect/test_reset.py
+++ b/tests/test_interconnect/test_reset.py
@@ -92,6 +92,8 @@ def test_interconnect_reset(batch_size: int, cw_files, add_pd, io_sides):
         shutil.copy(os.path.join("tests", "test_memory_core",
                                  "sram_stub.v"),
                     os.path.join(tempdir, "sram_512w_16b.v"))
+        for aoi_mux in glob.glob("tests/*.sv"):
+            shutil.copy(aoi_mux, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,


### PR DESCRIPTION
Add verilog files needed for Fault tests. Add the verilog pointers to the test files.