### PR TITLE
Change global buffer data pipeline register to have reset

### DIFF
--- a/global_buffer/genesis/global_buffer_int.svp
+++ b/global_buffer/genesis/global_buffer_int.svp
@@ -166,6 +166,7 @@ assign host_wr_en = |host_wr_strb;
     .BANK_DATA_WIDTH(BANK_DATA_WIDTH)
 ) `$host_bank_interconnect->iname()` (
     .clk(clk),
+    .reset(reset),
 
     .host_wr_en(host_wr_en),
     .host_wr_strb(host_wr_strb),

--- a/global_buffer/genesis/host_bank_interconnect.svp
+++ b/global_buffer/genesis/host_bank_interconnect.svp
@@ -16,6 +16,7 @@ module `mname` #(
 (
 
     input                                   clk,
+    input                                   reset,
     
     input                                   host_wr_en,
     input        [BANK_DATA_WIDTH/8-1:0]    host_wr_strb,
@@ -134,7 +135,15 @@ logic [BANK_DATA_WIDTH-1:0]   host_rd_data_reg;
 always_ff @(posedge clk) begin
     host_rd_en_d1 <= host_rd_en;
     host_rd_en_d2 <= host_rd_en_d1;
-    host_rd_data_reg <= host_rd_data;
+end
+
+always_ff @(posedge clk or posedge reset) begin
+    if (reset) begin
+        host_rd_data_reg <= 0;
+    end
+    else begin
+        host_rd_data_reg <= host_rd_data;
+    end
 end
 
 assign host_rd_data = host_rd_en_d2 ? int_host_rd_data : host_rd_data_reg;

--- a/global_buffer/genesis/sram_gen.svp
+++ b/global_buffer/genesis/sram_gen.svp
@@ -2,7 +2,6 @@
 //Author: Alex Carsello
 //Modification by Taeyoung Kong 
 
-`timescale 1ns/100fs
 module `mname` #(
     parameter integer DATA_WIDTH = 64,
     parameter integer ADDR_WIDTH = 14


### PR DESCRIPTION
Previously, I implemented all pipeline registers as flipflop w/o reset.
I think it is better for `rd_data` register to go to `0` at reset, so I changed it.

Also, in this PR, I removed unnecessary `timescale 1ns/100fs` code in `sram_gen.svp`
