### PR TITLE
Mem core fixes

### DIFF
--- a/memory_core/genesis_new/fifo_control.svp
+++ b/memory_core/genesis_new/fifo_control.svp
@@ -124,40 +124,38 @@ assign cen_mem[`$i`] = ren_mem[`$i`] | wen_mem_en[`$i`];
 // Status signals
 // ================
 //; for(my $idx = $bbanks-1; $idx > 0; $idx--) {
-	assign ren_mem[`$idx`] = ren & ((read_addr[`$bank_addr_width-1`:0]) == `$idx`);
+   assign ren_mem[`$idx`] = ren & ((read_addr[`$bank_addr_width-1`:0]) == `$idx`);
 //; }   
-	assign ren_mem[0] = ren & ((read_addr[`$bank_addr_width-1`:0] == 0) | init_stage);
+   assign ren_mem[0] = ren & ((read_addr[`$bank_addr_width-1`:0] == 0) | init_stage);
 
 //; for(my $i = $bbanks-1; $i > 0; $i--) {
-	assign wen_mem[`$i`] = wen & ((write_addr[`$bank_addr_width-1`]) == `$i`);
+   assign wen_mem[`$i`] = wen & ((write_addr[`$bank_addr_width-1`]) == `$i`);
 //; }
-	assign wen_mem[0] = wen & ((write_addr[`$bank_addr_width-1`:0] == 0) | init_stage);
+  assign wen_mem[0] = wen & ((write_addr[`$bank_addr_width-1`:0] == 0) | init_stage);
 
 //; for(my $i = 0; $i < $bbanks; $i++) {
-	assign wen_mem_en[`$i`] = (wen_mem[`$i`] & ~(same_bank[`$i`])) | write_buffed[`$i`];
+   assign wen_mem_en[`$i`] = (wen_mem[`$i`] & ~(same_bank[`$i`])) | write_buffed[`$i`];
 //; }
 
 //; for(my $i = 0; $i < $bbanks; $i++) {
-	assign fifo_to_mem_data[`$i`] = write_buffed[`$i`] ? write_buff[`$i`] : data_in;
+   assign fifo_to_mem_data[`$i`] = write_buffed[`$i`] ? write_buff[`$i`] : data_in;
 //; }
 //; for(my $i = 0; $i < $bbanks; $i++) {
-	assign fifo_to_mem_cen[`$i`] = cen_mem[`$i`];
+   assign fifo_to_mem_cen[`$i`] = cen_mem[`$i`];
 //; }
 //; for(my $i = 0; $i < $bbanks; $i++) {
-	assign fifo_to_mem_wen[`$i`] = wen_mem_en[`$i`];
+   assign fifo_to_mem_wen[`$i`] = wen_mem_en[`$i`];
 //; }
 //; for(my $i = 0; $i < $bbanks; $i++) {
-	assign fifo_to_mem_addr[`$i`] = data_addr[`$i`];
+   assign fifo_to_mem_addr[`$i`] = data_addr[`$i`];
 //; }
 //; for(my $i = 0; $i < $bbanks; $i++) {
-	assign data_out_sel[`$i`] = mem_to_fifo_data[`$i`];
+   assign data_out_sel[`$i`] = mem_to_fifo_data[`$i`];
 //; }
 
 // =========================
 // Combinational updates
 // =========================
-//
-//
 always @(posedge clk or posedge reset) begin
    if(reset) begin
       num_words_mem <= 0;
@@ -173,157 +171,157 @@ always @(posedge clk or posedge reset) begin
 end
 
 always @(*) begin
-    next_num_words_mem = 0;
 
-    if(ren & wen) begin
-        next_num_words_mem = 0;
-    end
-    else if(ren & ~empty) begin
-        next_num_words_mem = -1;
-    end
-    else if(wen & ~full) begin
-        next_num_words_mem = 1;
-    end
+   next_num_words_mem = 0;
+
+   if(ren & wen) begin
+      next_num_words_mem = 0;
+   end
+   else if(ren & ~empty) begin
+      next_num_words_mem = -1;
+   end
+   else if(wen & ~full) begin
+      next_num_words_mem = 1;
+   end
 end
 
 always @(*) begin
 
 //; for(my $i = 0; $i < $bbanks; $i++) {
