### PR TITLE
Sram read data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ tests/*/obj_dir/
 *.bs
 
 *.json
+mem_cfg.txt

--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -70,11 +70,13 @@ input logic                   switch;
 
 input logic read_mode;
 input logic  arbitrary_addr;
-input logic [31:0] starting_addr; 
+input logic [15:0] starting_addr; 
 input logic [31:0] iter_cnt;
-input logic [31:0] dimensionality;
-input logic [31:0] stride [`$iterator_support-1`:0];
+input logic [3:0] dimensionality;
+
+input logic [15:0] stride [`$iterator_support-1`:0];
 input logic [31:0] range [`$iterator_support-1`:0];
+logic [15:0] current_loc [`$iterator_support-1`:0];
 
 input logic                   flush;
 input logic                   wen;
@@ -98,7 +100,6 @@ output logic                   valid;
 // ==============================================
 logic init_state;
 logic  [12:0]                  depth_int;
-logic [31:0] current_loc [`$iterator_support-1`:0];
 
 logic [`$awidth-1`:0] addr;
 assign addr = addr_in[`$awidth-1`:0];
@@ -113,12 +114,11 @@ logic [31:0] dim_counter [`$iterator_support-1`:0];
 // ==============================================
 // Configuration
 // ==============================================
-
 logic                  update [`$iterator_support-1`:0];
-logic  [`$wwidth-1`:0] data_out_logic;
+logic  [`$wwidth-1`:0] data_out_reg;
 logic [`$wwidth-1`:0] strt_addr;
 
-assign strt_addr = starting_addr[`$wwidth`:0];
+assign strt_addr = starting_addr[`$wwidth-1`:0];
 
 logic ren_cnt;
 
@@ -136,10 +136,10 @@ assign autoswitch = (~read_mode & ~arbitrary_addr) ? write_done & (read_done | i
 
 always @ (posedge clk, posedge reset) begin
     if(reset) begin
-        data_out_logic <= 0;
+        data_out_reg <= 0;
     end
     else if(switch | autoswitch)begin
-        data_out_logic <= data_out;
+        data_out_reg <= data_out;
     end
 end
 

--- a/memory_core/genesis_new/linebuffer_control.svp
+++ b/memory_core/genesis_new/linebuffer_control.svp
@@ -37,19 +37,19 @@ input logic                 reset;
 input logic                 flush;
 input logic                 wen;
 
-input logic [31:0]          stencil_width;
+input logic [15:0]          stencil_width;
 input logic [12:0]          depth;
 output logic                valid;
 input logic [12:0]          num_words_mem;
 output logic                ren_to_fifo;
 
 // Is this the last line in the thing? Valid_out should be gated based on the stencil
-logic [31:0] vg_ctr;
+logic [15:0] vg_ctr;
 logic valid_gate;
 logic valid_int;
 logic threshold;
 
-assign valid_gate = (stencil_width == 0) ? 1 : vg_ctr >= (stencil_width - 1); 
+assign valid_gate = (stencil_width == (16'b0)) ? 16'b1 : vg_ctr >= (stencil_width - 1); 
 assign valid_int = (num_words_mem >= (depth - 1)) & wen & (depth > 0) & threshold; 
 assign valid = valid_gate & valid_int;
 assign ren_to_fifo = (num_words_mem >= (depth - 1)) & wen & (depth > 0);

--- a/memory_core/genesis_new/linebuffer_control.svp
+++ b/memory_core/genesis_new/linebuffer_control.svp
@@ -46,11 +46,12 @@ output logic                ren_to_fifo;
 // Is this the last line in the thing? Valid_out should be gated based on the stencil
 logic [31:0] vg_ctr;
 logic valid_gate;
+logic valid_int;
 logic threshold;
 
-
 assign valid_gate = (stencil_width == 0) ? 1 : vg_ctr >= (stencil_width - 1); 
-assign valid = valid_gate & (num_words_mem >= (depth - 1)) & wen & (depth > 0) & threshold; 
+assign valid_int = (num_words_mem >= (depth - 1)) & wen & (depth > 0) & threshold; 
+assign valid = valid_gate & valid_int;
 assign ren_to_fifo = (num_words_mem >= (depth - 1)) & wen & (depth > 0);
 
 always @(posedge clk, posedge reset) begin
@@ -76,7 +77,7 @@ always @(posedge clk, posedge reset) begin
             vg_ctr <= 0;
         end
         else begin
-          if(valid) begin
+          if(valid_int) begin
               vg_ctr <= (vg_ctr + 1) % depth;
           end
         end

--- a/memory_core/genesis_new/mem.vp
+++ b/memory_core/genesis_new/mem.vp
@@ -59,7 +59,7 @@ TS1N16FFCLLSBLVTC512X16M8S m (
   .D(data_in),
   .Q(data_out),
   // Testing interface (unused)
-  .RTSEL(2'b00),i //'
+  .RTSEL(2'b00), //'
   .WTSEL(2'b00) //'
   );
 

--- a/memory_core/genesis_new/memory_core.svp
+++ b/memory_core/genesis_new/memory_core.svp
@@ -231,7 +231,8 @@ always @(*) begin
    //; }  
 //; }
 
-  if(config_en_sram != 1'b0) begin
+  // Only can run the sram like this when the tile_en is off - pre-use
+  if((|config_en_sram) & ~tile_en) begin
 
    //; for (my $i = 0; $i < $bbanks; $i++) { 
       mem_cen_int[`$i`] = 1'b1; //' 
@@ -487,7 +488,7 @@ assign mem_cen[`$i`] = mem_cen_int[`$i`] & ( mem_wen[`$i`] | mem_ren[`$i`]);
 // ========================================================
 // Instantiate memory banks
 // ========================================================
-assign gclk_sram = (clk_en | (|config_en_sram)) ? gclk_in : 1'b0;
+assign gclk_sram = (|config_en_sram & ~tile_en) ? clk : (clk_en) ? gclk_in : 1'b0;
 //; my $mem = generate('mem', 'mem', dwidth => $dwidth, ddepth => $ddepth, wwidth => $wwidth, use_sram_stub => $use_sram_stub);
 //; for (my $i = 0; $i < $bbanks; $i++) {
    //; my $mem_obj = clone($mem, 'mem_inst' . $i);

--- a/memory_core/genesis_new/memory_core.svp
+++ b/memory_core/genesis_new/memory_core.svp
@@ -52,7 +52,6 @@ module `mname`(
 //; for (my $i = 0; $i < $num_sram_reads; $i++) {
    `'read_data_sram_' . $i`,
 //; }
-
    read_config_data,
    // Config
    stencil_width,
@@ -207,7 +206,7 @@ assign range[`$idx`] = `'range_' . $idx`;
 assign gclk_in = (tile_en==1'b1) ? clk : 1'b0;
 assign gclk = clk_en ? gclk_in : 1'b0;
 // TODO
-assign read_config_data = 1'b0;
+assign read_config_data = 0;
 // ========================================================
 // Chaining - basically changes data in/data out/valid/wen
 // ========================================================

--- a/memory_core/genesis_new/memory_core.svp
+++ b/memory_core/genesis_new/memory_core.svp
@@ -75,19 +75,17 @@ module `mname`(
    tile_en,
    depth,
    chain_idx
-
 );
 
-
 // ALL CONFIG
-input logic [31:0] stencil_width;
+input logic [15:0] stencil_width;
 input logic        read_mode;
 input logic        arbitrary_addr;
-input logic [31:0] starting_addr;
+input logic [15:0] starting_addr;
 input logic [31:0] iter_cnt;
-input logic [31:0] dimensionality;
+input logic [3:0] dimensionality;
 //; for(my $idx = 0; $idx < $iterator_support; $idx++) {
-input logic [31:0] `'stride_' . $idx`;
+input logic [15:0] `'stride_' . $idx`;
 //; }
 //; for(my $idx = 0; $idx < $iterator_support; $idx++) {
 input logic [31:0] `'range_' . $idx`;
@@ -103,7 +101,7 @@ input logic  [12:0]     depth;
 // ========================================================
 // Inputs and Outputs
 // ========================================================
-logic [31:0] stride [`$iterator_support-1`:0];
+logic [15:0] stride [`$iterator_support-1`:0];
 logic [31:0] range [`$iterator_support-1`:0];
 // Clock + Reset
 input clk;

--- a/memory_core/memory_core_genesis2.py
+++ b/memory_core/memory_core_genesis2.py
@@ -14,10 +14,11 @@ Example usage:
             data_width=16, data_depth=1024)
 """
 interface = GeneratorInterface()\
-    .register("data_depth", int, 128)\
+    .register("data_depth", int, 512)\
     .register("num_banks", int, 2)\
-    .register("data_width", int, 64)\
+    .register("data_width", int, 16)\
     .register("word_width", int, 16)\
+    .register("iterator_support", int, 6)\
     .register("use_sram_stub", int, 1)
 
 memory_core_wrapper = GenesisWrapper(
@@ -36,7 +37,8 @@ memory_core_wrapper = GenesisWrapper(
 
 param_mapping = {"data_width": "dwidth", "data_depth": "ddepth",
                  "word_width": "wwidth", "num_banks": "bbanks",
-                 "use_sram_stub": "use_sram_stub"}
+                 "use_sram_stub": "use_sram_stub",
+                 "iterator_support": "iterator_support"}
 
 if __name__ == "__main__":
     """

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -106,7 +106,8 @@ class MemCore(ConfigurableCore):
 
         zero_signals = (
             ("chain_wen_in", 1),
-            ("chain_in", self.word_width)
+            ("chain_in", self.word_width),
+          #  ("config_read", 1)
         )
 
         # enable read and write by default

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -15,10 +15,10 @@ class MemCore(ConfigurableCore):
     __circuit_cache = {}
 
     def __init__(self, data_width, word_width, data_depth,
-                 num_banks, use_sram_stub):
+                 num_banks, use_sram_stub, iterator_support=6):
 
         super().__init__(8, 32)
-
+        self.iterator_support = iterator_support
         self.data_width = data_width
         self.data_depth = data_depth
         self.num_banks = num_banks
@@ -60,14 +60,17 @@ class MemCore(ConfigurableCore):
                              data_depth=self.data_depth,
                              word_width=self.word_width,
                              num_banks=self.num_banks,
-                             use_sram_stub=self.use_sram_stub)
+                             use_sram_stub=self.use_sram_stub,
+                             iterator_support=self.iterator_support)
             MemCore.__circuit_cache[(data_width, word_width,
                                      data_depth, num_banks,
-                                     use_sram_stub)] = circ
+                                     use_sram_stub,
+                                     iterator_support)] = circ
         else:
             circ = MemCore.__circuit_cache[(data_width, word_width,
                                             data_depth, num_banks,
-                                            use_sram_stub)]
+                                            use_sram_stub,
+                                            iterator_support)]
 
         self.underlying = FromMagma(circ)
 
@@ -173,12 +176,12 @@ class MemCore(ConfigurableCore):
         #          self.underlying.ports.read_config_data)
 
         configurations = [
-            ("stencil_width", 32),
+            ("stencil_width", 16),
             ("read_mode", 1),
             ("arbitrary_addr", 1),
-            ("starting_addr", 32),
+            ("starting_addr", 16),
             ("iter_cnt", 32),
-            ("dimensionality", 32),
+            ("dimensionality", 4),
             ("circular_en", 1),
             ("almost_count", 4),
             ("enable_chain", 1),
@@ -198,8 +201,8 @@ class MemCore(ConfigurableCore):
                 self.wire(main_feature.registers[config_reg_name].ports.O,
                           self.underlying.ports[config_reg_name])
 
-        for idx in range(8):
-            main_feature.add_config(f"stride_{idx}", 32)
+        for idx in range(iterator_support):
+            main_feature.add_config(f"stride_{idx}", 16)
             main_feature.add_config(f"range_{idx}", 32)
             self.wire(main_feature.registers[f"stride_{idx}"].ports.O,
                       self.underlying.ports[f"stride_{idx}"])

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -106,12 +106,13 @@ class MemCore(ConfigurableCore):
 
         zero_signals = (
             ("chain_wen_in", 1),
-            ("chain_in", self.word_width),
+            ("chain_in", self.word_width)
         )
 
         # enable read and write by default
         for name, width in zero_signals:
             val = magma.bits(0, width) if width > 1 else magma.bit(0)
+            self.wire(Const(val), self.underlying.ports[name])
 
         self.wire(Const(magma.bits(0, 24)),
                   self.underlying.ports.config_addr[0:24])

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -38,6 +38,8 @@ class MemCore(ConfigurableCore):
             flush=magma.In(TBit),
             wen_in=magma.In(TBit),
             ren_in=magma.In(TBit),
+            # config_read=magma.In(TBit),
+            # config_write=magma.In(Tbit),
 
             stall=magma.In(magma.Bits[4]),
 
@@ -106,17 +108,11 @@ class MemCore(ConfigurableCore):
             ("chain_wen_in", 1),
             ("chain_in", self.word_width),
         )
-        one_signals = (
-            ("config_read", 1),
-            ("config_write", 1)
-        )
+
         # enable read and write by default
         for name, width in zero_signals:
             val = magma.bits(0, width) if width > 1 else magma.bit(0)
-            self.wire(Const(val), self.underlying.ports[name])
-        for name, width in one_signals:
-            val = magma.bits(1, width) if width > 1 else magma.bit(1)
-            self.wire(Const(val), self.underlying.ports[name])
+
         self.wire(Const(magma.bits(0, 24)),
                   self.underlying.ports.config_addr[0:24])
 
@@ -158,10 +154,6 @@ class MemCore(ConfigurableCore):
         self.wire(or_gates["config_data"].ports.O,
                   self.underlying.ports.config_data)
 
-        # only the first one has config_en
-#        self.wire(self.__features[0].ports.config.write[0],
-#                  self.underlying.ports.config_en)
-
         # read data out
         for idx, core_feature in enumerate(self.__features):
             if(idx > 0):
@@ -171,10 +163,7 @@ class MemCore(ConfigurableCore):
                 core_feature.ports["read_config_data"] = \
                     self.ports[f"read_config_data_{idx}"]
 
-        # MEM config
-        # self.wire(self.ports.read_config_data,
-        #          self.underlying.ports.read_config_data)
-
+        # MEM Config
         configurations = [
             ("stencil_width", 16),
             ("read_mode", 1),
@@ -190,6 +179,7 @@ class MemCore(ConfigurableCore):
             ("chain_idx", 4),
             ("depth", 13)
         ]
+
         # Do all the stuff for the main config
         main_feature = self.__features[0]
         for config_reg_name, width in configurations:
@@ -210,14 +200,30 @@ class MemCore(ConfigurableCore):
                       self.underlying.ports[f"range_{idx}"])
 
         # SRAM
+        or_all_cfg_rd = FromMagma(mantle.DefineOr(4, 1))
+        or_all_cfg_rd.instance_name = f"OR_CONFIG_WR_SRAM"
+        or_all_cfg_wr = FromMagma(mantle.DefineOr(4, 1))
+        or_all_cfg_wr.instance_name = f"OR_CONFIG_RD_SRAM"
         for sram_index in range(4):
             core_feature = self.__features[sram_index + 1]
             self.wire(core_feature.ports.read_config_data,
                       self.underlying.ports[f"read_data_sram_{sram_index}"])
             # also need to wire the sram signal
-            self.wire(core_feature.ports.config.write[0],
+            # the config enable is the OR of the rd+wr
+            or_gate_en = FromMagma(mantle.DefineOr(2, 1))
+            or_gate_en.instance_name = f"OR_CONFIG_EN_SRAM_{sram_index}"
+            self.wire(or_gate_en.ports.I0, core_feature.ports.config.write)
+            self.wire(or_gate_en.ports.I1, core_feature.ports.config.read)
+            self.wire(or_gate_en.ports.O[0],
                       self.underlying.ports["config_en_sram"][sram_index])
+            # Still connect to the OR of all the config rd/wr
+            self.wire(core_feature.ports.config.write,
+                      or_all_cfg_wr.ports[f"I{sram_index}"])
+            self.wire(core_feature.ports.config.read,
+                      or_all_cfg_rd.ports[f"I{sram_index}"])
 
+        self.wire(or_all_cfg_rd.ports.O[0], self.underlying.ports.config_read)
+        self.wire(or_all_cfg_wr.ports.O[0], self.underlying.ports.config_write)
         self._setup_config()
 
         conf_names = list(self.registers.keys())

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -102,6 +102,114 @@ def test_interconnect_point_wise(batch_size: int, cw_files, add_pd, io_sides):
 
 
 @pytest.mark.parametrize("add_pd", [True, False])
+@pytest.mark.parametrize("depth", [10, 100])
+@pytest.mark.parametrize("stencil_width", [3, 5])
+def test_interconnect_line_buffer_last_line_valid(cw_files, add_pd, io_sides,
+                                                  stencil_width, depth):
+
+    chip_size = 2
+    interconnect = create_cgra(chip_size, chip_size, io_sides,
+                               num_tracks=3,
+                               add_pd=add_pd,
+                               mem_ratio=(1, 2))
+
+    netlist = {
+        "e0": [("I0", "io2f_16"), ("m0", "data_in"), ("p0", "data0")],
+        "e1": [("m0", "data_out"), ("p0", "data1")],
+        "e3": [("p0", "alu_res"), ("I1", "f2io_16")],
+        "e4": [("i3", "io2f_1"), ("m0", "wen_in")],
+        "e5": [("m0", "valid_out"), ("i4", "f2io_1")]
+    }
+    bus = {"e0": 16, "e1": 16, "e3": 16, "e4": 1, "e5": 1}
+
+    placement, routing = pnr(interconnect, (netlist, bus))
+    config_data = interconnect.get_route_bitstream(routing)
+
+    # in this case we configure m0 as line buffer mode
+
+    mode = Mode.LINE_BUFFER
+    tile_en = 1
+
+    mem_x, mem_y = placement["m0"]
+    memtile = interconnect.tile_circuits[(mem_x, mem_y)]
+    mcore = memtile.core
+    config_data.append((interconnect.get_config_addr(
+                        mcore.get_reg_index("depth"),
+                        0, mem_x, mem_y), depth))
+    config_data.append((interconnect.get_config_addr(
+                        mcore.get_reg_index("mode"),
+                        0, mem_x, mem_y), mode.value))
+    config_data.append((interconnect.get_config_addr(
+                        mcore.get_reg_index("stencil_width"),
+                        0, mem_x, mem_y), stencil_width))
+    config_data.append((interconnect.get_config_addr(
+                        mcore.get_reg_index("tile_en"),
+                        0, mem_x, mem_y), tile_en))
+
+    # then p0 is configured as add
+    pe_x, pe_y = placement["p0"]
+    tile_id = pe_x << 8 | pe_y
+    tile = interconnect.tile_circuits[(pe_x, pe_y)]
+
+    add_bs = tile.core.get_config_bitstream(asm.add())
+    for addr, data in add_bs:
+        config_data.append(((addr << 24) | tile_id, data))
+
+    circuit = interconnect.circuit()
+
+    tester = BasicTester(circuit, circuit.clk, circuit.reset)
+    tester.reset()
+    for addr, index in config_data:
+        tester.configure(addr, index)
+        tester.config_read(addr)
+        tester.eval()
+        tester.expect(circuit.read_config_data, index)
+
+    src_x, src_y = placement["I0"]
+    src = f"glb2io_16_X{src_x:02X}_Y{src_y:02X}"
+    dst_x, dst_y = placement["I1"]
+    dst = f"io2glb_16_X{dst_x:02X}_Y{dst_y:02X}"
+    wen_x, wen_y = placement["i3"]
+    wen = f"glb2io_1_X{wen_x:02X}_Y{wen_y:02X}"
+    valid_x, valid_y = placement["i4"]
+    valid = f"io2glb_1_X{valid_x:02X}_Y{valid_y:02X}"
+
+    tester.poke(circuit.interface[wen], 1)
+
+    counter = 0
+    for i in range(3 * depth):
+        tester.poke(circuit.interface[src], counter)
+        tester.eval()
+
+        if i < depth + stencil_width - 1:
+            tester.expect(circuit.interface[valid], 0)
+        elif i < 2 * depth:
+            tester.expect(circuit.interface[valid], 1)
+        elif i < 2 * depth + stencil_width - 1:
+            tester.expect(circuit.interface[valid], 0)
+        else:
+            tester.expect(circuit.interface[valid], 1)
+
+        # toggle the clock
+        tester.step(2)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        for genesis_verilog in glob.glob("genesis_verif/*.*"):
+            shutil.copy(genesis_verilog, tempdir)
+        for filename in cw_files:
+            shutil.copy(filename, tempdir)
+        shutil.copy(os.path.join("tests", "test_memory_core",
+                                 "sram_stub.v"),
+                    os.path.join(tempdir, "sram_512w_16b.v"))
+        for aoi_mux in glob.glob("tests/*.sv"):
+            shutil.copy(aoi_mux, tempdir)
+        tester.compile_and_run(target="verilator",
+                               magma_output="coreir-verilog",
+                               directory=tempdir,
+                               flags=["-Wno-fatal", "--trace"])
+
+
+@pytest.mark.parametrize("add_pd", [True, False])
 def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
     depth = 10
     chip_size = 2

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -360,11 +360,6 @@ def test_interconnect_sram(cw_files, add_pd, io_sides):
 
     tester = BasicTester(circuit, circuit.clk, circuit.reset)
     tester.reset()
-    for addr, index in config_data:
-        tester.configure(addr, index)
-        tester.config_read(addr)
-        tester.eval()
-        tester.expect(circuit.read_config_data, index)
 
     for addr, data in sram_data:
         tester.configure(addr, data)
@@ -372,6 +367,12 @@ def test_interconnect_sram(cw_files, add_pd, io_sides):
         # tester.config_read(addr)
         # tester.eval()
         # tester.expect(circuit.read_config_data, data)
+
+    for addr, index in config_data:
+        tester.configure(addr, index)
+        tester.config_read(addr)
+        tester.eval()
+        tester.expect(circuit.read_config_data, index)
 
     addr_x, addr_y = placement["I0"]
     src = f"glb2io_16_X{addr_x:02X}_Y{addr_y:02X}"


### PR DESCRIPTION
Only want to do configuration of the SRAM **BEFORE** the tile is enabled.  - This basically implies that if you want to read the bare contents of the sram through config, you should **DISABLE** the tile