### PR TITLE
refactor out memory mode

### DIFF
--- a/memory_core/memory_core.py
+++ b/memory_core/memory_core.py
@@ -1,20 +1,13 @@
 from gemstone.common.configurable_model import ConfigurableModel
 import functools
 from hwtypes import BitVector
-from enum import Enum
 import magma as m
 import fault
 import logging
 import karst.basic as kam
 import buffer_mapping.mapping as bam
+from .memory_mode import Mode
 logging.basicConfig(level=logging.DEBUG)
-
-
-class Mode(Enum):
-    LINE_BUFFER = 0
-    FIFO = 1
-    SRAM = 2
-    DB = 3
 
 
 class Memory:

--- a/memory_core/memory_mode.py
+++ b/memory_core/memory_mode.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class Mode(Enum):
+    LINE_BUFFER = 0
+    FIFO = 1
+    SRAM = 2
+    DB = 3

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -9,7 +9,7 @@ from archipelago import pnr
 import pytest
 import random
 from cgra import create_cgra
-from memory_core.memory_core import Mode
+from memory_core.memory_mode import Mode
 
 
 @pytest.fixture()

--- a/tests/test_memory_core/test_memory_core.py
+++ b/tests/test_memory_core/test_memory_core.py
@@ -1,15 +1,11 @@
-from memory_core import memory_core_genesis2
 from memory_core.memory_core import gen_memory_core, Mode
 from memory_core.memory_core_magma import MemCore
 import glob
-import os
 import tempfile
 import shutil
 import fault
 import random
-from hwtypes import BitVector
-from gemstone.common.testers import ResetTester, ConfigurationTester
-from gemstone.generator.generator import Generator
+from gemstone.common.testers import ResetTester
 from gemstone.common.testers import BasicTester
 
 


### PR DESCRIPTION
This allows other modules to manipulate the memory mode without importing from the functional model module.