### PR TITLE
Fix sram config en

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ tests/*/obj_dir/
 *.json
 mem_cfg.txt
 mem_synth.txt
+dump/

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -12,7 +12,7 @@ from typing import List
 
 
 class MemCore(ConfigurableCore):
-      __circuit_cache = {}
+    __circuit_cache = {}
 
     def __init__(self, data_width, word_width, data_depth,
                  num_banks, use_sram_stub, iterator_support=6):

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -208,8 +208,10 @@ class MemCore(ConfigurableCore):
         or_all_cfg_wr.instance_name = f"OR_CONFIG_RD_SRAM"
         for sram_index in range(4):
             core_feature = self.__features[sram_index + 1]
-
-            core_feature.add_port("config_en", TBit)
+            self.add_port(f"config_en_{sram_index}", magma.In(magma.Bit))
+            # port aliasing
+            core_feature.ports["config_en"] = \
+                self.ports[f"config_en_{sram_index}"]
             self.wire(core_feature.ports.read_config_data,
                       self.underlying.ports[f"read_data_sram_{sram_index}"])
             # also need to wire the sram signal
@@ -219,7 +221,7 @@ class MemCore(ConfigurableCore):
 
             self.wire(or_gate_en.ports.I0, core_feature.ports.config.write)
             self.wire(or_gate_en.ports.I1, core_feature.ports.config.read)
-            self.wire(core_feature.ports.config_en[0],
+            self.wire(core_feature.ports.config_en,
                       self.underlying.ports["config_en_sram"][sram_index])
             # Still connect to the OR of all the config rd/wr
             self.wire(core_feature.ports.config.write,

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -208,15 +208,18 @@ class MemCore(ConfigurableCore):
         or_all_cfg_wr.instance_name = f"OR_CONFIG_RD_SRAM"
         for sram_index in range(4):
             core_feature = self.__features[sram_index + 1]
+
+            core_feature.add_port("config_en", TBit)
             self.wire(core_feature.ports.read_config_data,
                       self.underlying.ports[f"read_data_sram_{sram_index}"])
             # also need to wire the sram signal
             # the config enable is the OR of the rd+wr
             or_gate_en = FromMagma(mantle.DefineOr(2, 1))
             or_gate_en.instance_name = f"OR_CONFIG_EN_SRAM_{sram_index}"
+
             self.wire(or_gate_en.ports.I0, core_feature.ports.config.write)
             self.wire(or_gate_en.ports.I1, core_feature.ports.config.read)
-            self.wire(or_gate_en.ports.O[0],
+            self.wire(core_feature.ports.config_en[0],
                       self.underlying.ports["config_en_sram"][sram_index])
             # Still connect to the OR of all the config rd/wr
             self.wire(core_feature.ports.config.write,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e git://github.com/phanrahan/pe.git#egg=pe
 -e git://github.com/StanfordAHA/gemstone.git@done_config#egg=gemstone
--e git://github.com/StanfordAHA/canal.git#egg=canal
+-e git://github.com/StanfordAHA/canal.git@fix_config_en#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e git://github.com/phanrahan/pe.git#egg=pe
--e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
+-e git://github.com/StanfordAHA/gemstone.git@done_config#egg=gemstone
 -e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -69,6 +69,8 @@ def test_interconnect_point_wise(batch_size: int, cw_files, add_pd, io_sides):
         tester.eval()
         tester.expect(circuit.read_config_data, index)
 
+    tester.done_config()
+
     src_x0, src_y0 = placement["I0"]
     src_x1, src_y1 = placement["I1"]
     src_name0 = f"glb2io_16_X{src_x0:02X}_Y{src_y0:02X}"
@@ -164,6 +166,8 @@ def test_interconnect_line_buffer_last_line_valid(cw_files, add_pd, io_sides,
         tester.config_read(addr)
         tester.eval()
         tester.expect(circuit.read_config_data, index)
+
+    tester.done_config()
 
     src_x, src_y = placement["I0"]
     src = f"glb2io_16_X{src_x:02X}_Y{src_y:02X}"
@@ -267,6 +271,8 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
         tester.eval()
         tester.expect(circuit.read_config_data, index)
 
+    tester.done_config()
+
     src_x, src_y = placement["I0"]
     src = f"glb2io_16_X{src_x:02X}_Y{src_y:02X}"
     dst_x, dst_y = placement["I1"]
@@ -369,9 +375,17 @@ def test_interconnect_sram(cw_files, add_pd, io_sides):
     for addr, data in sram_data:
         tester.configure(addr, data)
         # currently read back doesn't work
-        # tester.config_read(addr)
-        # tester.eval()
-        # tester.expect(circuit.read_config_data, data)
+        tester.config_read(addr)
+        tester.eval()
+        tester.expect(circuit.read_config_data, data)
+
+    for addr, index in config_data:
+        tester.configure(addr, index)
+        tester.config_read(addr)
+        tester.eval()
+        tester.expect(circuit.read_config_data, index)
+
+    tester.done_config()
 
     addr_x, addr_y = placement["I0"]
     src = f"glb2io_16_X{addr_x:02X}_Y{addr_y:02X}"


### PR DESCRIPTION
this Ors the config_write and config_read for each SRAM port to be the respective config_en, then ORs together all config_read and config_write and sends to underlying config_read and config_write port on the memory core interface