### PR TITLE
Tile id pass

### DIFF
--- a/cgra/tile_id_pass.py
+++ b/cgra/tile_id_pass.py
@@ -1,0 +1,43 @@
+from gemstone.common.transform import replace, Generator, FromMagma
+from io_core.io_core_magma import IOCore
+from canal.interconnect import Interconnect
+from gemstone.common.configurable import Configurable, ConfigurationType
+import magma
+import mantle
+from gemstone.generator.const import Const
+
+## We create constant tie hi and tie lo outputs on each tile
+## These pins will be interleaved with the tile_id pins as follows
+## | hi[0] | id[0] | lo[0] | id[1] | hi[1] | id[2] | lo[1] | id[3] | hi[2] | ...
+## We are doing this so that we can actually connect the tile_id inputs
+## to the proper constant values without uniquifying the tiles and while
+## maintaining our abutted array of tile hard macros
+def add_hi_lo_outputs(interconnect: Interconnect):
+    tile_id_width = interconnect.tile_id_width
+    tie_hi_width = (tile_id_width // 2) + 1
+    if (tile_id_width % 2) == 0 :
+        tie_lo_width = tile_id_width // 2
+    else:
+        tie_lo_width = (tile_id_width // 2) + 1
+    for (x, y) in interconnect.tile_circuits:
+        tile = interconnect.tile_circuits[(x, y)]
+        tile_core = tile.core
+        if isinstance(tile_core, IOCore) or tile_core is None:
+            continue
+        tile.add_ports(
+            hi=magma.Out(magma.Bits[tie_hi_width]),
+            lo=magma.Out(magma.Bits[tie_lo_width])
+        )
+        # wire all hi bits high
+        tile.wire(tile.ports.hi, Const((2 ** tie_hi_width) - 1))
+        # wire all lo bits low
+        tile.wire(tile.ports.lo, Const(0))
+        # Actually connect hi/lo outputs to tile_id at top level
+        for i in range(tile_id_width):
+            lo_index = i // 2
+            if (i % 2) == 0:
+                hi_index = i // 2
+            else:
+                hi_index (i // 2) + 1
+            hi_port = tile.ports.hi[hi_index]
+            lo_port = tile.ports.lo[lo_index]  

--- a/cgra/util.py
+++ b/cgra/util.py
@@ -34,6 +34,7 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
                 num_tracks: int = 5,
                 add_pd: bool = True,
                 use_sram_stub: bool = True,
+                hi_lo_tile_id: bool = True,
                 global_signal_wiring: GlobalSignalWiring =
                 GlobalSignalWiring.Meso,
                 standalone: bool = False,
@@ -133,7 +134,8 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
     interconnect = Interconnect(ics, reg_addr_width, config_data_width,
                                 tile_id_width,
                                 lift_ports=standalone)
-    tile_id_physical(interconnect)
+    if hi_lo_tile_id: 
+        tile_id_physical(interconnect)
     if add_pd:
         add_power_domain(interconnect)
     interconnect.finalize()

--- a/cgra/util.py
+++ b/cgra/util.py
@@ -10,7 +10,7 @@ from io_core.io_core_magma import IOCore
 from memory_core.memory_core_magma import MemCore
 from peak_core.peak_core import PeakCore
 from typing import Tuple, Dict, List, Tuple
-from cgra.tile_id_pass import add_hi_lo_outputs
+from tile_id_pass.tile_id_pass import tile_id_physical
 
 
 def get_actual_size(width: int, height: int, io_sides: IOSide):
@@ -133,7 +133,7 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
     interconnect = Interconnect(ics, reg_addr_width, config_data_width,
                                 tile_id_width,
                                 lift_ports=standalone)
-    #add_hi_lo_outputs(interconnect)
+    tile_id_physical(interconnect)
     if add_pd:
         add_power_domain(interconnect)
     interconnect.finalize()

--- a/cgra/util.py
+++ b/cgra/util.py
@@ -133,7 +133,7 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
     interconnect = Interconnect(ics, reg_addr_width, config_data_width,
                                 tile_id_width,
                                 lift_ports=standalone)
-    add_hi_lo_outputs(interconnect)
+    #add_hi_lo_outputs(interconnect)
     if add_pd:
         add_power_domain(interconnect)
     interconnect.finalize()

--- a/cgra/util.py
+++ b/cgra/util.py
@@ -10,6 +10,7 @@ from io_core.io_core_magma import IOCore
 from memory_core.memory_core_magma import MemCore
 from peak_core.peak_core import PeakCore
 from typing import Tuple, Dict, List, Tuple
+from cgra.tile_id_pass import add_hi_lo_outputs
 
 
 def get_actual_size(width: int, height: int, io_sides: IOSide):
@@ -132,6 +133,7 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
     interconnect = Interconnect(ics, reg_addr_width, config_data_width,
                                 tile_id_width,
                                 lift_ports=standalone)
+    add_hi_lo_outputs(interconnect)
     if add_pd:
         add_power_domain(interconnect)
     interconnect.finalize()

--- a/tile_id_pass/tile_id_pass.py
+++ b/tile_id_pass/tile_id_pass.py
@@ -42,6 +42,7 @@ def tile_id_physical(interconnect: Interconnect):
         for wire in interconnect.wires:
             if tile_id_port in wire:
                 interconnect.remove_wire(wire[0], wire[1])
+                break
         
         # Actually connect hi/lo outputs to tile_id at top level
         for i in range(tile_id_width):

--- a/tile_id_pass/tile_id_pass.py
+++ b/tile_id_pass/tile_id_pass.py
@@ -4,12 +4,13 @@ import magma
 from gemstone.generator.const import Const
 from hwtypes import BitVector
 
-## We create constant tie hi and tie lo outputs on each tile
-## These pins will be interleaved with the tile_id pins as follows
-## | hi[0] | id[0] | lo[0] | id[1] | hi[1] | id[2] | lo[1] | id[3] | hi[2] | ...
-## We are doing this so that we can actually connect the tile_id inputs
-## to the proper constant values without uniquifying the tiles and while
-## maintaining our abutted array of tile hard macros
+# We create constant tie hi and tie lo outputs on each tile
+# These pins will be interleaved with the tile_id pins as follows
+# | hi[0] | id[0] | lo[0] | id[1] | hi[1] | id[2] | lo[1] | id[3] | hi[2] | ...
+# We are doing this so that we can actually connect the tile_id inputs
+# to the proper constant values without uniquifying the tiles and while
+# maintaining our abutted array of tile hard macros
+
 def tile_id_physical(interconnect: Interconnect):
     tile_id_width = interconnect.tile_id_width
     tie_hi_width = (tile_id_width // 2) + 1

--- a/tile_id_pass/tile_id_pass.py
+++ b/tile_id_pass/tile_id_pass.py
@@ -1,9 +1,6 @@
-from gemstone.common.transform import replace, Generator, FromMagma
 from io_core.io_core_magma import IOCore
 from canal.interconnect import Interconnect
-from gemstone.common.configurable import Configurable, ConfigurationType
 import magma
-import mantle
 from gemstone.generator.const import Const
 from hwtypes import BitVector
 

--- a/tile_id_pass/tile_id_pass.py
+++ b/tile_id_pass/tile_id_pass.py
@@ -13,7 +13,7 @@ from hwtypes import BitVector
 ## We are doing this so that we can actually connect the tile_id inputs
 ## to the proper constant values without uniquifying the tiles and while
 ## maintaining our abutted array of tile hard macros
-def add_hi_lo_outputs(interconnect: Interconnect):
+def tile_id_physical(interconnect: Interconnect):
     tile_id_width = interconnect.tile_id_width
     tie_hi_width = (tile_id_width // 2) + 1
     if (tile_id_width % 2) == 0 :


### PR DESCRIPTION
A new pass on the CGRA to perform the tile_id connections in a slightly different way.

Because we are creating a fully abutted grid of tiles, there are no channels between the tiles to place tie cells to tie the tile_id pins to the correct constant values. we could assign tile_id values within the tiles themselves, but this would uniquify every single tile, which would be very bad for our physical design flow, because we'd have to place and route each tile individually given our current setup. 

This pass gets around both of these issues by giving each tile a set of constant outputs: hi (constant 1) and lo (constant 0). During tile level place and route these hi and lo pins will be interleaved with the tile_id pins as follows:

 | hi[0] | id[0] | lo[0] | id[1] | hi[1] | id[2] | lo[1] | id[3] | hi[2] | ... and so on ...

Tile id connections will be made by making connecting each tile_id input pin to the adjacent hi or lo pin on the same tile, depending on the tile_id value. In this way all, tile_id connections are made at the top level (which avoids uniquification) and all tie cells are internal to the tile (which allows us to keep our fully abutted floorplan).