### PR TITLE
Db valid

### DIFF
--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -118,16 +118,17 @@ logic                  write_done_d1;
 
 logic next_valid;
 logic write_gate;
-
+logic read_first;
+logic next_take_the_flop;
 logic valid_from_read;
 logic [15:0] vg_ctr;
 logic valid_int;
 logic in_range;
-logic rw;
-assign rw = (rate_matched) ? wen : ren;
+logic read_mux;
+assign read_mux = (rate_matched) ? wen : ren;
 assign in_range = 1;
 
-assign autoswitch = ~arbitrary_addr & write_done & (read_done | init_state);
+assign autoswitch = ~arbitrary_addr & write_done & (read_done | init_state) & (wen | ~rate_matched);
 assign strt_addr = starting_addr[`$wwidth-1`:0];
 assign addr = addr_in[`$awidth-1`:0];
 
@@ -137,7 +138,10 @@ always @ (posedge clk or posedge reset) begin
   if(reset) begin
     data_out_reg <= 0;
   end
-  else if(switch | autoswitch)begin
+  if(flush) begin
+    data_out_reg <= 0;
+  end
+  else begin
     data_out_reg <= data_out;
   end
 end
@@ -164,40 +168,67 @@ always @(posedge clk or posedge reset) begin
 end
 
 always @ (posedge clk or posedge reset) begin
+    if(reset) begin
+        write_done_d1 <= 0;
+    end
+    else begin
+        if(flush) begin
+            write_done_d1 <= 0;
+        end
+        else begin    
+            write_done_d1 <= write_done;
+        end
+    end
+end
+
+
+always @(posedge clk or posedge reset) begin
+    if(reset) begin
+        read_done <= 1;
+    end
+    else begin
+        if(flush) begin
+            read_done <= 0;
+        end
+        else begin
+            if(switch | autoswitch) begin
+                read_done <= 0;
+            end
+            else if(read_cnt == (iter_cnt - 2)) begin
+                read_done <= 1;
+            end
+        end
+    end
+end
+
+
+always @ (posedge clk or posedge reset) begin
   if(reset) begin
-    read_done <= 1'b1;
     write_done <= 1'b0;
-    write_done_d1 <= 1'b0;
   end
   else begin
     if(flush) begin
-      read_done <= 0;
       write_done <= 0;
-      write_done_d1 <= 0;
     end
     else if(switch | autoswitch) begin
-      read_done <= 1'b0;
       write_done <= 1'b0;
-      write_done_d1 <= 1'b0;
     end
     else begin
       if(write_addr == (depth - 2)) begin
         write_done <= 1'b1;
       end
-      if(read_cnt == (iter_cnt - 2)) begin
-        read_done <= 1'b1;
-      end
-      write_done_d1 <= write_done;
     end
   end
 end
+
 
 // valid only used in chaining for db? timing is sorta irrelevant
 assign write_gate = write_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 assign next_valid = read_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 
-assign valid_from_read = (rw) & in_range & ~init_state;
-assign valid = last_line_gate & ((arbitrary_addr | ~rate_matched) ? valid_int : valid_from_read);
+assign valid_from_read = (read_mux) & in_range & ~init_state;
+assign valid = last_line_gate & valid_int;
+//assign valid = last_line_gate & ((arbitrary_addr | ~rate_matched) ? valid_int : valid_from_read);
 
 always @ (posedge clk or posedge reset) begin
   if(reset) begin
@@ -214,7 +245,7 @@ always @ (posedge clk or posedge reset) begin
         valid_int <= valid_from_read;
       end
       else begin
-        valid_int <= valid_from_read | autoswitch;
+        valid_int <= (valid_from_read | autoswitch); //& ~init_state;
       end
     end
   end
@@ -226,7 +257,7 @@ always @(*) begin
   doublebuffer_data_in[`$idx`] = data_in;
 //; }
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
-  doublebuffer_cen_mem[`$idx`] = wen | ~init_state | switch | autoswitch | (rw);
+  doublebuffer_cen_mem[`$idx`] = wen | ~init_state | switch | autoswitch | (read_mux);
 //; }
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
   doublebuffer_wen_mem[`$idx`] = (ping_npong == `$idx`) & (wen | ~write_done_d1) & write_gate;
@@ -268,15 +299,63 @@ always @(posedge clk or posedge reset) begin
 end
 
 
-logic next_take_the_flop;
-assign next_take_the_flop = (take_the_flop & rw) ? 0 : autoswitch | switch | take_the_flop;
+
+assign next_take_the_flop = (autoswitch | switch) ? 1 : 
+                            (take_the_flop & ~(read_mux)) ? 1 :
+                                                    0 ;
+//                            (take_the_flop & rw & ~read_first) ? 0 :
+ //                                       take_the_flop ;
+                                                    
+//assign next_take_the_flop = arbitrary_addr | (take_the_flop & rw & ~read_first) ? 0 : autoswitch | switch | take_the_flop;
+/*
+logic saturated;
+always_ff @(posedge clk or posedge reset) begin
+    if(reset) begin
+        saturated <= 0;
+    end
+    else begin
+        if(flush) begin
+            saturated <= 0;
+        end
+        else begin
+            
+        end
+    end
+end */
+
+
+
+
+always_ff @(posedge clk or posedge reset) begin
+    if(reset) begin
+        read_first <= 1;
+    end
+    else begin
+        if(flush) begin
+            read_first <= 1;
+        end
+        else if(take_the_flop & read_mux) begin
+            read_first <= 0;
+        end
+    end
+end
+
 
 always_ff @(posedge clk or posedge reset) begin
   if(reset) begin
     take_the_flop <= 0;
   end
   else begin
-    take_the_flop <= next_take_the_flop; 
+      if(flush) begin
+         take_the_flop <= 0;
+      end
+      else begin
+         take_the_flop <= next_take_the_flop; 
+      end
+  //  if(switch | autoswitch & ~arbitrary_addr) begin
+  //      take_the_flop <= 1;
+ //   end
+  //  else if()
   end
 end
 
@@ -326,11 +405,11 @@ always_ff @(posedge clk or posedge reset) begin
         // ADDRS
         // ===================
         // Increment write_addr on wen
-        if(wen) begin
+        if(wen & ~write_done) begin
           write_addr <= (write_addr + 1); 
         end
         // Once we expect data to start spilling out, we start moving the read_addr - move is based on counters
-        if(~init_state & (rw) & ~read_done) begin
+        if( (~init_state & read_mux & ~read_done & ~take_the_flop) | (~init_state & read_mux & take_the_flop) ) begin 
           read_cnt <= read_cnt + 1;
         //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
           if(update[`$idx`]) begin

--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -103,7 +103,6 @@ logic [31:0] dim_counter [`$iterator_support-1`:0];
 logic                  update [`$iterator_support-1`:0];
 logic  [`$wwidth-1`:0] data_out_reg;
 logic  [`$wwidth-1`:0] strt_addr;
-logic                  ren_cnt;
 logic  [31:0]          read_cnt;
 logic  [`$wwidth-1`:0] firstn [1:0];
 logic                  take_the_flop;
@@ -228,22 +227,6 @@ always @(posedge clk, posedge reset) begin
       if ((write_addr == strt_addr) & wen) begin
         firstn[0] <= (~ping_npong) ? data_in : firstn[0];
         firstn[1] <= (ping_npong) ? data_in : firstn[1];
-      end
-    end
-  end
-end
-
-always @(posedge clk, posedge reset) begin
-  if(reset) begin
-    ren_cnt <= 0;
-  end
-  else begin
-    if(flush) begin
-      ren_cnt <= 0;
-    end
-    else begin
-      if(take_the_flop & ren) begin
-        ren_cnt <= ren_cnt + 1;
       end
     end
   end

--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -123,6 +123,8 @@ logic valid_from_read;
 logic [15:0] vg_ctr;
 logic valid_int;
 logic in_range;
+logic rw;
+assign rw = (rate_matched) ? wen : ren;
 assign in_range = 1;
 
 assign autoswitch = ~arbitrary_addr & write_done & (read_done | init_state);
@@ -194,7 +196,7 @@ end
 assign write_gate = write_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 assign next_valid = read_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 
-assign valid_from_read = (rate_matched ? wen : ren) & in_range & ~init_state;
+assign valid_from_read = (rw) & in_range & ~init_state;
 assign valid = last_line_gate & ((arbitrary_addr | ~rate_matched) ? valid_int : valid_from_read);
 
 always @ (posedge clk, posedge reset) begin
@@ -224,7 +226,7 @@ always @(*) begin
   doublebuffer_data_in[`$idx`] = data_in;
 //; }
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
-  doublebuffer_cen_mem[`$idx`] = wen | ~init_state | switch | autoswitch | ren;
+  doublebuffer_cen_mem[`$idx`] = wen | ~init_state | switch | autoswitch | (rw);
 //; }
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
   doublebuffer_wen_mem[`$idx`] = (ping_npong == `$idx`) & (wen | ~write_done_d1) & write_gate;
@@ -265,7 +267,21 @@ always @(posedge clk, posedge reset) begin
   end
 end
 
