### PR TITLE
Add CoSA problems for Garnet PE Tile Interconnect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ install:
     - docker exec -i garnet bash -c "pip install -r /garnet/requirements.txt" 
     - docker exec -i garnet bash -c "pip install pytest python-coveralls"
     - docker exec -i garnet bash -c "pip install pytest-cov pytest-codestyle z3-solver" 
-    # check CoSA dependencies
+    - docker exec -i garnet bash -c "wget https://web.stanford.edu/~makaim/files/yosys-static -O ./bin/yosys"
+    - docker exec -i garnet bash -c "chmod +x ./bin/yosys"
+    - docker exec -i garnet bash -c "pysmt-install --confirm-agreement --msat"
     - docker exec -i garnet bash -c "pysmt-install --check"
 
     - git clone https://github.com/StanfordVLSI/Genesis2.git

--- a/tests/test_pe_tile_formal/problem.txt
+++ b/tests/test_pe_tile_formal/problem.txt
@@ -1,0 +1,62 @@
+[GENERAL]
+model_files: source.vlist[Tile_PE]
+# remove neg-edge clock behavior
+# this speeds up verification and we
+# think it's safe because we're not using the reset anyway
+synchronize: True
+
+[DEFAULT]
+bmc_length: 4
+
+[GLOBAL_SIGNALS]
+description: "Check global signals are ON after tile is OFF"
+assumptions: PowerDomainConfigReg_inst0.ps_en.Register_has_ce_True_has_reset_False_has_async_reset_True_type_Bits_n_1_inst0.value.out = 1_1
+properties: (clk_out = clk) &
+            (reset_out = reset) &
+            (config_out_config_data = config_config_data) &
+            (config_out_config_addr = config_config_addr) &
+            (config_out_write = config_write) &
+            (config_out_read = config_read) &
+            (stall_out = stall) &
+            (read_config_data = read_config_data_in)
+verification: safety
+prove: True
+
+[NO_OTHER_ADDR_ENABLES_PS_REG]
+description: "Prove that writing to another register doesn't enable PS reg"
+assumptions: (config_config_addr != 524288_32);
+             (tile_id = 0_16);
+             (reset = 0_1)
+properties: (PowerDomainConfigReg_inst0.ps_en.Register_has_ce_True_has_reset_False_has_async_reset_True_type_Bits_n_1_inst0.value.out = 1_1) ->
+            (next(PowerDomainConfigReg_inst0.ps_en.Register_has_ce_True_has_reset_False_has_async_reset_True_type_Bits_n_1_inst0.value.out) = 1_1)
+verification: safety
+prove: True
+
+# Unknown means it works (because starting from an arbitrary state
+# Ask Makai if you want more information
+[AOI_CONST_MUX_SET]
+description: "Prove that configuration sets select accordingly"
+assumptions: (tile_id = 0_16) & (reset = 0_1)
+properties: ((config_config_addr = 524288_32) &
+            (config_config_data = 4294967280_32) &
+            (config_write = 1_1) &
+            (X(config_config_addr = 262144_32)) &
+            (X(config_config_data = 20_32)) &
+            (X(config_write = 1_1))) ->
+            (X(X(CB_data0.CB_data0.mux_aoi_const_20_16_inst0.S = 20_5)))
+verification: ltl
+expected: Unknown
+
+[AOI_CONST_MUX_STAYS]
+description: "Prove that the configuration can't change"
+assumptions: (tile_id = 0_16) & (reset = 0_1)
+properties: (config_write = 0_1) -> (next(CB_data0.CB_data0.mux_aoi_const_20_16_inst0.S) = CB_data0.CB_data0.mux_aoi_const_20_16_inst0.S)
+verification: safety
+prove: True
+
+[AOI_CONST_MUX_OUT]
+description: "Prove that aoi-const-mux final output is zero when sel==height"
+assumptions: CB_data0.CB_data0.mux_aoi_const_20_16_inst0.S = dec2bv(20, CB_data0.CB_data0.mux_aoi_const_20_16_inst0.S)
+properties: CB_data0.CB_data0.mux_aoi_const_20_16_inst0.O = dec2bv(0, CB_data0.CB_data0.mux_aoi_const_20_16_inst0.O)
+verification: safety
+prove: True

--- a/tests/test_pe_tile_formal/source.vlist
+++ b/tests/test_pe_tile_formal/source.vlist
@@ -1,0 +1,5 @@
+./garnet.v
+./tests/AN2D0BWP16P90.sv
+./tests/AO22D0BWP16P90.sv
+./peak_core/CW_fp_mult.v
+./peak_core/CW_fp_add.v

--- a/tests/test_pe_tile_formal/test_pe_tile_interconnect.py
+++ b/tests/test_pe_tile_formal/test_pe_tile_interconnect.py
@@ -1,0 +1,21 @@
+import glob
+import pytest
+import os
+import subprocess
+
+GARNET_VERILOG_FILENAME = os.path.join(os.path.dirname(__file__),
+                               os.path.pardir, os.path.pardir,
+                               "garnet.v")
+
+PROBLEM_FILENAME = os.path.join(os.path.dirname(__file__),
+                                "problem.txt")
+
+def test_pe_tile_interconnect():
+    if not os.path.isfile(GARNET_VERILOG_FILENAME):
+        garnet_root = os.path.dirname(GARNET_VERILOG_FILENAME)
+        subprocess.check_call(["python", 'garnet.py', "-v"], cwd=garnet_root)
+    assert os.path.isfile(GARNET_VERILOG_FILENAME)
+    subprocess.check_call(["CoSA", "--problems", PROBLEM_FILENAME])
+
+if __name__ == "__main__":
+    test_pe_tile_interconnect()

--- a/tests/test_pe_tile_formal/test_pe_tile_interconnect.py
+++ b/tests/test_pe_tile_formal/test_pe_tile_interconnect.py
@@ -4,11 +4,12 @@ import os
 import subprocess
 
 GARNET_VERILOG_FILENAME = os.path.join(os.path.dirname(__file__),
-                               os.path.pardir, os.path.pardir,
-                               "garnet.v")
+                                       os.path.pardir, os.path.pardir,
+                                       "garnet.v")
 
 PROBLEM_FILENAME = os.path.join(os.path.dirname(__file__),
                                 "problem.txt")
+
 
 def test_pe_tile_interconnect():
     if not os.path.isfile(GARNET_VERILOG_FILENAME):
@@ -16,6 +17,7 @@ def test_pe_tile_interconnect():
         subprocess.check_call(["python", 'garnet.py', "-v"], cwd=garnet_root)
     assert os.path.isfile(GARNET_VERILOG_FILENAME)
     subprocess.check_call(["CoSA", "--problems", PROBLEM_FILENAME])
+
 
 if __name__ == "__main__":
     test_pe_tile_interconnect()


### PR DESCRIPTION
This pull requests adds a test for `pytest` to run that loads in the generated Verilog and checks a few basic properties of the PE Tile (instantiated as the top module). The properties are generalizations of ttests 4, 5, 6 and 7 from this [testbench](https://github.com/StanfordAHA/garnet/blob/tapeout/tapeout_16/gls/tb_Tile_PE.v).

These are performed at the RTL level, but we will soon try to check the properties on the final netlist with power/ground information.

Ideally, we will also continue to add more formal property verification to Travis. If this makes the Travis build time too long, I'm happy to set it up on BuildKite or elsewhere instead.

@ankita0805 