### PR TITLE
Make JTAG IDCODE 650

### DIFF
--- a/global_controller/genesis/jtag.svp
+++ b/global_controller/genesis/jtag.svp
@@ -48,7 +48,7 @@
 //; my $sc_cfg_bus_width =  $self->define_param(SYSCLK_CFG_BUS_WIDTH => 32);
 //; my $sc_cfg_addr_width =  $self->define_param(SYSCLK_CFG_ADDR_WIDTH => 32);
 //; my $sc_cfg_op_width = $self->define_param(SYSCLK_CFG_OPCODE_WIDTH => 5);
-//; my $IDCODE = $self->define_param(IDCODE => 1);
+//; my $IDCODE = $self->define_param(IDCODE => 650);
 //; my $io_list = $self->force_param(IO_LIST => 
 //;		[	
 //;			{name => 'trst_n',	width => 1,  direction => 'in',  bsr => 'no',  pad => 'digital', orientation => 'right'},

--- a/global_controller/genesis/tap.svp
+++ b/global_controller/genesis/tap.svp
@@ -38,7 +38,7 @@
 //; #					{name => 'CFG_ADDR', code => 0xA}
 //; #				     ]
 //; 
-//; my $IDCODE = $self->define_param(IDCODE => 1);
+//; my $IDCODE = $self->define_param(IDCODE => 650);
 //; my ($IDCODE_num, $man_num, $part, $version);
 //; if (looks_like_number($IDCODE)){ 
 //;     $IDCODE_num = $IDCODE;


### PR DESCRIPTION
Per @zamyers request, make the JTAG IDCODE more distinctive for easier chip bringup.