-always @(posedge clk, posedge reset) begin
+
+logic next_take_the_flop;
+assign next_take_the_flop = (take_the_flop & rw) ? 0 : autoswitch | switch | take_the_flop;
+
+always_ff @(posedge clk or posedge reset) begin
+  if(reset) begin
+    take_the_flop <= 0;
+  end
+  else begin
+    take_the_flop <= next_take_the_flop; 
+  end
+end
+
+//always @(posedge clk, posedge reset) begin
+always_ff @(posedge clk or posedge reset) begin
   if(reset) begin 
   //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
     dim_counter[`$idx`] <= 0;
@@ -276,7 +292,6 @@ always @(posedge clk, posedge reset) begin
     init_state <= 1'b1;
     ping_npong <= 0;
     write_addr <= 0;
-    take_the_flop <= 0;
     read_cnt <= 0;
   end
   else begin
@@ -290,7 +305,6 @@ always @(posedge clk, posedge reset) begin
       init_state <= 1'b1;
       ping_npong <= 0;
       write_addr <= 0;
-      take_the_flop <= 0;
       read_cnt <= 0;
     end
     else begin
@@ -301,7 +315,6 @@ always @(posedge clk, posedge reset) begin
         read_cnt <= 0;
         write_addr <= 0;
         init_state <= 0;
-        take_the_flop <= ~arbitrary_addr;
       //; for (my $idx = 1; $idx < $iterator_support; $idx++) {
         dim_counter[`$idx`] <= 0;
         current_loc[`$idx`] <= 0;
@@ -313,19 +326,12 @@ always @(posedge clk, posedge reset) begin
         // ===================
         // ADDRS
         // ===================
-        if(take_the_flop) begin
-          // If in auto mode - just turn it off
-          if(ren) begin
-            take_the_flop <= 0;
-          end 
-        end
-
         // Increment write_addr on wen
         if(wen) begin
           write_addr <= (write_addr + 1); 
         end
         // Once we expect data to start spilling out, we start moving the read_addr - move is based on counters
-        if(~init_state & (rate_matched ? wen : ren) & ~read_done) begin
+        if(~init_state & (rw) & ~read_done) begin
           read_cnt <= read_cnt + 1;
         //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
           if(update[`$idx`]) begin

--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -164,6 +164,9 @@ end
 assign write_gate = write_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 assign next_valid = read_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 
+logic valid_from_read;
+assign valid_from_read = ren & in_range & ~init_state;
+
 always @ (posedge clk, posedge reset) begin
   if(reset) begin
     valid <= 1'b0;
@@ -176,10 +179,10 @@ always @ (posedge clk, posedge reset) begin
       if(arbitrary_addr) begin
         // In arbitrary mode, valid will go high
         // if you assert an in_range ren
-        valid <= ren & in_range & ~init_state;
+        valid <= valid_from_read;
       end
       else begin
-        valid <= (ren & in_range & ~init_state) | (autoswitch);
+        valid <= valid_from_read | autoswitch;
       end
     end
   end

--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -133,7 +133,7 @@ assign addr = addr_in[`$awidth-1`:0];
 
 assign last_line_gate = (stencil_width == 0) ? 1 : vg_ctr >= (stencil_width - 1);
 
-always @ (posedge clk, posedge reset) begin
+always @ (posedge clk or posedge reset) begin
   if(reset) begin
     data_out_reg <= 0;
   end
@@ -163,7 +163,7 @@ always @(posedge clk or posedge reset) begin
   end
 end
 
-always @ (posedge clk, posedge reset) begin
+always @ (posedge clk or posedge reset) begin
   if(reset) begin
     read_done <= 1'b1;
     write_done <= 1'b0;
@@ -199,7 +199,7 @@ assign next_valid = read_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 assign valid_from_read = (rw) & in_range & ~init_state;
 assign valid = last_line_gate & ((arbitrary_addr | ~rate_matched) ? valid_int : valid_from_read);
 
-always @ (posedge clk, posedge reset) begin
+always @ (posedge clk or posedge reset) begin
   if(reset) begin
     valid_int <= 1'b0;
   end
@@ -248,7 +248,7 @@ always @(*) begin
 //; }
 end
 
-always @(posedge clk, posedge reset) begin
+always @(posedge clk or posedge reset) begin
   if(reset) begin
     firstn[0] <= 0;
     firstn[1] <= 0;
@@ -280,7 +280,6 @@ always_ff @(posedge clk or posedge reset) begin
   end
 end
 
-//always @(posedge clk, posedge reset) begin
 always_ff @(posedge clk or posedge reset) begin
   if(reset) begin 
   //; for (my $idx = 0; $idx < $iterator_support; $idx++) {

--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -47,7 +47,10 @@ module `mname()`(
   iter_cnt,
   dimensionality,
   stride,
-  range
+  range,
+
+  rate_matched,
+  stencil_width
 );
 
 // =============================================