-	data_addr[`$i`] = write_buffed[`$i`] ?
+   data_addr[`$i`] = write_buffed[`$i`] ?
 			  write_buff_addr[`$i`] :
 			  (ren_mem[`$i`] ? read_addr_mem : write_addr_mem);	
 //; }
-
-	if (ren_mem_reg[0]) begin
-		data_out = (passthru) ? passthru_reg : data_out_sel[0];
-	end
+   if (ren_mem_reg[0]) begin
+      data_out = (passthru) ? passthru_reg : data_out_sel[0];
+   end
 //; for(my $i = 1; $i < $bbanks; $i++) {
-	else if (ren_mem_reg[`$i`]) begin
-		data_out = (passthru) ? passthru_reg : data_out_sel[`$i`];
-	end
+   else if (ren_mem_reg[`$i`]) begin
+      data_out = (passthru) ? passthru_reg : data_out_sel[`$i`];
+   end
 //; }
-	else begin
-		data_out = data_out_reg;
-	end
+   else begin
+      data_out = data_out_reg;
+   end
 end
 
 // =======================
 // State updates
 // =======================
 always @(posedge clk_gated or posedge reset) begin
-	if(reset == 1'b1) begin
-		read_addr <= 0;
-		write_addr <= 0;
-		init_stage <= 1;
-		read_to_write <= 1;
-		data_out_reg <= 0;
-        passthru <= 0;
-        passthru_reg <= 0;
+   if(reset == 1'b1) begin
+      read_addr <= 0;
+      write_addr <= 0;
+	  init_stage <= 1;
+	  read_to_write <= 1;
+	  data_out_reg <= 0;
+      passthru <= 0;
+      passthru_reg <= 0;
 	//; for (my $i = 0; $i < $bbanks; $i++) {
-		write_buffed[`$i`] <= 0;
-		write_buff[`$i`] <= 0;
-		write_buff_addr[`$i`] <= 0;
-		ren_mem_reg[`$i`] <= 0;
+	  write_buffed[`$i`] <= 0;
+	  write_buff[`$i`] <= 0;
+	  write_buff_addr[`$i`] <= 0;
+	  ren_mem_reg[`$i`] <= 0;
 	//; }	
-	end
-	else begin
-
-		if (flush == 1'b1) begin
-			read_addr <= 0;
-			write_addr <= 0;
-			init_stage <= 1;
-			read_to_write <= 1;
-			data_out_reg <= 0;
-            passthru <= 0;
-            passthru_reg <= 0;
+   end
+   else begin
+      if (flush == 1'b1) begin
+         read_addr <= 0;
+		 write_addr <= 0;
+		 init_stage <= 1;
+		 read_to_write <= 1;
+		 data_out_reg <= 0;
+         passthru <= 0;
+         passthru_reg <= 0;
 		//; for (my $i = 0; $i < $bbanks; $i++) {
-			write_buffed[`$i`] <= 0;
-			write_buff[`$i`] <= 0;
-			write_buff_addr[`$i`] <= 0;
-			ren_mem_reg[`$i`] <= 0;
+		 write_buffed[`$i`] <= 0;
+		 write_buff[`$i`] <= 0;
+		 write_buff_addr[`$i`] <= 0;
+		 ren_mem_reg[`$i`] <= 0;
 		//; }	
-		end	
-		else begin
-		///
-			if (same_bank[0] == 1'b1) begin
-				write_buffed[0] <= 1'b1;
-				write_buff[0] <= data_in;
-				write_buff_addr[0] <= write_addr_mem;
-			end
+      end	
+	  else begin
+	  ///
+         if (same_bank[0] == 1'b1) begin
+		    write_buffed[0] <= 1'b1;
+			write_buff[0] <= data_in;
+			write_buff_addr[0] <= write_addr_mem;
+		 end
 		//; for (my $i = 1; $i < $bbanks; $i++) {
-			else if (same_bank[`$i`]) begin
-				write_buffed[`$i`] <= 1;
-				write_buff[`$i`] <= data_in;
-				write_buff_addr[`$i`] <= write_addr_mem;			
-			end
+		 else if (same_bank[`$i`]) begin
+			write_buffed[`$i`] <= 1;
+			write_buff[`$i`] <= data_in;
+			write_buff_addr[`$i`] <= write_addr_mem;			
+		 end
 		//; }
 
 		//; for(my $i = 0; $i < $bbanks; $i++) {
-			if (write_buffed[`$i`]) begin
-				write_buffed[`$i`] <= 0;
-			end
-		//; }
-			
+		 if (write_buffed[`$i`]) begin
+			write_buffed[`$i`] <= 0;
+		 end
+		//; }	
 			// If READ AND NO WRITE
-			if (ren & ~wen) begin
-                passthru <= 0;
-				if(circular_en & ~empty) begin
-					if ((read_addr + 1) % (2 ** `$full_addr`) == write_addr) begin
-						// circular buffer
-						read_addr <= 0;
-						// caught up to write
-						read_to_write <= 1;
-					end
-					else begin
-						read_addr <= (read_addr + 1) % (2 ** `$full_addr`);
-						read_to_write <= 0;
-					end
-				end
-				else begin
-					if (~empty) begin				
-						read_addr <= (read_addr + 1) % (2 ** `$full_addr`);
-						if ((read_addr + 1) % (2 ** `$full_addr`) == write_addr) begin
-							read_to_write <= 1;
-						end
-						else begin
-							read_to_write <= 0;
-						end			
-					end
-				end
-            end
-			// If WRITE AND NO READ
-			else if (wen & ~ren) begin
+         if (ren & ~wen) begin
+            passthru <= 0;
+			if(circular_en & ~empty) begin
+			   if ((read_addr + 1) % (2 ** `$full_addr`) == write_addr) begin
+			   // circular buffer
+			      read_addr <= 0;
+				  // caught up to write
+				  read_to_write <= 1;
+			   end
+			   else begin
+				  read_addr <= (read_addr + 1) % (2 ** `$full_addr`);
+				  read_to_write <= 0;
+			   end
+			end
+			else begin
+			   if (~empty) begin				
+			      read_addr <= (read_addr + 1) % (2 ** `$full_addr`);
+				  if ((read_addr + 1) % (2 ** `$full_addr`) == write_addr) begin
+				     read_to_write <= 1;
+				  end
+				  else begin
+				     read_to_write <= 0;
+				  end			
+			   end
+			end
+         end
+		 // If WRITE AND NO READ
+		 else if (wen & ~ren) begin
                 passthru <= 0;
 				write_addr <= (write_addr + 1) % (2 ** `$full_addr`);
 				read_to_write <= 0;
-			end	
-			// If READ AND WRITE
-			else if (ren & wen) begin
-        if(empty & (|same_bank)) begin
-          passthru <= 1;
-          passthru_reg <= data_in;
-        end
-        else begin
-          passthru <= 0;
-        end
-				read_addr <= (read_addr + 1) % (2 ** `$full_addr`);
-				write_addr <= (write_addr + 1) % (2 ** `$full_addr`);
-			end
+         end	
+		 // If READ AND WRITE
+		 else if (ren & wen) begin
+            if(empty & (|same_bank)) begin
+               passthru <= 1;
+               passthru_reg <= data_in;
+            end
+            else begin
+               passthru <= 0;
+            end
+			
+            read_addr <= (read_addr + 1) % (2 ** `$full_addr`);
+			write_addr <= (write_addr + 1) % (2 ** `$full_addr`);
+
+	  end
       // No read or write - turn off passthru
       else begin
         passthru <= 0;
       end
-			// Transition out of the init stage after a read or write
-			if (ren | wen) begin
-				init_stage <= 0;
-			end
+         // Transition out of the init stage after a read or write
+		 if (ren | wen) begin
+	        init_stage <= 0;
+		 end
 		//; for (my $i = 0; $i < $bbanks; $i++) {
-			ren_mem_reg[`$i`] <= ren_mem[`$i`];
+		 ren_mem_reg[`$i`] <= ren_mem[`$i`];
 		//; }
-			data_out_reg <= data_out;
-		end
-		end
-	end
+		 data_out_reg <= data_out;
+      end
+   end
+end
 //end
 
 endmodule

--- a/memory_core/genesis_new/linebuffer_control.svp
+++ b/memory_core/genesis_new/linebuffer_control.svp
@@ -46,10 +46,26 @@ output logic                ren_to_fifo;
 // Is this the last line in the thing? Valid_out should be gated based on the stencil
 logic [31:0] vg_ctr;
 logic valid_gate;
+logic threshold;
+
 
 assign valid_gate = (stencil_width == 0) ? 1 : vg_ctr >= (stencil_width - 1); 
-assign valid = valid_gate & (num_words_mem == depth) & wen & (depth > 0); 
+assign valid = valid_gate & (num_words_mem >= (depth - 1)) & wen & (depth > 0) & threshold; 
 assign ren_to_fifo = (num_words_mem >= (depth - 1)) & wen & (depth > 0);
+
+always @(posedge clk, posedge reset) begin
+   if(reset) begin
+      threshold <= 0;
+   end
+   else begin
+      if(flush) begin
+         threshold <= 0;
+      end
+      else if ((num_words_mem == (depth - 1)) & wen) begin
+         threshold <= 1;
+      end
+   end
+end
 
 always @(posedge clk, posedge reset) begin
     if(reset) begin

--- a/memory_core/genesis_new/linebuffer_control.svp
+++ b/memory_core/genesis_new/linebuffer_control.svp
@@ -43,7 +43,6 @@ output logic                valid;
 input logic [12:0]          num_words_mem;
 output logic                ren_to_fifo;
 
-logic [31:0] lb_config_rd_data;
 // Is this the last line in the thing? Valid_out should be gated based on the stencil
 logic [31:0] vg_ctr;
 logic valid_gate;
@@ -52,15 +51,20 @@ logic [12:0] depth_int;
 
 assign valid_gate = (stencil_width == 0) ? 1 : vg_ctr >= (stencil_width - 1); 
 assign valid = valid_gate ? valid_int : 0;
-assign ren_to_fifo = (depth_int > 0) ? (num_words_mem >= (depth_int-1)) : 0;
+assign ren_to_fifo = (depth_int > 0) ? (num_words_mem >= (depth_int - 1)) & wen: 0;
 
 always @(posedge clk, posedge reset) begin
     if(reset) begin
        vg_ctr <= 0; 
     end
     else begin
-        if(valid_int) begin
-            vg_ctr <= (vg_ctr + 1) % depth_int;
+        if (flush) begin
+            vg_ctr <= 0;
+        end
+        else begin
+          if(valid_int) begin
+              vg_ctr <= (vg_ctr + 1) % depth_int;
+          end
         end
     end
 end 
@@ -69,18 +73,16 @@ always @(posedge clk, posedge reset) begin
     if (reset) begin
         depth_int <= 0;
         valid_int <= 0;
-        lb_config_rd_data <= 0;
     end
     else begin
         if (flush) begin
            depth_int <= depth;
            valid_int <= 0;
-           lb_config_rd_data <= 0;
         end
         else begin
            depth_int <= depth;
 
-           if (((num_words_mem >= depth_int) | (((num_words_mem) >= (depth_int-1)))) & (depth_int > 0)) begin
+           if (((num_words_mem >= (depth_int-1)) & wen) & (depth_int > 0)) begin
                valid_int <= 1;
            end
            else begin

--- a/memory_core/genesis_new/linebuffer_control.svp
+++ b/memory_core/genesis_new/linebuffer_control.svp
@@ -46,12 +46,10 @@ output logic                ren_to_fifo;
 // Is this the last line in the thing? Valid_out should be gated based on the stencil
 logic [31:0] vg_ctr;
 logic valid_gate;
-logic valid_int;
-logic [12:0] depth_int;
 
 assign valid_gate = (stencil_width == 0) ? 1 : vg_ctr >= (stencil_width - 1); 
-assign valid = valid_gate ? valid_int : 0;
-assign ren_to_fifo = (depth_int > 0) ? (num_words_mem >= (depth_int - 1)) & wen: 0;
+assign valid = valid_gate & (num_words_mem == depth) & wen & (depth > 0); 
+assign ren_to_fifo = (num_words_mem >= (depth - 1)) & wen & (depth > 0);
 
 always @(posedge clk, posedge reset) begin
     if(reset) begin
@@ -62,34 +60,11 @@ always @(posedge clk, posedge reset) begin
             vg_ctr <= 0;
         end
         else begin
-          if(valid_int) begin
-              vg_ctr <= (vg_ctr + 1) % depth_int;
+          if(valid) begin
+              vg_ctr <= (vg_ctr + 1) % depth;
           end
         end
     end
 end 
-
-always @(posedge clk, posedge reset) begin
-    if (reset) begin
-        depth_int <= 0;
-        valid_int <= 0;
-    end
-    else begin
-        if (flush) begin
-           depth_int <= depth;
-           valid_int <= 0;
-        end
-        else begin
-           depth_int <= depth;
-
-           if (((num_words_mem >= (depth_int-1)) & wen) & (depth_int > 0)) begin
-               valid_int <= 1;
-           end
-           else begin
-               valid_int <= 0;
-           end
-        end
-    end
-end
 
 endmodule

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -170,15 +170,24 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
 
     tester.poke(circuit.interface[wen], 1)
 
+    counter = 0
     for i in range(200):
-        tester.poke(circuit.interface[src], i)
+        tester.poke(circuit.interface[src], counter)
         tester.eval()
 
-        if i > depth + 10:
-            tester.expect(circuit.interface[dst], i * 2 - depth)
+        if i == depth - 1:
+            tester.expect(circuit.interface[valid], 0)
+            tester.poke(circuit.interface[wen], 0)
+        elif i == depth:
+            tester.poke(circuit.interface[wen], 1)
+            counter += 1
+        elif i >= depth + 1:
+            tester.expect(circuit.interface[dst], i * 2 - depth - 2)
             tester.expect(circuit.interface[valid], 1)
+            counter += 1
         else:
             tester.expect(circuit.interface[valid], 0)
+            counter += 1
 
         # toggle the clock
         tester.step(2)

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -180,6 +180,7 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
             tester.poke(circuit.interface[wen], 0)
         elif i == depth:
             tester.poke(circuit.interface[wen], 1)
+            tester.expect(circuit.interface[valid], 0)
             counter += 1
         elif i >= depth + 1:
             tester.expect(circuit.interface[dst], i * 2 - depth - 2)

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -114,9 +114,10 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
         "e0": [("I0", "io2f_16"), ("m0", "data_in"), ("p0", "data0")],
         "e1": [("m0", "data_out"), ("p0", "data1")],
         "e3": [("p0", "alu_res"), ("I1", "f2io_16")],
-        "e4": [("i3", "io2f_1"), ("m0", "wen_in")]
+        "e4": [("i3", "io2f_1"), ("m0", "wen_in")],
+        "e5": [("m0", "valid_out"), ("i4", "f2io_1")]
     }
-    bus = {"e0": 16, "e1": 16, "e3": 16, "e4": 1}
+    bus = {"e0": 16, "e1": 16, "e3": 16, "e4": 1, "e5": 1}
 
     placement, routing = pnr(interconnect, (netlist, bus))
     config_data = interconnect.get_route_bitstream(routing)
@@ -164,6 +165,8 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
     dst = f"io2glb_16_X{dst_x:02X}_Y{dst_y:02X}"
     wen_x, wen_y = placement["i3"]
     wen = f"glb2io_1_X{wen_x:02X}_Y{wen_y:02X}"
+    valid_x, valid_y = placement["i4"]
+    valid = f"io2glb_1_X{valid_x:02X}_Y{valid_y:02X}"
 
     tester.poke(circuit.interface[wen], 1)
 
@@ -173,6 +176,9 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
 
         if i > depth + 10:
             tester.expect(circuit.interface[dst], i * 2 - depth)
+            tester.expect(circuit.interface[valid], 1)
+        else:
+            tester.expect(circuit.interface[valid], 0)
 
         # toggle the clock
         tester.step(2)


### PR DESCRIPTION
addressing #259  - valid is now combinational (was previously registered) with real dependence on the wen signal. the ren_to_fifo goes high at depth-1 because we register the first input to the output so it is ready to be consumed downstream. The ren won't be asserted again, so the fifo data should remain until it is forcibly pushed downstream.