### PR TITLE
Add latch to gate the stall

### DIFF
--- a/global_controller/genesis/global_controller.svp
+++ b/global_controller/genesis/global_controller.svp
@@ -99,6 +99,9 @@ logic [`$cfg_op_width-1`:0] op_jtag;
 logic [`$cfg_op_width-1`:0] op_axi;
 logic [`$cfg_op_width-1`:0] op;
 
+// stall
+logic stall;
+
 //============================================================================//
 // jtag controller instantiation
 //============================================================================//
@@ -444,9 +447,18 @@ always @ (negedge clk_in or posedge reset_in) begin
 end
 
 //============================================================================//
-// stall signal
+//stall signal
 //============================================================================//
-assign glb_stall = cgra_stalled;
+
+// We do not want the clock enables to go high during the time when the
+// clock is high. So we instantiate a transparent latch that only changes
+// its value when the clock is low.
+always_latch begin
+    if (~clk) begin
+        cgra_stalled <= stall;
+        glb_stall <= stall;
+    end
+end
 
 //============================================================================//
 // CGRA control registers
@@ -754,7 +766,7 @@ always @ (posedge clk or posedge reset_in) begin
         glb_sram_config_data_out <= 0;
 
         // other control registers
-        cgra_stalled <= 0;
+        stall <= 0;
         clk_switch_request <= 1;
         rd_delay_reg <= 2;
         TST <= 0;
@@ -950,8 +962,8 @@ always @ (posedge clk or posedge reset_in) begin
                 cgra_ctrl_rd_en <= 0;
             end
             read_stall: begin
-                if (axi_activated)  gc_to_axi_rd_data <= {`$cfg_bus_width-1`'b0, cgra_stalled};
-                else                config_data_jtag_in <= {`$cfg_bus_width-1`'b0, cgra_stalled};
+                if (axi_activated)  gc_to_axi_rd_data <= {`$cfg_bus_width-1`'b0, stall};
+                else                config_data_jtag_in <= {`$cfg_bus_width-1`'b0, stall};
                 read <= 0;
                 write <= 0;
                 glb_write <= 0;
@@ -962,7 +974,7 @@ always @ (posedge clk or posedge reset_in) begin
                 cgra_ctrl_rd_en <= 0;
             end
             write_stall: begin
-                cgra_stalled <= int_config_data_out[0];
+                stall <= int_config_data_out[0];
                 read <= 0;
                 write <= 0;
                 glb_write <= 0;
@@ -974,10 +986,10 @@ always @ (posedge clk or posedge reset_in) begin
             end         
             advance_clk: begin
                 if (int_config_data_out > 0) begin
-                    if (cgra_stalled) begin
+                    if (stall) begin
                         counter <= int_config_data_out-1;
                         state <= advancing_clk; 
-                        cgra_stalled <= 1'b0;
+                        stall <= 1'b0;
                     end
                 end
                 read <= 0;
@@ -1150,7 +1162,7 @@ always @ (posedge clk or posedge reset_in) begin
                     cgra_ctrl_rd_en <= 0;
                 end
                 else if (state == advancing_clk) begin
-                    cgra_stalled <= 1;
+                    stall <= 1;
                 end
             end
         end     

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper
 -e git://github.com/Kuree/karst.git#egg=karst
 -e git://github.com/joyliu37/BufferMapping#egg=buffer_mapping
+-e git://github.com/THofstee/Pyverilog.git#egg=pyverilog
 ordered_set
 magma-lang >= 1.0.5
 mantle


### PR DESCRIPTION
We have two choices, we can either gate the enables on the registers and rely on the synthesis tools to convert these to clock gates, or we can latch the clock and do this ourselves. We implement the latch here. The latch is transparent while the clock is high, so if we get a transition on the stall right after the posedge then we don't want to create an extra early posedge with the gating logic.

This is the behavior the memory tile is expecting from the stall logic.