@@ -56,6 +59,8 @@ module `mname()`(
 input logic        chain_en;
 input logic [3:0]  chain_idx;
 
+input logic [15:0] stencil_width;
+input logic        rate_matched;
 // ==============================================
 // I/O
 // ==============================================
@@ -114,13 +119,17 @@ logic                  write_done_d1;
 logic next_valid;
 logic write_gate;
 
+logic valid_from_read;
+logic [15:0] vg_ctr;
+logic valid_int;
 logic in_range;
 assign in_range = 1;
 
 assign autoswitch = ~arbitrary_addr & write_done & (read_done | init_state);
-
 assign strt_addr = starting_addr[`$wwidth-1`:0];
 assign addr = addr_in[`$awidth-1`:0];
+
+assign last_line_gate = (stencil_width == 0) ? 1 : vg_ctr >= (stencil_width - 1);
 
 always @ (posedge clk, posedge reset) begin
   if(reset) begin
@@ -128,6 +137,27 @@ always @ (posedge clk, posedge reset) begin
   end
   else if(switch | autoswitch)begin
     data_out_reg <= data_out;
+  end
+end
+
+always @(posedge clk or posedge reset) begin
+  if(reset) begin
+    vg_ctr <= 0;
+  end
+  else begin
+    if(flush) begin
+      vg_ctr <= 0;
+    end
+    else begin
+        if(~init_state) begin
+          if(vg_ctr == (depth - 1)) begin
+            vg_ctr <= 0;
+          end
+          else begin
+            vg_ctr <= vg_ctr + 1;
+          end
+        end
+    end
   end
 end
 
@@ -164,25 +194,25 @@ end
 assign write_gate = write_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 assign next_valid = read_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 
-logic valid_from_read;
-assign valid_from_read = ren & in_range & ~init_state;
+assign valid_from_read = (rate_matched ? wen : ren) & in_range & ~init_state;
+assign valid = last_line_gate & ((arbitrary_addr | ~rate_matched) ? valid_int : valid_from_read);
 
 always @ (posedge clk, posedge reset) begin
   if(reset) begin
-    valid <= 1'b0;
+    valid_int <= 1'b0;
   end
   else begin
     if(flush) begin
-      valid <= 1'b0;
+      valid_int <= 1'b0;
     end
     else begin
       if(arbitrary_addr) begin
         // In arbitrary mode, valid will go high
         // if you assert an in_range ren
-        valid <= valid_from_read;
+        valid_int <= valid_from_read;
       end
       else begin
-        valid <= valid_from_read | autoswitch;
+        valid_int <= valid_from_read | autoswitch;
       end
     end
   end
@@ -295,7 +325,7 @@ always @(posedge clk, posedge reset) begin
           write_addr <= (write_addr + 1); 
         end
         // Once we expect data to start spilling out, we start moving the read_addr - move is based on counters
-        if(~init_state & ren & ~read_done) begin
+        if(~init_state & (rate_matched ? wen : ren) & ~read_done) begin
           read_cnt <= read_cnt + 1;
         //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
           if(update[`$idx`]) begin

--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -128,7 +128,7 @@ logic read_mux;
 assign read_mux = (rate_matched) ? wen : ren;
 assign in_range = 1;
 
-assign autoswitch = ~arbitrary_addr & write_done & (read_done | init_state) & (wen | ~rate_matched);
+assign autoswitch = ~arbitrary_addr & write_done & (read_done | ~init_state) & (wen | ~rate_matched);
 assign strt_addr = starting_addr[`$wwidth-1`:0];
 assign addr = addr_in[`$awidth-1`:0];
 
@@ -155,7 +155,7 @@ always @(posedge clk or posedge reset) begin
       vg_ctr <= 0;
     end
     else begin
-        if(~init_state) begin
+        if(init_state) begin
           if(vg_ctr == (depth - 1)) begin
             vg_ctr <= 0;
           end
@@ -226,7 +226,7 @@ end
 assign write_gate = write_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 assign next_valid = read_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 
-assign valid_from_read = (read_mux) & in_range & ~init_state;
+assign valid_from_read = (read_mux) & in_range & init_state;
 assign valid = last_line_gate & valid_int;
 //assign valid = last_line_gate & ((arbitrary_addr | ~rate_matched) ? valid_int : valid_from_read);
 
@@ -257,7 +257,7 @@ always @(*) begin
   doublebuffer_data_in[`$idx`] = data_in;
 //; }
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
-  doublebuffer_cen_mem[`$idx`] = wen | ~init_state | switch | autoswitch | (read_mux);
+  doublebuffer_cen_mem[`$idx`] = wen | init_state | switch | autoswitch | (read_mux);
 //; }
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
   doublebuffer_wen_mem[`$idx`] = (ping_npong == `$idx`) & (wen | ~write_done_d1) & write_gate;
@@ -272,7 +272,7 @@ always @(*) begin
    ((`$idx` < dimensionality) ? (current_loc[`$idx`]) : 0) +
   //; }
     (current_loc[0]) + strt_addr;
-  update[0] = ~init_state;
+  update[0] = init_state;
   // Update iterator when the previous one will update and flow over
 //; for (my $idx = 1 ; $idx < $iterator_support; $idx++) {
   update[`$idx`] = ((dim_counter[`$idx-1`]) == (range[`$idx-1`] - 1)) & update[`$idx-1`];
@@ -360,6 +360,21 @@ always_ff @(posedge clk or posedge reset) begin
 end
 
 always_ff @(posedge clk or posedge reset) begin
+	if(reset) begin
+		init_state <= 0;
+	end
+	else begin
+		if(flush) begin
+			init_state <= 0;
+		end
+		else if(autoswitch | switch) begin
+			init_state <= 1;
+		end
+	end
+end
+
+
+always_ff @(posedge clk or posedge reset) begin
   if(reset) begin 
   //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
     dim_counter[`$idx`] <= 0;
@@ -367,7 +382,6 @@ always_ff @(posedge clk or posedge reset) begin
   //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
     current_loc[`$idx`] <= 0;
   //; }
-    init_state <= 1'b1;
     ping_npong <= 0;
     write_addr <= 0;
     read_cnt <= 0;
@@ -380,7 +394,6 @@ always_ff @(posedge clk or posedge reset) begin
     //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
       current_loc[`$idx`] <= 0;
     //; }
-      init_state <= 1'b1;
       ping_npong <= 0;
       write_addr <= 0;
       read_cnt <= 0;
@@ -392,7 +405,6 @@ always_ff @(posedge clk or posedge reset) begin
         ping_npong <= ~ping_npong;
         read_cnt <= 0;
         write_addr <= 0;
-        init_state <= 0;
       //; for (my $idx = 1; $idx < $iterator_support; $idx++) {
         dim_counter[`$idx`] <= 0;
         current_loc[`$idx`] <= 0;
@@ -409,7 +421,7 @@ always_ff @(posedge clk or posedge reset) begin
           write_addr <= (write_addr + 1); 
         end
         // Once we expect data to start spilling out, we start moving the read_addr - move is based on counters
-        if( (~init_state & read_mux & ~read_done & ~take_the_flop) | (~init_state & read_mux & take_the_flop) ) begin 
+        if( (init_state & read_mux & ~read_done & ~take_the_flop) | (init_state & read_mux & take_the_flop) ) begin 
           read_cnt <= read_cnt + 1;
         //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
           if(update[`$idx`]) begin

--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -19,71 +19,66 @@
 
 module `mname()`(
 
-   clk,
-   clk_en,
-   reset,
-   flush,
-   ren,
-   wen,
-   data_in,
-   data_out,
+  clk,
+  clk_en,
+  reset,
+  flush,
+  ren,
+  wen,
+  data_in,
+  data_out,
+  addr_in,
 
-   doublebuffer_data_in,
-   doublebuffer_cen_mem,
-   doublebuffer_wen_mem,
-   doublebuffer_addr_mem,
-   doublebuffer_data_out,
+  doublebuffer_data_in,
+  doublebuffer_cen_mem,
+  doublebuffer_wen_mem,
+  doublebuffer_addr_mem,
+  doublebuffer_data_out,
 
-   addr_in,
+  depth,
+  valid,
+  switch,
 
-   depth,
-   valid,
-   switch,
+  chain_en,
+  chain_idx,
 
-   chain_en,
-   chain_idx,
-
-   read_mode,
-   arbitrary_addr,
-   starting_addr,
-   iter_cnt,
-   dimensionality,
-   stride,
-   range
+  arbitrary_addr,
+  starting_addr,
+  iter_cnt,
+  dimensionality,
+  stride,
+  range
 );
-
 
 // =============================================
 // Depth or Ping Pong In Configuration
 // =============================================
-input logic       chain_en;
-input logic [3:0] chain_idx;
+input logic        chain_en;
+input logic [3:0]  chain_idx;
 
 // ==============================================
 // I/O
 // ==============================================
-input logic                   clk;
-input logic                   clk_en;
-input logic                   reset;
+input logic        clk;
+input logic        clk_en;
+input logic        reset;
+input logic        switch;
 
-input logic                   switch;
-
-input logic read_mode;
-input logic  arbitrary_addr;
+input logic        arbitrary_addr;
 input logic [15:0] starting_addr; 
 input logic [31:0] iter_cnt;
-input logic [3:0] dimensionality;
+input logic [3:0]  dimensionality;
 
 input logic [15:0] stride [`$iterator_support-1`:0];
 input logic [31:0] range [`$iterator_support-1`:0];
-logic [15:0] current_loc [`$iterator_support-1`:0];
+logic       [15:0] current_loc [`$iterator_support-1`:0];
 
 input logic                   flush;
 input logic                   wen;
 input logic                   ren;
 input logic  [`$wwidth-1`:0]  data_in;
 output logic [`$wwidth-1`:0]  data_out;
-input logic [`$wwidth-1`:0] addr_in;
+input logic  [`$wwidth-1`:0]  addr_in;
 
 output logic [`$wwidth-1`:0]  doublebuffer_data_in  [`$bbanks-1`:0];
 output logic [`$bbanks-1`:0]  doublebuffer_cen_mem;
@@ -91,138 +86,131 @@ output logic [`$bbanks-1`:0]  doublebuffer_wen_mem;
 output logic [`$awidth-1`:0]  doublebuffer_addr_mem [`$bbanks-1`:0];
 input logic  [`$wwidth-1`:0]  doublebuffer_data_out [`$bbanks-1`:0];
 
-
-input logic [12:0]            depth;
-output logic                   valid;
-
+input logic  [12:0]           depth;
+output logic                  valid;
 // ==============================================
 // Internal
 // ==============================================
-logic init_state;
-logic  [12:0]                  depth_int;
-
-logic [`$awidth-1`:0] addr;
-assign addr = addr_in[`$awidth-1`:0];
-
-logic ping_npong;
-
-logic [`$wwidth-1`:0] read_addr;
-logic [`$wwidth-1`:0] write_addr;
-
+logic                  init_state;
+logic [`$awidth-1`:0]  addr;
+logic                  ping_npong;
+logic [`$wwidth-1`:0]  read_addr;
+logic [`$wwidth-1`:0]  write_addr;
 logic [31:0] dim_counter [`$iterator_support-1`:0]; 
-
 // ==============================================
 // Configuration
 // ==============================================
 logic                  update [`$iterator_support-1`:0];
 logic  [`$wwidth-1`:0] data_out_reg;
-logic [`$wwidth-1`:0] strt_addr;
+logic  [`$wwidth-1`:0] strt_addr;
+logic                  ren_cnt;
+logic  [31:0]          read_cnt;
+logic  [`$wwidth-1`:0] firstn [1:0];
+logic                  take_the_flop;
+logic                  autoswitch;
+logic                  read_done;
+logic                  write_done;
+logic                  write_done_d1;
+
+logic next_valid;
+logic write_gate;
+
+assign autoswitch = ~arbitrary_addr & write_done & (read_done | init_state);
 
 assign strt_addr = starting_addr[`$wwidth-1`:0];
-
-logic ren_cnt;
-
-logic [31:0] read_cnt;
-
-logic [`$wwidth-1`:0] firstn [1:0];
-logic take_the_flop;
-
-logic autoswitch;
-logic read_done;
-logic write_done;
-logic write_done_d1;
-
-assign autoswitch = (~read_mode & ~arbitrary_addr) ? write_done & (read_done | init_state) : 1'b0;
+assign addr = addr_in[`$awidth-1`:0];
 
 always @ (posedge clk, posedge reset) begin
-    if(reset) begin
-        data_out_reg <= 0;
-    end
-    else if(switch | autoswitch)begin
-        data_out_reg <= data_out;
-    end
+  if(reset) begin
+    data_out_reg <= 0;
+  end
+  else if(switch | autoswitch)begin
+    data_out_reg <= data_out;
+  end
 end
 
 always @ (posedge clk, posedge reset) begin
-    if(reset) begin
-        read_done <= 1'b1;
-        write_done <= 1'b0;
-        write_done_d1 <= 1'b0;
+  if(reset) begin
+    read_done <= 1'b1;
+    write_done <= 1'b0;
+    write_done_d1 <= 1'b0;
+  end
+  else begin
+    if(flush) begin
+      read_done <= 0;
+      write_done <= 0;
+      write_done_d1 <= 0;
     end
     else if(switch | autoswitch) begin
-        read_done <= 1'b0;
-        write_done <= 1'b0;
-        write_done_d1 <= 1'b0;
+      read_done <= 1'b0;
+      write_done <= 1'b0;
+      write_done_d1 <= 1'b0;
     end
     else begin
-        if(write_addr == (depth - 2)) begin
-            write_done <= 1'b1;
-        end
-        if(read_cnt == (iter_cnt - 2)) begin
-            read_done <= 1'b1;
-        end
-        write_done_d1 <= write_done;
+      if(write_addr == (depth - 2)) begin
+        write_done <= 1'b1;
+      end
+      if(read_cnt == (iter_cnt - 2)) begin
+        read_done <= 1'b1;
+      end
+      write_done_d1 <= write_done;
     end
+  end
 end
 
-logic write_gate;
-assign write_gate = write_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
-logic next_valid;
-
 // valid only used in chaining for db? timing is sorta irrelevant
+assign write_gate = write_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 assign next_valid = read_addr[`$awidth+4-1`:`$awidth`] == chain_idx;
 
 always @ (posedge clk, posedge reset) begin
-    if(reset) begin
-        valid <= 1'b0;
+  if(reset) begin
+    valid <= 1'b0;
+  end
+  else begin
+    if(flush) begin
+      valid <= 1'b0;
     end
     else begin
-        valid <= next_valid & ((~init_state) | switch | autoswitch);
+      valid <= next_valid & ((~init_state) | switch | autoswitch);
     end
+  end
 end
 
-
 always @(*) begin
-
-  // Data to memory is just da, n
+  // Data to memory is just data in
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
   doublebuffer_data_in[`$idx`] = data_in;
 //; }
-
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
-  doublebuffer_cen_mem[`$idx`] = ((wen & read_mode) | ~init_state | switch | autoswitch | (ren & read_mode) | ~read_mode);
+  doublebuffer_cen_mem[`$idx`] = wen | ~init_state | switch | autoswitch | ren;
 //; }
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
-  doublebuffer_wen_mem[`$idx`] = (ping_npong == `$idx`) & ((wen & read_mode) | (~read_mode & ~write_done_d1)) & (write_gate);
+  doublebuffer_wen_mem[`$idx`] = (ping_npong == `$idx`) & (wen | ~write_done_d1) & write_gate;
 //; }
 //; for (my $idx = 0; $idx < $bbanks; $idx++) {
   doublebuffer_addr_mem[`$idx`] = (ping_npong == `$idx`) ? write_addr : read_addr;
 //; }
   // select proper data - 
   data_out = take_the_flop ? firstn[~ping_npong] : doublebuffer_data_out[~ping_npong];
-  
-  read_addr = (arbitrary_addr) ? addr :  
+  read_addr = arbitrary_addr ? addr :  
   //; for (my $idx = $iterator_support - 1; $idx > 0; $idx--) {
    ((`$idx` < dimensionality) ? (current_loc[`$idx`]) : 0) +
   //; }
     (current_loc[0]) + strt_addr;
-
   update[0] = ~init_state;
   // Update iterator when the previous one will update and flow over
 //; for (my $idx = 1 ; $idx < $iterator_support; $idx++) {
   update[`$idx`] = ((dim_counter[`$idx-1`]) == (range[`$idx-1`] - 1)) & update[`$idx-1`];
 //; }
-  // Innermost loop always updated
-
 end
 
 always @(posedge clk, posedge reset) begin
-  if (reset) begin
+  if(reset) begin
     firstn[0] <= 0;
     firstn[1] <= 0;
   end
   else begin
-    if (flush) begin
+    if(flush) begin
       firstn[0] <= 0;
       firstn[1] <= 0;
     end
@@ -236,31 +224,29 @@ always @(posedge clk, posedge reset) begin
 end
 
 always @(posedge clk, posedge reset) begin
-    if (reset) begin
-        ren_cnt <= 0;
+  if(reset) begin
+    ren_cnt <= 0;
+  end
+  else begin
+    if(flush) begin
+      ren_cnt <= 0;
     end
     else begin
-        if (flush) begin
-            ren_cnt <= 0;
-        end
-        else begin
-          if(take_the_flop & ren) begin
-             ren_cnt <= ren_cnt + 1;
-          end
-       end
+      if(take_the_flop & ren) begin
+        ren_cnt <= ren_cnt + 1;
+      end
     end
+  end
 end
 
-
 always @(posedge clk, posedge reset) begin
-  if (reset) begin 
+  if(reset) begin 
   //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
     dim_counter[`$idx`] <= 0;
   //; }
   //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
     current_loc[`$idx`] <= 0;
   //; }
-    depth_int <= 0;
     init_state <= 1'b1;
     ping_npong <= 0;
     write_addr <= 0;
@@ -268,25 +254,22 @@ always @(posedge clk, posedge reset) begin
     read_cnt <= 0;
   end
   else begin
-    if (flush) begin 
+    if(flush) begin 
     //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
       dim_counter[`$idx`] <= 0;
     //; }
     //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
       current_loc[`$idx`] <= 0;
     //; }
-    depth_int <= 0;
-    init_state <= 1'b1;
-    ping_npong <= 0;
-    write_addr <= 0;
-    take_the_flop <= 0;
-    read_cnt <= 0;
+      init_state <= 1'b1;
+      ping_npong <= 0;
+      write_addr <= 0;
+      take_the_flop <= 0;
+      read_cnt <= 0;
     end
     else begin
-      depth_int <= depth;
       // When we switch for the first time (and all times), the valid becomes 1 because good data is at the output
       // Start over write and read addr, switch buffer (ping or pong)
-      // and kill counters
       if(switch | autoswitch) begin // Or if configged to trigger on depth
         ping_npong <= ~ping_npong;
         read_cnt <= 0;
@@ -295,11 +278,9 @@ always @(posedge clk, posedge reset) begin
         take_the_flop <= ~arbitrary_addr;
       //; for (my $idx = 1; $idx < $iterator_support; $idx++) {
         dim_counter[`$idx`] <= 0;
-      //; }
-        dim_counter[0] <= (range[0] > 1) ? 1 : 0; 
-      //; for (my $idx = 1; $idx < $iterator_support; $idx++) {
         current_loc[`$idx`] <= 0;
       //; }
+        dim_counter[0] <= range[0] > 1; 
         current_loc[0] <= stride[0];
       end
       else begin
@@ -308,52 +289,34 @@ always @(posedge clk, posedge reset) begin
         // ===================
         if(take_the_flop) begin
           // If in auto mode - just turn it off
-          if(~read_mode) begin
+          if(ren) begin
             take_the_flop <= 0;
-          end
-          else begin
-            if(ren_cnt & ren) begin
-              take_the_flop <= 0;
-            end 
-          end
-          // If in read mode - want to kill it once we get the second ren
+          end 
         end
 
         // Increment write_addr on wen
-        if ((wen)) begin
-        //if ((wen & read_mode) | (~write_done & ~read_mode)) begin
+        if(wen) begin
           write_addr <= (write_addr + 1); 
         end
         // Once we expect data to start spilling out, we start moving the read_addr - move is based on counters
-        if (~init_state & ((~read_mode & ~read_done) | (read_mode & ((ren & ~take_the_flop) | (ren & take_the_flop & ren_cnt))))) begin
+        if(~init_state & ren & ~read_done) begin
           read_cnt <= read_cnt + 1;
-
         //; for (my $idx = 0; $idx < $iterator_support; $idx++) {
           if(update[`$idx`]) begin
-              if(dim_counter[`$idx`] == (range[`$idx`] - 1)) begin
-                dim_counter[`$idx`] <= 0;
-                current_loc[`$idx`] <= 0;
-              end
-              else begin
-                dim_counter[`$idx`] <= dim_counter[`$idx`] + 1;
-                current_loc[`$idx`] <= current_loc[`$idx`] + stride[`$idx`];
-              end
+            if(dim_counter[`$idx`] == (range[`$idx`] - 1)) begin
+              dim_counter[`$idx`] <= 0;
+              current_loc[`$idx`] <= 0;
+            end
+            else begin
+              dim_counter[`$idx`] <= dim_counter[`$idx`] + 1;
+              current_loc[`$idx`] <= current_loc[`$idx`] + stride[`$idx`];
+            end
           end
         //; }
-//          if(dim_counter[0] == (range[0] - 1)) begin
- //           dim_counter[0] <= 0;
- //           current_loc[0] <= 0;
- //         end
- //         else begin
- //           dim_counter[0] <= dim_counter[0] + 1;
-  //          current_loc[0] <= current_loc[0] + stride[0];
-    //      end
         end
       end
     end
-  // else
   end
-// always  
 end
 
 endmodule

--- a/memory_core/genesis_new/doublebuffer_control.svp
+++ b/memory_core/genesis_new/doublebuffer_control.svp
@@ -115,6 +115,9 @@ logic                  write_done_d1;
 logic next_valid;
 logic write_gate;
 
+logic in_range;
+assign in_range = 1;
+
 assign autoswitch = ~arbitrary_addr & write_done & (read_done | init_state);
 
 assign strt_addr = starting_addr[`$wwidth-1`:0];
@@ -171,7 +174,14 @@ always @ (posedge clk, posedge reset) begin
       valid <= 1'b0;
     end
     else begin
-      valid <= next_valid & ((~init_state) | switch | autoswitch);
+      if(arbitrary_addr) begin
+        // In arbitrary mode, valid will go high
+        // if you assert an in_range ren
+        valid <= ren & in_range & ~init_state;
+      end
+      else begin
+        valid <= (ren & in_range & ~init_state) | (autoswitch);
+      end
     end
   end
 end

--- a/memory_core/genesis_new/linebuffer_control.svp
+++ b/memory_core/genesis_new/linebuffer_control.svp
@@ -49,7 +49,7 @@ logic valid_gate;
 logic valid_int;
 logic threshold;
 
-assign valid_gate = (stencil_width == (16'b0)) ? 16'b1 : vg_ctr >= (stencil_width - 1); 
+assign valid_gate = (stencil_width == 0) ? 1 : vg_ctr >= (stencil_width - 1); 
 assign valid_int = (num_words_mem >= (depth - 1)) & wen & (depth > 0) & threshold; 
 assign valid = valid_gate & valid_int;
 assign ren_to_fifo = (num_words_mem >= (depth - 1)) & wen & (depth > 0);
@@ -78,7 +78,7 @@ always @(posedge clk, posedge reset) begin
         end
         else begin
           if(valid_int) begin
-              if(vg_ctr == (depth-1)) begin
+            if(vg_ctr == (depth-1)) begin
                 vg_ctr <= 0;
             end
             else begin

--- a/memory_core/genesis_new/memory_core.svp
+++ b/memory_core/genesis_new/memory_core.svp
@@ -43,6 +43,7 @@ module `mname`(
    almost_empty, 
 
    switch_db,
+   rate_matched,
 
    config_addr, 
    config_data, 
@@ -80,7 +81,8 @@ input logic [15:0] stencil_width;
 input logic        arbitrary_addr;
 input logic [15:0] starting_addr;
 input logic [31:0] iter_cnt;
-input logic [3:0] dimensionality;
+input logic [3:0]  dimensionality;
+input logic        rate_matched;   
 //; for(my $idx = 0; $idx < $iterator_support; $idx++) {
 input logic [15:0] `'stride_' . $idx`;
 //; }
@@ -272,15 +274,27 @@ always @(*) begin
    // LINE BUFFER MODE
    // ========================================================
    2'd0: begin 
-      mem_cen_int = fifo_cen;
-      mem_wen = fifo_wen;
+   //   mem_cen_int = fifo_cen;
+   //   mem_wen = fifo_wen;
+   //   mem_ren = {$bbanks{1'b1}};
+   //   mem_addr = fifo_addr;
+   //   mem_data_in = fifo_mem_data_out;
+   //   data_out = fifo_out; 
+//      valid_out = lb_valid_out; //& wen_in_int;
+ //     almost_full = fifo_almost_full;
+//      almost_empty = fifo_almost_empty;
+
+      mem_cen_int = db_cen;
+      mem_wen = db_wen;
+      //mem_ren = sram_ren;
       mem_ren = {`$bbanks`{1'b1}};
-      mem_addr = fifo_addr;
-      mem_data_in = fifo_mem_data_out;
-      data_out = fifo_out; 
-      valid_out = lb_valid_out; //& wen_in_int;
-      almost_full = fifo_almost_full;
-      almost_empty = fifo_almost_empty;
+      mem_addr = db_addr;
+      mem_data_in = db_mem_data_out;
+      data_out = (enable_chain & chain_wen_in) ? chain_in : db_out;
+      valid_out = db_valid_out;
+      almost_full = 1'b0;
+      almost_empty = 1'b0;
+
    end
 
    // ========================================================
@@ -477,7 +491,11 @@ assign mem_cen[`$i`] = mem_cen_int[`$i`] & ( mem_wen[`$i`] | mem_ren[`$i`]);
 .iter_cnt(iter_cnt),
 .dimensionality(dimensionality),
 .stride(stride),
-.range(range)
+.range(range),
+
+// merge with LB
+.rate_matched(rate_matched),
+.stencil_width(stencil_width)
 
 );
 

--- a/memory_core/genesis_new/memory_core.svp
+++ b/memory_core/genesis_new/memory_core.svp
@@ -274,27 +274,15 @@ always @(*) begin
    // LINE BUFFER MODE
    // ========================================================
    2'd0: begin 
-   //   mem_cen_int = fifo_cen;
-   //   mem_wen = fifo_wen;
-   //   mem_ren = {$bbanks{1'b1}};
-   //   mem_addr = fifo_addr;
-   //   mem_data_in = fifo_mem_data_out;
-   //   data_out = fifo_out; 
-//      valid_out = lb_valid_out; //& wen_in_int;
- //     almost_full = fifo_almost_full;
-//      almost_empty = fifo_almost_empty;
-
-      mem_cen_int = db_cen;
-      mem_wen = db_wen;
-      //mem_ren = sram_ren;
+      mem_cen_int = fifo_cen;
+      mem_wen = fifo_wen;
       mem_ren = {`$bbanks`{1'b1}};
-      mem_addr = db_addr;
-      mem_data_in = db_mem_data_out;
-      data_out = (enable_chain & chain_wen_in) ? chain_in : db_out;
-      valid_out = db_valid_out;
-      almost_full = 1'b0;
-      almost_empty = 1'b0;
-
+      mem_addr = fifo_addr;
+      mem_data_in = fifo_mem_data_out;
+      data_out = fifo_out; 
+      valid_out = lb_valid_out; 
+      almost_full = fifo_almost_full;
+      almost_empty = fifo_almost_empty;
    end
 
    // ========================================================

--- a/memory_core/genesis_new/memory_core.svp
+++ b/memory_core/genesis_new/memory_core.svp
@@ -52,11 +52,10 @@ module `mname`(
 //; for (my $i = 0; $i < $num_sram_reads; $i++) {
    `'read_data_sram_' . $i`,
 //; }
-
+   // Fake
    read_config_data,
    // Config
    stencil_width,
-   read_mode,
    arbitrary_addr,
    starting_addr,
    iter_cnt,
@@ -68,7 +67,6 @@ module `mname`(
   `'range_' . $idx`,
 //; }
    circular_en,
-
    almost_count,
    enable_chain,
    mode,
@@ -79,7 +77,6 @@ module `mname`(
 
 // ALL CONFIG
 input logic [15:0] stencil_width;
-input logic        read_mode;
 input logic        arbitrary_addr;
 input logic [15:0] starting_addr;
 input logic [31:0] iter_cnt;
@@ -475,7 +472,6 @@ assign mem_cen[`$i`] = mem_cen_int[`$i`] & ( mem_wen[`$i`] | mem_ren[`$i`]);
 .chain_en(enable_chain),
 .chain_idx(chain_idx),
 
-.read_mode(read_mode),
 .arbitrary_addr(arbitrary_addr),
 .starting_addr(starting_addr),
 .iter_cnt(iter_cnt),

--- a/memory_core/memory_core.py
+++ b/memory_core/memory_core.py
@@ -86,7 +86,6 @@ def gen_memory_core(data_width: int, data_depth: int):
         def switch(self):
             if self.__mode == Mode.DB:
                 self._db_model.switch()
-                print("switch")
             else:
                 raise NotImplementedError(self.__mode)  # pragma: nocover
 
@@ -98,7 +97,6 @@ def gen_memory_core(data_width: int, data_depth: int):
                 self.data_out = self._fifo_model.dequeue()
             elif self.__mode == Mode.DB:
                 self.data_out = self._db_model.read(0, addr)[0]
-                print(self.data_out)
             else:
                 raise NotImplementedError(self.__mode)  # pragma: nocover
 
@@ -158,7 +156,6 @@ def gen_memory_core(data_width: int, data_depth: int):
             elif self.__mode == Mode.DB:
                 self._db_model.write(data)
                 self.data_out = self._db_model.read(0, addr)[0]
-                print(self.data_out)
             else:
                 raise NotImplementedError(self.__mode)  # pragma: nocover
 

--- a/memory_core/memory_core.py
+++ b/memory_core/memory_core.py
@@ -18,7 +18,7 @@ class Memory:
         self.memory = {BitVector(i, address_width): BitVector(0, data_width)
                        for i in range(self.data_depth)}
 
-    def check_addr(fn): # pragma: nocover
+    def check_addr(fn):  # pragma: nocover
         @functools.wraps(fn)
         def wrapped(self, addr, *args):
             assert 0 <= addr < self.data_depth, \
@@ -28,10 +28,10 @@ class Memory:
 
     @check_addr
     def read(self, addr):
-        return self.memory[addr] # pragma: nocover
+        return self.memory[addr]  # pragma: nocover
 
     @check_addr
-    def write(self, addr, value): # pragma: nocover
+    def write(self, addr, value):  # pragma: nocover
         if isinstance(value, BitVector):
             assert value.num_bits <= self.data_width, \
                 f"value.num_bits must be <= {self.data_width}"
@@ -157,7 +157,7 @@ def gen_memory_core(data_width: int, data_depth: int):
                 raise NotImplementedError(self.__mode)  # pragma: nocover
 
         def __call__(self, *args, **kwargs):
-            raise NotImplementedError() # pragma: nocover
+            raise NotImplementedError()  # pragma: nocover
 
         @property
         def __mode(self):

--- a/memory_core/memory_core.py
+++ b/memory_core/memory_core.py
@@ -18,28 +18,6 @@ class Memory:
         self.memory = {BitVector(i, address_width): BitVector(0, data_width)
                        for i in range(self.data_depth)}
 
-    def check_addr(fn):  # pragma: nocover
-        @functools.wraps(fn)
-        def wrapped(self, addr, *args):
-            assert 0 <= addr < self.data_depth, \
-                f"Address ({addr}) must be within range(0, {self.data_depth})"
-            return fn(self, addr, *args)
-        return wrapped
-
-    @check_addr
-    def read(self, addr):
-        return self.memory[addr]  # pragma: nocover
-
-    @check_addr
-    def write(self, addr, value):  # pragma: nocover
-        if isinstance(value, BitVector):
-            assert value.num_bits <= self.data_width, \
-                f"value.num_bits must be <= {self.data_width}"
-        if isinstance(value, int):
-            assert value.bit_length() <= self.data_width, \
-                f"value.bit_length() must be <= {self.data_width}"
-        self.memory[addr] = value
-
 
 def gen_memory_core(data_width: int, data_depth: int):
 
@@ -66,7 +44,6 @@ def gen_memory_core(data_width: int, data_depth: int):
             self.memory = Memory(address_width, data_width)
             self.data_out = fault.UnknownValue
             self.read_data = fault.UnknownValue
-            # TODO: Is the initial config actually 0?
             self.configure(CONFIG_ADDR, BitVector(0, 32))
             # Ignore these signals for now
             self.valid_out = fault.UnknownValue
@@ -166,5 +143,4 @@ def gen_memory_core(data_width: int, data_depth: int):
             configuration data.
             """
             return Mode(self.___mode)
-            # return Mode((self.config[CONFIG_ADDR] & 0x3).as_uint())
     return MemoryCore

--- a/memory_core/memory_core.py
+++ b/memory_core/memory_core.py
@@ -18,7 +18,7 @@ class Memory:
         self.memory = {BitVector(i, address_width): BitVector(0, data_width)
                        for i in range(self.data_depth)}
 
-    def check_addr(fn):
+    def check_addr(fn): # pragma: nocover
         @functools.wraps(fn)
         def wrapped(self, addr, *args):
             assert 0 <= addr < self.data_depth, \
@@ -28,10 +28,10 @@ class Memory:
 
     @check_addr
     def read(self, addr):
-        return self.memory[addr]
+        return self.memory[addr] # pragma: nocover
 
     @check_addr
-    def write(self, addr, value):
+    def write(self, addr, value): # pragma: nocover
         if isinstance(value, BitVector):
             assert value.num_bits <= self.data_width, \
                 f"value.num_bits must be <= {self.data_width}"
@@ -79,9 +79,6 @@ def gen_memory_core(data_width: int, data_depth: int):
 
         def set_mode(self, newmode):
             self.___mode = newmode
-
-        def clear_db(self):
-            self.data_out = 0
 
         def switch(self):
             if self.__mode == Mode.DB:
@@ -160,7 +157,7 @@ def gen_memory_core(data_width: int, data_depth: int):
                 raise NotImplementedError(self.__mode)  # pragma: nocover
 
         def __call__(self, *args, **kwargs):
-            raise NotImplementedError()
+            raise NotImplementedError() # pragma: nocover
 
         @property
         def __mode(self):

--- a/memory_core/memory_core_genesis2.py
+++ b/memory_core/memory_core_genesis2.py
@@ -32,8 +32,7 @@ memory_core_wrapper = GenesisWrapper(
      "memory_core/genesis_new/sram_stub.vp"],
     type_map={"clk": m.In(m.Clock),
               "reset": m.In(m.AsyncReset),
-              "config_en": m.In(m.Enable)},
-              system_verilog=True)
+              "config_en": m.In(m.Enable)}, system_verilog=True)
 
 param_mapping = {"data_width": "dwidth", "data_depth": "ddepth",
                  "word_width": "wwidth", "num_banks": "bbanks",

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -170,7 +170,8 @@ class MemCore(ConfigurableCore):
             ("mode", 2),
             ("tile_en", 1),
             ("chain_idx", 4),
-            ("depth", 13)
+            ("depth", 13),
+            ("rate_matched", 1)
         ]
 
         # Do all the stuff for the main config

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -38,18 +38,11 @@ class MemCore(ConfigurableCore):
             flush=magma.In(TBit),
             wen_in=magma.In(TBit),
             ren_in=magma.In(TBit),
-            # config_read=magma.In(TBit),
-            # config_write=magma.In(Tbit),
+            valid_out=magma.Out(TBit),
+            switch_db=magma.In(TBit),
 
             stall=magma.In(magma.Bits[4]),
-
-            valid_out=magma.Out(TBit),
-
-            switch_db=magma.In(TBit)
         )
-        # Instead of a single read_config_data, we have multiple for each
-        # "sub"-feature of this core.
-        # self.ports.pop("read_config_data")
 
         if (data_width, word_width, data_depth,
             num_banks, use_sram_stub, iterator_support) not in \
@@ -107,7 +100,6 @@ class MemCore(ConfigurableCore):
         zero_signals = (
             ("chain_wen_in", 1),
             ("chain_in", self.word_width),
-          #  ("config_read", 1)
         )
 
         # enable read and write by default
@@ -168,7 +160,6 @@ class MemCore(ConfigurableCore):
         # MEM Config
         configurations = [
             ("stencil_width", 16),
-            ("read_mode", 1),
             ("arbitrary_addr", 1),
             ("starting_addr", 16),
             ("iter_cnt", 32),

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -26,7 +26,7 @@ class MemCore(ConfigurableCore):
         if use_sram_stub:
             self.use_sram_stub = 1
         else:
-            self.use_sram_stub = 0
+            self.use_sram_stub = 0 # pragma: nocover
 
         TData = magma.Bits[self.word_width]
         TBit = magma.Bits[1]
@@ -242,10 +242,10 @@ class MemCore(ConfigurableCore):
         return idx
 
     def get_config_bitstream(self, instr):
-        raise NotImplementedError()
+        raise NotImplementedError() # pragma: nocover
 
     def instruction_type(self):
-        raise NotImplementedError()
+        raise NotImplementedError() # pragma: nocover
 
     def inputs(self):
         return [self.ports.data_in, self.ports.addr_in, self.ports.flush,

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -26,7 +26,7 @@ class MemCore(ConfigurableCore):
         if use_sram_stub:
             self.use_sram_stub = 1
         else:
-            self.use_sram_stub = 0 # pragma: nocover
+            self.use_sram_stub = 0  # pragma: nocover
 
         TData = magma.Bits[self.word_width]
         TBit = magma.Bits[1]
@@ -242,10 +242,10 @@ class MemCore(ConfigurableCore):
         return idx
 
     def get_config_bitstream(self, instr):
-        raise NotImplementedError() # pragma: nocover
+        raise NotImplementedError()  # pragma: nocover
 
     def instruction_type(self):
-        raise NotImplementedError() # pragma: nocover
+        raise NotImplementedError()  # pragma: nocover
 
     def inputs(self):
         return [self.ports.data_in, self.ports.addr_in, self.ports.flush,

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -213,8 +213,8 @@ def test_interconnect_line_buffer_last_line_valid(cw_files, add_pd, io_sides,
                                flags=["-Wno-fatal", "--trace"])
 
 
-@pytest.mark.parametrize("add_pd", [False])
-def test_interconnect_line_buffer_mek(cw_files, add_pd, io_sides):
+@pytest.mark.parametrize("add_pd", [True, False])
+def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
     depth = 10
     chip_size = 2
     interconnect = create_cgra(chip_size, chip_size, io_sides,

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -213,8 +213,8 @@ def test_interconnect_line_buffer_last_line_valid(cw_files, add_pd, io_sides,
                                flags=["-Wno-fatal", "--trace"])
 
 
-@pytest.mark.parametrize("add_pd", [True, False])
-def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
+@pytest.mark.parametrize("add_pd", [False])
+def test_interconnect_line_buffer_mek(cw_files, add_pd, io_sides):
     depth = 10
     chip_size = 2
     interconnect = create_cgra(chip_size, chip_size, io_sides,
@@ -236,7 +236,7 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
 
     # in this case we configure m0 as line buffer mode
 
-    mode = Mode.DB
+    mode = Mode.LINE_BUFFER
     tile_en = 1
 
     mem_x, mem_y = placement["m0"]
@@ -269,7 +269,6 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
     config_data.append((interconnect.get_config_addr(
                         mcore.get_reg_index("range_0"),
                         0, mem_x, mem_y), depth))
-
     # then p0 is configured as add
     pe_x, pe_y = placement["p0"]
     tile_id = pe_x << 8 | pe_y
@@ -323,24 +322,22 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
             counter += 1
 
         # toggle the clock
-        tester.eval()
         tester.step(2)
 
-    #with tempfile.TemporaryDirectory() as tempdir:
-    tempdir = "dump/"
-    for genesis_verilog in glob.glob("genesis_verif/*.*"):
-        shutil.copy(genesis_verilog, tempdir)
-    for filename in cw_files:
-        shutil.copy(filename, tempdir)
-    shutil.copy(os.path.join("tests", "test_memory_core",
+    with tempfile.TemporaryDirectory() as tempdir:
+        for genesis_verilog in glob.glob("genesis_verif/*.*"):
+            shutil.copy(genesis_verilog, tempdir)
+        for filename in cw_files:
+            shutil.copy(filename, tempdir)
+        shutil.copy(os.path.join("tests", "test_memory_core",
                                  "sram_stub.v"),
                     os.path.join(tempdir, "sram_512w_16b.v"))
-    for aoi_mux in glob.glob("tests/*.sv"):
-        shutil.copy(aoi_mux, tempdir)
-    tester.compile_and_run(target="verilator",
+        for aoi_mux in glob.glob("tests/*.sv"):
+            shutil.copy(aoi_mux, tempdir)
+        tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,
-                               flags=["-Wno-fatal", "--trace"])
+                               flags=["-Wno-fatal"])
 
 
 @pytest.mark.parametrize("add_pd", [True, False])

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -338,7 +338,7 @@ def test_interconnect_line_buffer_unified(cw_files, add_pd, io_sides, mode):
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,
-                               flags=["-Wno-fatal", "--trace"])
+                               flags=["-Wno-fatal"])
 
 
 @pytest.mark.parametrize("add_pd", [True, False])

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -210,7 +210,7 @@ def test_interconnect_line_buffer_last_line_valid(cw_files, add_pd, io_sides,
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,
-                               flags=["-Wno-fatal", "--trace"])
+                               flags=["-Wno-fatal"])
 
 
 @pytest.mark.parametrize("add_pd", [True, False])

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -214,7 +214,8 @@ def test_interconnect_line_buffer_last_line_valid(cw_files, add_pd, io_sides,
 
 
 @pytest.mark.parametrize("add_pd", [True, False])
-def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
+@pytest.mark.parametrize("mode", [Mode.LINE_BUFFER, Mode.DB])
+def test_interconnect_line_buffer_unified(cw_files, add_pd, io_sides, mode):
     depth = 10
     chip_size = 2
     interconnect = create_cgra(chip_size, chip_size, io_sides,
@@ -235,8 +236,6 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
     config_data = interconnect.get_route_bitstream(routing)
 
     # in this case we configure m0 as line buffer mode
-
-    mode = Mode.LINE_BUFFER
     tile_en = 1
 
     mem_x, mem_y = placement["m0"]
@@ -269,6 +268,7 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
     config_data.append((interconnect.get_config_addr(
                         mcore.get_reg_index("range_0"),
                         0, mem_x, mem_y), depth))
+
     # then p0 is configured as add
     pe_x, pe_y = placement["p0"]
     tile_id = pe_x << 8 | pe_y
@@ -334,10 +334,11 @@ def test_interconnect_line_buffer(cw_files, add_pd, io_sides):
                     os.path.join(tempdir, "sram_512w_16b.v"))
         for aoi_mux in glob.glob("tests/*.sv"):
             shutil.copy(aoi_mux, tempdir)
+
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
                                directory=tempdir,
-                               flags=["-Wno-fatal"])
+                               flags=["-Wno-fatal", "--trace"])
 
 
 @pytest.mark.parametrize("add_pd", [True, False])

--- a/tests/test_memory_core/test_memory_core.py
+++ b/tests/test_memory_core/test_memory_core.py
@@ -85,7 +85,6 @@ class MemoryCoreTester(ResetTester, BasicTester):
         # \_
         self.poke(self._circuit.clk, 0)
         self.poke(self._circuit.ren_in, 1)
-        # self.poke(self._circuit.wen_in, 1)
         self.poke(self._circuit.addr_in, addr)
         self.eval()
 
@@ -265,7 +264,6 @@ def test_db_arbitrary_rw_addr():
     tester.poke(Mem.clk, 0)
     tester.poke(Mem.switch_db, 0)
     tester.functional_model.switch()
-    # tester.functional_model.clear_db()
     tester.functional_model.data_out = fault.AnyValue
 
     for i in range(100):

--- a/tests/test_memory_core/test_memory_core.py
+++ b/tests/test_memory_core/test_memory_core.py
@@ -7,7 +7,7 @@ import fault
 import random
 from gemstone.common.testers import ResetTester
 from gemstone.common.testers import BasicTester
-
+import pytest
 
 def make_memory_core():
     mem_core = MemCore(16, 16, 512, 2, 1)
@@ -68,24 +68,29 @@ class MemoryCoreTester(ResetTester, BasicTester):
         # \_
         self.poke(self._circuit.clk, 0)
         self.poke(self._circuit.wen_in, 1)
+        self.poke(self._circuit.ren_in, 1)
         self.poke(self._circuit.addr_in, addr)
         self.poke(self._circuit.data_in, data)
         self.eval()
 
         # _/
         self.poke(self._circuit.clk, 1)
+        self.poke(self._circuit.wen_in, 0)
+        self.poke(self._circuit.ren_in, 0)
 
     def observe(self, addr=0):
         self.functional_model.read(addr)
         self.eval()
         # \_
         self.poke(self._circuit.clk, 0)
-        self.poke(self._circuit.wen_in, 1)
+        self.poke(self._circuit.ren_in, 1)
+        # self.poke(self._circuit.wen_in, 1)
         self.poke(self._circuit.addr_in, addr)
         self.eval()
 
         # _/
         self.poke(self._circuit.clk, 1)
+        self.poke(self._circuit.ren_in, 0)
 
     def read(self, addr=0):
         # \_
@@ -141,8 +146,6 @@ def test_passthru_fifo(depth=50, read_cadence=2):
     # Configure
     for addr, data, feat in config_data:
         tester.configure(addr, data, feat)
-    # for i in range(27):
-    #    tester.write(i + 1)
 
     tester.read_and_write(42)
     tester.read_and_write(43)
@@ -185,11 +188,7 @@ def test_fifo_arb(depth=50):
                                flags=["-Wno-fatal"])
 
 
-def test_general_fifo():
-    fifo(50, 6)
-
-
-def fifo(depth=50, read_cadence=2):
+def test_general_fifo(depth=50, read_cadence=6):
     [Mem, tester, MCore] = make_memory_core()
     mode = Mode.FIFO
     tile_en = 1
@@ -217,29 +216,6 @@ def fifo(depth=50, read_cadence=2):
                                flags=["-Wno-fatal"])
 
 
-def test_db_basic_read():
-    # Basic access
-    db_basic(1, 3, 9, 0, 0, 0,
-             3, 3, 3, 1, 1, 1,
-             3)
-
-
-def test_db_long_read():
-    # More advanced access
-    db_basic(1, 3, 1, 3, 9, 0,
-             2, 2, 2, 2, 3, 1,
-             5)
-
-
-def test_db_read_mode():
-    # Test read mode
-    db_basic(1, 3, 9, 0, 0, 0,
-             3, 3, 3, 1, 1, 1,
-             3,
-             0,
-             1)
-
-
 def test_db_arbitrary_rw_addr():
 
     [Mem, tester, MCore] = make_memory_core()
@@ -249,7 +225,6 @@ def test_db_arbitrary_rw_addr():
     tester.functional_model.config_db(memory_size, ranges, strides,
                                       0, 1, 3, 1)
 
-    read_mode = 1
     arbitrary_addr = 1
     mode = Mode.DB
     tile_en = 1
@@ -258,8 +233,6 @@ def test_db_arbitrary_rw_addr():
     config_data.append((MCore.get_reg_index("depth"), depth, 0))
     config_data.append((MCore.get_reg_index("tile_en"), tile_en, 0))
     config_data.append((MCore.get_reg_index("mode"), mode.value, 0))
-    config_data.append((MCore.get_reg_index("read_mode"),
-                        read_mode, 0))
     config_data.append((MCore.get_reg_index("arbitrary_addr"),
                         arbitrary_addr, 0))
 
@@ -316,7 +289,6 @@ def test_db_arbitrary_addr():
     tester.functional_model.config_db(memory_size, ranges, strides,
                                       0, 1, 3, 1)
 
-    read_mode = 1
     arbitrary_addr = 1
     mode = Mode.DB
     tile_en = 1
@@ -326,7 +298,6 @@ def test_db_arbitrary_addr():
     config_data.append((MCore.get_reg_index("depth"), depth, 0))
     config_data.append((MCore.get_reg_index("tile_en"), tile_en, 0))
     config_data.append((MCore.get_reg_index("mode"), mode.value, 0))
-    config_data.append((MCore.get_reg_index("read_mode"), read_mode, 0))
     config_data.append((MCore.get_reg_index("arbitrary_addr"),
                         arbitrary_addr, 0))
     for addr, data, feat in config_data:
@@ -374,33 +345,33 @@ def test_db_arbitrary_addr():
                                flags=["-Wno-fatal"])
 
 
-def test_db_auto():
-    db_auto(1, 3, 9, 0, 0, 0,
+def test_db_gen1():
+    db_gen(1, 3, 9, 0, 0, 0,
             3, 3, 3, 1, 1, 1,
             3, 27)
 
 
-def test_db_auto2():
-    db_auto(1, 3, 1, 3, 9, 0,
+def test_db_gen2():
+    db_gen(1, 3, 1, 3, 9, 0,
             2, 2, 2, 2, 3, 1,
             5, 27)
 
 
-def db_auto(stride_0, stride_1, stride_2, stride_3, stride_4, stride_5,
+def db_gen(stride_0, stride_1, stride_2, stride_3, stride_4, stride_5,
             range_0, range_1, range_2, range_3, range_4, range_5,
             dimensionality, input_size,
             starting_addr=0,
-            read_mode=0, manual_switch=0, arbitrary_addr=0):
+            arbitrary_addr=0):
 
     [Mem, tester, MCore] = make_memory_core()
     iter_cnt = range_0 * range_1 * range_2 * range_3 * range_4 * range_5
     depth = input_size
+    # Assumes all ranges are 1 minimally
     ranges = [range_0, range_1, range_2, range_3, range_4, range_5]
     strides = [stride_0, stride_1, stride_2, stride_3, stride_4, stride_5]
     tester.functional_model.config_db(depth, ranges, strides,
                                       starting_addr,
-                                      manual_switch, dimensionality)
-    # Assumes all ranges are 1 minimally
+                                      0, dimensionality)
 
     mode = Mode.DB
     tile_en = 1
@@ -408,8 +379,6 @@ def db_auto(stride_0, stride_1, stride_2, stride_3, stride_4, stride_5,
     config_data.append((MCore.get_reg_index("depth"), depth, 0))
     config_data.append((MCore.get_reg_index("tile_en"), tile_en, 0))
     config_data.append((MCore.get_reg_index("mode"), mode.value, 0))
-    config_data.append((MCore.get_reg_index("read_mode"),
-                        read_mode, 0))
     config_data.append((MCore.get_reg_index("arbitrary_addr"),
                         arbitrary_addr, 0))
     config_data.append((MCore.get_reg_index("starting_addr"),
@@ -450,119 +419,8 @@ def db_auto(stride_0, stride_1, stride_2, stride_3, stride_4, stride_5,
                                flags=["-Wno-fatal"])
 
 
-def db_basic(stride_0, stride_1, stride_2, stride_3, stride_4, stride_5,
-             range_0, range_1, range_2, range_3, range_4, range_5,
-             dimensionality,
-             starting_addr=0,
-             read_mode=0, manual_switch=1, arbitrary_addr=0):
-
-    [Mem, tester, MCore] = make_memory_core()
-    memory_size = 1024
-    ranges = [range_0, range_1, range_2, range_3, range_4, range_5]
-    strides = [stride_0, stride_1, stride_2, stride_3, stride_4, stride_5]
-    tester.functional_model.config_db(memory_size, ranges, strides,
-                                      starting_addr,
-                                      manual_switch, dimensionality)
-
-    mode = Mode.DB
-    tile_en = 1
-    depth = 50
-    config_data = []
-
-    config_data.append((MCore.get_reg_index("depth"), depth, 0))
-    config_data.append((MCore.get_reg_index("tile_en"), tile_en, 0))
-    config_data.append((MCore.get_reg_index("mode"), mode.value, 0))
-    config_data.append((MCore.get_reg_index("read_mode"), read_mode, 0))
-    config_data.append((MCore.get_reg_index("arbitrary_addr"),
-                        arbitrary_addr, 0))
-    config_data.append((MCore.get_reg_index("starting_addr"),
-                        starting_addr, 0))
-    config_data.append((MCore.get_reg_index("dimensionality"),
-                        dimensionality, 0))
-    config_data.append((MCore.get_reg_index("stride_0"), stride_0, 0))
-    config_data.append((MCore.get_reg_index("stride_1"), stride_1, 0))
-    config_data.append((MCore.get_reg_index("stride_2"), stride_2, 0))
-    config_data.append((MCore.get_reg_index("stride_3"), stride_3, 0))
-    config_data.append((MCore.get_reg_index("stride_4"), stride_4, 0))
-    config_data.append((MCore.get_reg_index("stride_5"), stride_5, 0))
-    config_data.append((MCore.get_reg_index("range_0"), range_0, 0))
-    config_data.append((MCore.get_reg_index("range_1"), range_1, 0))
-    config_data.append((MCore.get_reg_index("range_2"), range_2, 0))
-    config_data.append((MCore.get_reg_index("range_3"), range_3, 0))
-    config_data.append((MCore.get_reg_index("range_4"), range_4, 0))
-    config_data.append((MCore.get_reg_index("range_5"), range_5, 0))
-    for addr, data, feat in config_data:
-        tester.configure(addr, data, feat)
-
-    red = 0
-    for i in range(27):
-        tester.write((i + 1))
-
-    tester.poke(Mem.clk, 0)
-    tester.poke(Mem.switch_db, 1)
-    tester.eval()
-    tester.poke(Mem.clk, 1)
-    tester.eval()
-    tester.poke(Mem.clk, 0)
-    tester.poke(Mem.switch_db, 0)
-    tester.functional_model.switch()
-    # pull based functional model hack
-    if(read_mode == 0):
-        tester.functional_model.read(0)
-    tester.eval()
-
-    for i in range(100):
-        if(read_mode == 1):
-            if(i == 47):
-                tester.poke(Mem.switch_db, 1)
-            if(i > 57):
-                tester.read_and_write(i + 1)
-            else:
-                tester.write(i + 1)
-            if(i == 47):
-                tester.poke(Mem.switch_db, 0)
-                tester.functional_model.switch()
-                tester.eval()
-        else:
-            if(i == 47):
-                tester.poke(Mem.switch_db, 1)
-
-            # \_
-            tester.poke(Mem.clk, 0)
-            tester.poke(Mem.ren_in, 1)
-            tester.poke(Mem.wen_in, 1)
-            tester.poke(Mem.data_in, i + 1)
-            tester.eval()
-
-            # _/
-            tester.poke(Mem.clk, 1)
-
-            if(i == 47):
-                tester.functional_model.write(0, i + 1)
-                tester.functional_model.switch()
-                tester.functional_model.read(0)
-            else:
-                tester.functional_model.read_and_write(0, i + 1)
-
-            tester.eval()
-            tester.poke(Mem.wen_in, 0)
-            tester.poke(Mem.ren_in, 0)
-            tester.eval()
-
-            if(i == 47):
-                tester.poke(Mem.switch_db, 0)
-                tester.eval()
-
-    with tempfile.TemporaryDirectory() as tempdir:
-        for genesis_verilog in glob.glob("genesis_verif/*.*"):
-            shutil.copy(genesis_verilog, tempdir)
-        tester.compile_and_run(directory=tempdir,
-                               magma_output="coreir-verilog",
-                               target="verilator",
-                               flags=["-Wno-fatal"])
-
-
-def test_sram_magma(num_writes=500):
+@pytest.mark.parametrize("num_writes", [10, 100, 500])
+def test_sram_magma(num_writes):
 
     [Mem, tester, MCore] = make_memory_core()
     mode = Mode.SRAM
@@ -590,14 +448,12 @@ def test_sram_magma(num_writes=500):
     # Perform a sequence of random writes
     for i in range(num_writes):
         addr = get_fresh_addr(addrs)
-        # TODO: Should be parameterized by data_width
         data = random.randint(0, (1 << 10))
         tester.write(data, addr)
         addrs.add(addr)
 
     # Read the values we wrote to make sure they are there
     for addr in addrs:
-        print(str(addr))
         tester.read(addr)
 
     for i in range(num_writes):

--- a/tests/test_memory_core/test_memory_core.py
+++ b/tests/test_memory_core/test_memory_core.py
@@ -9,6 +9,7 @@ from gemstone.common.testers import ResetTester
 from gemstone.common.testers import BasicTester
 import pytest
 
+
 def make_memory_core():
     mem_core = MemCore(16, 16, 512, 2, 1)
     mem_circ = mem_core.circuit()
@@ -347,21 +348,21 @@ def test_db_arbitrary_addr():
 
 def test_db_gen1():
     db_gen(1, 3, 9, 0, 0, 0,
-            3, 3, 3, 1, 1, 1,
-            3, 27)
+           3, 3, 3, 1, 1, 1,
+           3, 27)
 
 
 def test_db_gen2():
     db_gen(1, 3, 1, 3, 9, 0,
-            2, 2, 2, 2, 3, 1,
-            5, 27)
+           2, 2, 2, 2, 3, 1,
+           5, 27)
 
 
 def db_gen(stride_0, stride_1, stride_2, stride_3, stride_4, stride_5,
-            range_0, range_1, range_2, range_3, range_4, range_5,
-            dimensionality, input_size,
-            starting_addr=0,
-            arbitrary_addr=0):
+           range_0, range_1, range_2, range_3, range_4, range_5,
+           dimensionality, input_size,
+           starting_addr=0,
+           arbitrary_addr=0):
 
     [Mem, tester, MCore] = make_memory_core()
     iter_cnt = range_0 * range_1 * range_2 * range_3 * range_4 * range_5


### PR DESCRIPTION
cleaned up the double buffer to support the two modes of interest:

arbitrary_addr mode - treat the double buffer like a read bank and write bank (generic double buffering without address generation) - manual switch

normal mode - address generation, switches automatically after all reads/writes finished

also added the logic for valid that matches other forms of valid