### PR TITLE
Replace soft_reset_delay with soft_resetting_time

### DIFF
--- a/global_controller/genesis/global_controller.svp
+++ b/global_controller/genesis/global_controller.svp
@@ -551,27 +551,17 @@ always_ff @(posedge clk or posedge reset_in) begin
     end
     else begin
         if (int_cgra_start_pulse) begin
-            if (int_soft_reset_delay == 0) begin
-                soft_reset_cnt <= 0;
-                int_soft_reset <= 1;
-            end
-            else begin
-                soft_reset_cnt <= int_soft_reset_delay;
-                int_soft_reset <= 0;
-            end
+            soft_reset_cnt <= int_soft_reset_delay;
+            int_soft_reset <= 1;
         end
         else begin
-            if (soft_reset_cnt > 1) begin
-                soft_reset_cnt <= soft_reset_cnt - 1;
-                int_soft_reset <= 0;
-            end
-            else if (soft_reset_cnt == 1) begin 
+            if (soft_reset_cnt == 0) begin
                 soft_reset_cnt <= 0;
-                int_soft_reset <= 1;
+                int_soft_reset <= 0;
             end
             else begin
-                soft_reset_cnt <= 0;
-                int_soft_reset <= 0;
+                soft_reset_cnt <= soft_reset_cnt - 1;
+                int_soft_reset <= 1;
             end
         end
     end

--- a/tests/test_global_controller/genesis/test.svp
+++ b/tests/test_global_controller/genesis/test.svp
@@ -546,11 +546,6 @@ typedef enum logic [1:0] {io_ctrl = 2'b01, cfg_ctrl = 2'b10} tile_id;
     axi_write(axi_cgra_soft_reset_en, 1);
     check_register(top.dut.int_cgra_soft_reset_en, 1);
 
-    // axi4 write_cgra_soft_reset_en
-    @(posedge ifc.Clk);
-    axi_write(axi_soft_reset_delay, 4);
-    check_register(top.dut.int_soft_reset_delay, 4);
-
     // axi4 write_ier
     @(posedge ifc.Clk);
     axi_write(axi_ier, 2'b01);
@@ -588,6 +583,16 @@ typedef enum logic [1:0] {io_ctrl = 2'b01, cfg_ctrl = 2'b10} tile_id;
     @(posedge ifc.Clk);
     axi_write(axi_isr, 1);
     check_register(top.dut.int_isr[0], 0);
+
+    // axi4 write_cgra_soft_reset_en
+    @(posedge ifc.Clk);
+    axi_write(axi_soft_reset_delay, 4);
+    check_register(top.dut.int_soft_reset_delay, 4);
+
+    // axi4 write_cgra_start
+    @(posedge ifc.Clk);
+    axi_write(axi_cgra_start, 1);
+    check_register(top.dut.int_cgra_start, 1);
 
     // axi4 write_config_start
     @(posedge ifc.Clk);


### PR DESCRIPTION
This is a minor change about `soft_reset_delay` register.
Previously, `soft_reset` is asserted for one cycle and `soft_reset_delay` register just decided the delay between `cgra_start` and `soft_reset`.
With this PR, `soft_reset` is asserted when `cgra_start` register is written, and `soft_reset_delay` determines how many cycles it would be asserted.
(if `soft_reset_delay` is 0, it is asserted for one cycle. If `soft_reset_delay` is `n`, `soft reset` is asserted for `n+1` cycle.)