### PR TITLE
Add ability to have active/inactive cycles in global buffer io controller

### DIFF
--- a/global_buffer/genesis/io_address_generator.svp
+++ b/global_buffer/genesis/io_address_generator.svp
@@ -195,7 +195,8 @@ always_ff @(posedge clk or posedge reset) begin
                                 done_cnt_instream <= done_cnt_instream;
                                 int_addr_instream <= int_addr_instream + CGRA_DATA_BYTE;
                                 // bank_rd_en goes high only when the last word is read
-                                io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
+                                // io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
+                                io_to_bank_rd_en_instream <= 0;
                                 cgra_done_pulse_instream <= 0;
                             end
                             else begin

--- a/global_buffer/genesis/io_address_generator.svp
+++ b/global_buffer/genesis/io_address_generator.svp
@@ -289,7 +289,7 @@ end
 // When num_words_cnt is non-zero, rd_data_valid is positive
 // io_to_cgra_rd_data_valid goes high 2 cycles after num_cnt is greater than 0
 // due to read latency
-assign int_rd_data_valid_instream = (num_words_cnt_instream > 0);
+assign int_rd_data_valid_instream = (num_words_cnt_instream > 0) && (state_instream == READ_ACTIVE_INSTREAM);
 always_ff @(posedge clk) begin
     if (clk_en) begin
         int_rd_data_valid_instream_d1 <= int_rd_data_valid_instream;

--- a/global_buffer/genesis/io_address_generator.svp
+++ b/global_buffer/genesis/io_address_generator.svp
@@ -186,7 +186,7 @@ always_ff @(posedge clk or posedge reset) begin
                             cgra_done_pulse_instream <= 0;
                         end
                         else begin
-                            if (cnt_instream == num_active_instream-1) begin
+                            if (cnt_instream == num_active_cnt_instream-1) begin
                                 state_instream <= READ_INACTIVE_INSTREAM;
                                 num_words_cnt_instream <= num_words_cnt_instream - 1;
                                 num_active_cnt_instream <= num_active_cnt_instream;
@@ -213,7 +213,7 @@ always_ff @(posedge clk or posedge reset) begin
                         end
                     end
                     READ_INACTIVE_INSTREAM: begin
-                        if (cnt_instream == num_inactive_instream-1) begin
+                        if (cnt_instream == num_inactive_cnt_instream-1) begin
                             state_instream <= READ_ACTIVE_INSTREAM;
                             num_words_cnt_instream <= num_words_cnt_instream;
                             num_active_cnt_instream <= num_active_cnt_instream;

--- a/global_buffer/genesis/io_address_generator.svp
+++ b/global_buffer/genesis/io_address_generator.svp
@@ -25,6 +25,7 @@ module `mname` #(
     input  logic [GLB_ADDR_WIDTH-1:0]       num_words,
     input  logic [GLB_ADDR_WIDTH-1:0]       num_active,
     input  logic [GLB_ADDR_WIDTH-1:0]       num_inactive,
+    input  logic                            auto_restart,
     input  logic [1:0]                      mode,
     input  logic [CONFIG_DATA_WIDTH-1:0]    done_delay,
 
@@ -93,6 +94,7 @@ logic [GLB_ADDR_WIDTH-1:0]      cnt_instream;
 logic [GLB_ADDR_WIDTH-1:0]      num_active_cnt_instream;
 logic [GLB_ADDR_WIDTH-1:0]      num_inactive_cnt_instream;
 logic [CONFIG_DATA_WIDTH-1:0]   done_cnt_instream;
+logic                           auto_restart_instream;
 
 logic [DATA_SEL_WIDTH-1:0]      data_sel_instream;
 logic [DATA_SEL_WIDTH-1:0]      data_sel_instream_d1;
@@ -128,12 +130,14 @@ always_ff @(posedge clk or posedge reset) begin
         num_inactive_cnt_instream <= 0;
         cnt_instream <= 0;
         done_cnt_instream <= 0;
+        auto_restart_instream <= 0;
         int_addr_instream <= 0;
         io_to_bank_rd_en_instream <= 0;
         cgra_done_pulse_instream <= 0;
     end
     else if (clk_en) begin
         if (mode == INSTREAM) begin
+            auto_restart_instream <= auto_restart_instream | auto_restart;
             if (cgra_start_pulse) begin
                 if (num_words > 0) begin
                     state_instream <= READ_ACTIVE_INSTREAM;
@@ -175,15 +179,46 @@ always_ff @(posedge clk or posedge reset) begin
                     end
                     READ_ACTIVE_INSTREAM: begin
                         if (num_words_cnt_instream == 1) begin
-                            state_instream <= DONE_INSTREAM;
-                            num_words_cnt_instream <= 0;
-                            num_active_cnt_instream <= 0;
-                            num_inactive_cnt_instream <= 0;
-                            cnt_instream <= 0;
-                            done_cnt_instream <= done_cnt_instream;
-                            int_addr_instream <= int_addr_instream;
-                            io_to_bank_rd_en_instream <= 0;
-                            cgra_done_pulse_instream <= 0;
+                            if (auto_restart_instream) begin
+                                // TODO: should maybe send a clear signal to parent instead
+                                auto_restart_instream <= 0;
+
+                                if (num_words > 0) begin
+                                    state_instream <= READ_ACTIVE_INSTREAM;
+                                    num_words_cnt_instream <= num_words;
+                                    // if number of active words wasn't specified (was 0), assume num_words instead
+                                    num_active_cnt_instream <= (num_active > 0) ? num_active : num_words;
+                                    num_inactive_cnt_instream <= num_inactive;
+                                    cnt_instream <= 0;
+                                    done_cnt_instream <= done_delay;
+                                    int_addr_instream <= start_addr;
+                                    io_to_bank_rd_en_instream <= 1;
+                                    cgra_done_pulse_instream <= 0;
+                                end
+                                // corner case when num_words is set to 0 when cgra_start_pulse is high
+                                else begin
+                                    state_instream <= DONE_INSTREAM;
+                                    num_words_cnt_instream <= 0;
+                                    num_active_cnt_instream <= 0;
+                                    num_inactive_cnt_instream <= 0;
+                                    cnt_instream <= 0;
+                                    done_cnt_instream <= done_delay;
+                                    int_addr_instream <= start_addr;
+                                    io_to_bank_rd_en_instream <= 0;
+                                    cgra_done_pulse_instream <= 0;
+                                end
+                            end
+                            else begin
+                                state_instream <= DONE_INSTREAM;
+                                num_words_cnt_instream <= 0;
+                                num_active_cnt_instream <= 0;
+                                num_inactive_cnt_instream <= 0;
+                                cnt_instream <= 0;
+                                done_cnt_instream <= done_cnt_instream;
+                                int_addr_instream <= int_addr_instream;
+                                io_to_bank_rd_en_instream <= 0;
+                                cgra_done_pulse_instream <= 0;
+                            end
                         end
                         else begin
                             if (cnt_instream == num_active_cnt_instream-1) begin

--- a/global_buffer/genesis/io_address_generator.svp
+++ b/global_buffer/genesis/io_address_generator.svp
@@ -3,7 +3,7 @@
 ** Description:
 **              Address generator for I/O controller
 ** Author: Taeyoung Kong
-** Change history: 04/10/2019 - Implement first version only with interface 
+** Change history: 04/10/2019 - Implement first version only with interface
 **                 05/10/2019 - INSTREAM, OUTSTREAM modes are implemented
 **===========================================================================*/
 
@@ -36,7 +36,7 @@ module `mname` #(
     output logic                            io_to_cgra_rd_data_valid,
     input  logic [CGRA_DATA_WIDTH-1:0]      cgra_to_io_addr_high,
     input  logic [CGRA_DATA_WIDTH-1:0]      cgra_to_io_addr_low,
-    
+
     output logic                            io_to_bank_wr_en,
     output logic [BANK_DATA_WIDTH-1:0]      io_to_bank_wr_data,
     output logic [BANK_DATA_WIDTH-1:0]      io_to_bank_wr_data_bit_sel,
@@ -59,8 +59,8 @@ localparam integer BANK_ADDR_OFFSET = $clog2(BANK_DATA_WIDTH/8); // 3
 //============================================================================//
 // register to latch data from bank
 //============================================================================//
-logic                       io_to_bank_rd_en_d1; 
-logic                       io_to_bank_rd_en_d2; 
+logic                       io_to_bank_rd_en_d1;
+logic                       io_to_bank_rd_en_d2;
 logic [BANK_DATA_WIDTH-1:0] bank_to_io_rd_data_reg;
 logic                       bank_to_io_rd_data_valid_reg;
 logic [BANK_DATA_WIDTH-1:0] int_bank_to_io_rd_data;
@@ -178,50 +178,51 @@ always_ff @(posedge clk or posedge reset) begin
                         cgra_done_pulse_instream <= 0;
                     end
                     READ_ACTIVE_INSTREAM: begin
-                        if (num_words_cnt_instream == 1) begin
-                            if (auto_restart_instream) begin
-                                // TODO: should maybe send a clear signal to parent instead
-                                auto_restart_instream <= 0;
+                        if (cnt_instream == num_active_cnt_instream-1) begin
+                            if (num_inactive_cnt_instream == 0 && num_words_cnt_instream == 1) begin
+                                if (auto_restart_instream) begin
+                                    // TODO: should maybe send a clear signal to parent instead
+                                    // TODO: needs to generate interrupt
+                                    auto_restart_instream <= 0;
 
-                                if (num_words > 0) begin
-                                    state_instream <= READ_ACTIVE_INSTREAM;
-                                    num_words_cnt_instream <= num_words;
-                                    // if number of active words wasn't specified (was 0), assume num_words instead
-                                    num_active_cnt_instream <= (num_active > 0) ? num_active : num_words;
-                                    num_inactive_cnt_instream <= num_inactive;
-                                    cnt_instream <= 0;
-                                    done_cnt_instream <= done_delay;
-                                    int_addr_instream <= start_addr;
-                                    io_to_bank_rd_en_instream <= 1;
-                                    cgra_done_pulse_instream <= 0;
+                                    if (num_words > 0) begin
+                                        state_instream <= READ_ACTIVE_INSTREAM;
+                                        num_words_cnt_instream <= num_words;
+                                        // if number of active words wasn't specified (was 0), assume num_words instead
+                                        num_active_cnt_instream <= (num_active > 0) ? num_active : num_words;
+                                        num_inactive_cnt_instream <= num_inactive;
+                                        cnt_instream <= 0;
+                                        done_cnt_instream <= done_delay;
+                                        int_addr_instream <= start_addr;
+                                        io_to_bank_rd_en_instream <= 1;
+                                        cgra_done_pulse_instream <= 0;
+                                    end
+                                    // corner case when num_words is set to 0 when cgra_start_pulse is high
+                                    else begin
+                                        state_instream <= DONE_INSTREAM;
+                                        num_words_cnt_instream <= 0;
+                                        num_active_cnt_instream <= 0;
+                                        num_inactive_cnt_instream <= 0;
+                                        cnt_instream <= 0;
+                                        done_cnt_instream <= done_delay;
+                                        int_addr_instream <= start_addr;
+                                        io_to_bank_rd_en_instream <= 0;
+                                        cgra_done_pulse_instream <= 0;
+                                    end
                                 end
-                                // corner case when num_words is set to 0 when cgra_start_pulse is high
                                 else begin
                                     state_instream <= DONE_INSTREAM;
                                     num_words_cnt_instream <= 0;
                                     num_active_cnt_instream <= 0;
                                     num_inactive_cnt_instream <= 0;
                                     cnt_instream <= 0;
-                                    done_cnt_instream <= done_delay;
-                                    int_addr_instream <= start_addr;
+                                    done_cnt_instream <= done_cnt_instream;
+                                    int_addr_instream <= int_addr_instream;
                                     io_to_bank_rd_en_instream <= 0;
                                     cgra_done_pulse_instream <= 0;
                                 end
                             end
                             else begin
-                                state_instream <= DONE_INSTREAM;
-                                num_words_cnt_instream <= 0;
-                                num_active_cnt_instream <= 0;
-                                num_inactive_cnt_instream <= 0;
-                                cnt_instream <= 0;
-                                done_cnt_instream <= done_cnt_instream;
-                                int_addr_instream <= int_addr_instream;
-                                io_to_bank_rd_en_instream <= 0;
-                                cgra_done_pulse_instream <= 0;
-                            end
-                        end
-                        else begin
-                            if (cnt_instream == num_active_cnt_instream-1) begin
                                 state_instream <= READ_INACTIVE_INSTREAM;
                                 num_words_cnt_instream <= num_words_cnt_instream - 1;
                                 num_active_cnt_instream <= num_active_cnt_instream;
@@ -233,31 +234,76 @@ always_ff @(posedge clk or posedge reset) begin
                                 io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
                                 cgra_done_pulse_instream <= 0;
                             end
-                            else begin
-                                state_instream <= READ_ACTIVE_INSTREAM;
-                                num_words_cnt_instream <= num_words_cnt_instream - 1;
-                                num_active_cnt_instream <= num_active_cnt_instream;
-                                num_inactive_cnt_instream <= num_inactive_cnt_instream;
-                                cnt_instream <= cnt_instream + 1;
-                                done_cnt_instream <= done_cnt_instream;
-                                int_addr_instream <= int_addr_instream + CGRA_DATA_BYTE;
-                                // bank_rd_en goes high only when the last word is read
-                                io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
-                                cgra_done_pulse_instream <= 0;
-                            end
+                        end
+                        else begin
+                            state_instream <= READ_ACTIVE_INSTREAM;
+                            num_words_cnt_instream <= num_words_cnt_instream - 1;
+                            num_active_cnt_instream <= num_active_cnt_instream;
+                            num_inactive_cnt_instream <= num_inactive_cnt_instream;
+                            cnt_instream <= cnt_instream + 1;
+                            done_cnt_instream <= done_cnt_instream;
+                            int_addr_instream <= int_addr_instream + CGRA_DATA_BYTE;
+                            // bank_rd_en goes high only when the last word is read
+                            io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
+                            cgra_done_pulse_instream <= 0;
                         end
                     end
                     READ_INACTIVE_INSTREAM: begin
                         if (cnt_instream == num_inactive_cnt_instream-1) begin
-                            state_instream <= READ_ACTIVE_INSTREAM;
-                            num_words_cnt_instream <= num_words_cnt_instream;
-                            num_active_cnt_instream <= num_active_cnt_instream;
-                            num_inactive_cnt_instream <= num_inactive_cnt_instream;
-                            cnt_instream <= 0;
-                            done_cnt_instream <= 0;
-                            int_addr_instream <= int_addr_instream;
-                            io_to_bank_rd_en_instream <= 0;
-                            cgra_done_pulse_instream <= 0;
+                            if (num_words_cnt_instream == 0) begin
+                                if (auto_restart_instream) begin
+                                    // TODO: should maybe send a clear signal to parent instead
+                                    // TODO: needs to generate interrupt
+                                    auto_restart_instream <= 0;
+
+                                    if (num_words > 0) begin
+                                        state_instream <= READ_ACTIVE_INSTREAM;
+                                        num_words_cnt_instream <= num_words;
+                                        // if number of active words wasn't specified (was 0), assume num_words instead
+                                        num_active_cnt_instream <= (num_active > 0) ? num_active : num_words;
+                                        num_inactive_cnt_instream <= num_inactive;
+                                        cnt_instream <= 0;
+                                        done_cnt_instream <= done_delay;
+                                        int_addr_instream <= start_addr;
+                                        io_to_bank_rd_en_instream <= 1;
+                                        cgra_done_pulse_instream <= 0;
+                                    end
+                                    // corner case when num_words is set to 0 when cgra_start_pulse is high
+                                    else begin
+                                        state_instream <= DONE_INSTREAM;
+                                        num_words_cnt_instream <= 0;
+                                        num_active_cnt_instream <= 0;
+                                        num_inactive_cnt_instream <= 0;
+                                        cnt_instream <= 0;
+                                        done_cnt_instream <= done_delay;
+                                        int_addr_instream <= start_addr;
+                                        io_to_bank_rd_en_instream <= 0;
+                                        cgra_done_pulse_instream <= 0;
+                                    end
+                                end
+                                else begin
+                                    state_instream <= DONE_INSTREAM;
+                                    num_words_cnt_instream <= 0;
+                                    num_active_cnt_instream <= 0;
+                                    num_inactive_cnt_instream <= 0;
+                                    cnt_instream <= 0;
+                                    done_cnt_instream <= done_cnt_instream;
+                                    int_addr_instream <= int_addr_instream;
+                                    io_to_bank_rd_en_instream <= 0;
+                                    cgra_done_pulse_instream <= 0;
+                                end
+                            end
+                            else begin
+                                state_instream <= READ_ACTIVE_INSTREAM;
+                                num_words_cnt_instream <= num_words_cnt_instream;
+                                num_active_cnt_instream <= num_active_cnt_instream;
+                                num_inactive_cnt_instream <= num_inactive_cnt_instream;
+                                cnt_instream <= 0;
+                                done_cnt_instream <= 0;
+                                int_addr_instream <= int_addr_instream;
+                                io_to_bank_rd_en_instream <= 0;
+                                cgra_done_pulse_instream <= 0;
+                            end
                         end
                         else begin
                             state_instream <= READ_INACTIVE_INSTREAM;
@@ -366,7 +412,7 @@ logic [DATA_SEL_WIDTH-1:0]      data_sel_outstream;
 // In OUTSTREAM mode, wr_en and wr_data comes from cgra
 assign cgra_to_io_wr_en_outstream = cgra_to_io_wr_en;
 assign cgra_to_io_wr_data_outstream = cgra_to_io_wr_data;
-                                                 
+
 // We need mux due to the difference BANK_DATA_WIDTH and CGRA_DATA_WIDTH
 // It will be used to decide io_to_bank_bit_sel for partial write
 assign data_sel_outstream = int_addr_outstream[CGRA_DATA_BYTE-1 +: DATA_SEL_WIDTH];
@@ -541,7 +587,7 @@ end
 // If num_words is set to n, it generates cgra_done_pulse when the sum of
 // the number of cgra writes and reads becomes n.
 // If both cgra_to_io_wr_en and cgra_to_io_rd_en are asserted at the same
-// cycle (which is not desired scenario), cgra_to_io_wr_en has priority. 
+// cycle (which is not desired scenario), cgra_to_io_wr_en has priority.
 //============================================================================//
 enum logic[1:0] {IDLE_SRAM, RUN_SRAM, RUN_SRAM_LOOP, DONE_SRAM} state_sram;
 
@@ -573,7 +619,7 @@ logic [DATA_SEL_WIDTH-1:0]      data_sel_sram_d2;
 // In SRAM mode, wr_en and wr_data comes from cgra
 assign cgra_to_io_wr_en_sram = cgra_to_io_wr_en;
 assign cgra_to_io_wr_data_sram = cgra_to_io_wr_data;
-                                                 
+
 // In SRAM mode, rd_en comes from cgra
 assign cgra_to_io_rd_en_sram = cgra_to_io_rd_en;
 

--- a/global_buffer/genesis/io_address_generator.svp
+++ b/global_buffer/genesis/io_address_generator.svp
@@ -195,8 +195,7 @@ always_ff @(posedge clk or posedge reset) begin
                                 done_cnt_instream <= done_cnt_instream;
                                 int_addr_instream <= int_addr_instream + CGRA_DATA_BYTE;
                                 // bank_rd_en goes high only when the last word is read
-                                // io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
-                                io_to_bank_rd_en_instream <= 0;
+                                io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
                                 cgra_done_pulse_instream <= 0;
                             end
                             else begin

--- a/global_buffer/genesis/io_address_generator.svp
+++ b/global_buffer/genesis/io_address_generator.svp
@@ -23,6 +23,8 @@ module `mname` #(
 
     input  logic [GLB_ADDR_WIDTH-1:0]       start_addr,
     input  logic [GLB_ADDR_WIDTH-1:0]       num_words,
+    input  logic [GLB_ADDR_WIDTH-1:0]       num_active,
+    input  logic [GLB_ADDR_WIDTH-1:0]       num_inactive,
     input  logic [1:0]                      mode,
     input  logic [CONFIG_DATA_WIDTH-1:0]    done_delay,
 
@@ -77,11 +79,19 @@ assign int_bank_to_io_rd_data_valid = io_to_bank_rd_en_d2 ? bank_to_io_rd_data_v
 //============================================================================//
 // INSTREAM mode
 //============================================================================//
-enum logic[1:0] {IDLE_INSTREAM, READ_INSTREAM, DONE_INSTREAM} state_instream;
+enum logic[1:0] {
+    IDLE_INSTREAM,
+    READ_ACTIVE_INSTREAM,
+    READ_INACTIVE_INSTREAM,
+    DONE_INSTREAM
+} state_instream;
 
 logic [GLB_ADDR_WIDTH-1:0]      int_addr_instream;
 
 logic [GLB_ADDR_WIDTH-1:0]      num_words_cnt_instream;
+logic [GLB_ADDR_WIDTH-1:0]      cnt_instream;
+logic [GLB_ADDR_WIDTH-1:0]      num_active_cnt_instream;
+logic [GLB_ADDR_WIDTH-1:0]      num_inactive_cnt_instream;
 logic [CONFIG_DATA_WIDTH-1:0]   done_cnt_instream;
 
 logic [DATA_SEL_WIDTH-1:0]      data_sel_instream;
@@ -114,6 +124,9 @@ always_ff @(posedge clk or posedge reset) begin
     if (reset) begin
         state_instream <= IDLE_INSTREAM;
         num_words_cnt_instream <= 0;
+        num_active_cnt_instream <= 0;
+        num_inactive_cnt_instream <= 0;
+        cnt_instream <= 0;
         done_cnt_instream <= 0;
         int_addr_instream <= 0;
         io_to_bank_rd_en_instream <= 0;
@@ -123,8 +136,12 @@ always_ff @(posedge clk or posedge reset) begin
         if (mode == INSTREAM) begin
             if (cgra_start_pulse) begin
                 if (num_words > 0) begin
-                    state_instream <= READ_INSTREAM;
+                    state_instream <= READ_ACTIVE_INSTREAM;
                     num_words_cnt_instream <= num_words;
+                    // if number of active words wasn't specified (was 0), assume num_words instead
+                    num_active_cnt_instream <= (num_active > 0) ? num_active : num_words;
+                    num_inactive_cnt_instream <= num_inactive;
+                    cnt_instream <= 0;
                     done_cnt_instream <= done_delay;
                     int_addr_instream <= start_addr;
                     io_to_bank_rd_en_instream <= 1;
@@ -134,6 +151,9 @@ always_ff @(posedge clk or posedge reset) begin
                 else begin
                     state_instream <= DONE_INSTREAM;
                     num_words_cnt_instream <= 0;
+                    num_active_cnt_instream <= 0;
+                    num_inactive_cnt_instream <= 0;
+                    cnt_instream <= 0;
                     done_cnt_instream <= done_delay;
                     int_addr_instream <= start_addr;
                     io_to_bank_rd_en_instream <= 0;
@@ -145,27 +165,74 @@ always_ff @(posedge clk or posedge reset) begin
                     IDLE_INSTREAM: begin
                         state_instream <= IDLE_INSTREAM;
                         num_words_cnt_instream <= 0;
+                        num_active_cnt_instream <= 0;
+                        num_inactive_cnt_instream <= 0;
+                        cnt_instream <= 0;
                         done_cnt_instream <= 0;
                         int_addr_instream <= int_addr_instream;
                         io_to_bank_rd_en_instream <= 0;
                         cgra_done_pulse_instream <= 0;
                     end
-                    READ_INSTREAM: begin
+                    READ_ACTIVE_INSTREAM: begin
                         if (num_words_cnt_instream == 1) begin
                             state_instream <= DONE_INSTREAM;
                             num_words_cnt_instream <= 0;
+                            num_active_cnt_instream <= 0;
+                            num_inactive_cnt_instream <= 0;
+                            cnt_instream <= 0;
                             done_cnt_instream <= done_cnt_instream;
                             int_addr_instream <= int_addr_instream;
                             io_to_bank_rd_en_instream <= 0;
                             cgra_done_pulse_instream <= 0;
                         end
                         else begin
-                            state_instream <= READ_INSTREAM;
-                            num_words_cnt_instream <= num_words_cnt_instream - 1;
-                            done_cnt_instream <= done_cnt_instream;
-                            int_addr_instream <= int_addr_instream + CGRA_DATA_BYTE;
-                            // bank_rd_en goes high only when the last word is read
-                            io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
+                            if (cnt_instream == num_active_instream-1) begin
+                                state_instream <= READ_INACTIVE_INSTREAM;
+                                num_words_cnt_instream <= num_words_cnt_instream - 1;
+                                num_active_cnt_instream <= num_active_cnt_instream;
+                                num_inactive_cnt_instream <= num_inactive_cnt_instream;
+                                cnt_instream <= 0;
+                                done_cnt_instream <= done_cnt_instream;
+                                int_addr_instream <= int_addr_instream + CGRA_DATA_BYTE;
+                                // bank_rd_en goes high only when the last word is read
+                                io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
+                                cgra_done_pulse_instream <= 0;
+                            end
+                            else begin
+                                state_instream <= READ_ACTIVE_INSTREAM;
+                                num_words_cnt_instream <= num_words_cnt_instream - 1;
+                                num_active_cnt_instream <= num_active_cnt_instream;
+                                num_inactive_cnt_instream <= num_inactive_cnt_instream;
+                                cnt_instream <= cnt_instream + 1;
+                                done_cnt_instream <= done_cnt_instream;
+                                int_addr_instream <= int_addr_instream + CGRA_DATA_BYTE;
+                                // bank_rd_en goes high only when the last word is read
+                                io_to_bank_rd_en_instream <= (data_sel_instream == {DATA_SEL_WIDTH{1'b1}});
+                                cgra_done_pulse_instream <= 0;
+                            end
+                        end
+                    end
+                    READ_INACTIVE_INSTREAM: begin
+                        if (cnt_instream == num_inactive_instream-1) begin
+                            state_instream <= READ_ACTIVE_INSTREAM;
+                            num_words_cnt_instream <= num_words_cnt_instream;
+                            num_active_cnt_instream <= num_active_cnt_instream;
+                            num_inactive_cnt_instream <= num_inactive_cnt_instream;
+                            cnt_instream <= 0;
+                            done_cnt_instream <= 0;
+                            int_addr_instream <= int_addr_instream;
+                            io_to_bank_rd_en_instream <= 0;
+                            cgra_done_pulse_instream <= 0;
+                        end
+                        else begin
+                            state_instream <= READ_INACTIVE_INSTREAM;
+                            num_words_cnt_instream <= num_words_cnt_instream;
+                            num_active_cnt_instream <= num_active_cnt_instream;
+                            num_inactive_cnt_instream <= num_inactive_cnt_instream;
+                            cnt_instream <= cnt_instream + 1;
+                            done_cnt_instream <= 0;
+                            int_addr_instream <= int_addr_instream;
+                            io_to_bank_rd_en_instream <= 0;
                             cgra_done_pulse_instream <= 0;
                         end
                     end
@@ -173,6 +240,8 @@ always_ff @(posedge clk or posedge reset) begin
                         if (done_cnt_instream == 0) begin
                             state_instream <= IDLE_INSTREAM;
                             num_words_cnt_instream <= 0;
+                            num_active_cnt_instream <= 0;
+                            num_inactive_cnt_instream <= 0;
                             done_cnt_instream <= 0;
                             int_addr_instream <= int_addr_instream;
                             io_to_bank_rd_en_instream <= 0;
@@ -181,6 +250,8 @@ always_ff @(posedge clk or posedge reset) begin
                         else begin
                             state_instream <= DONE_INSTREAM;
                             num_words_cnt_instream <= 0;
+                            num_active_cnt_instream <= 0;
+                            num_inactive_cnt_instream <= 0;
                             done_cnt_instream <= done_cnt_instream - 1;
                             int_addr_instream <= int_addr_instream;
                             io_to_bank_rd_en_instream <= 0;
@@ -190,6 +261,8 @@ always_ff @(posedge clk or posedge reset) begin
                     default: begin
                         state_instream <= IDLE_INSTREAM;
                         num_words_cnt_instream <= 0;
+                        num_active_cnt_instream <= 0;
+                        num_inactive_cnt_instream <= 0;
                         done_cnt_instream <= 0;
                         int_addr_instream <= int_addr_instream;
                         io_to_bank_rd_en_instream <= 0;
@@ -202,6 +275,8 @@ always_ff @(posedge clk or posedge reset) begin
         else begin
             state_instream <= IDLE_INSTREAM;
             num_words_cnt_instream <= 0;
+            num_active_cnt_instream <= 0;
+            num_inactive_cnt_instream <= 0;
             done_cnt_instream <= 0;
             int_addr_instream <= int_addr_instream;
             io_to_bank_rd_en_instream <= 0;

--- a/global_buffer/genesis/io_controller.svp
+++ b/global_buffer/genesis/io_controller.svp
@@ -76,6 +76,7 @@ logic [GLB_ADDR_WIDTH-1:0]      io_ctrl_start_addr [`$num_io_channels-1`:0];
 logic [GLB_ADDR_WIDTH-1:0]      io_ctrl_num_words [`$num_io_channels-1`:0];
 logic [GLB_ADDR_WIDTH-1:0]      io_ctrl_num_active [`$num_io_channels-1`:0];
 logic [GLB_ADDR_WIDTH-1:0]      io_ctrl_num_inactive [`$num_io_channels-1`:0];
+logic                           io_ctrl_auto_restart [`$num_io_channels-1`:0];
 logic [1:0]                     io_ctrl_mode [`$num_io_channels-1`:0];
 logic [`$banks_per_io-1`:0]     io_ctrl_switch_sel [`$num_io_channels-1`:0];
 logic [CONFIG_DATA_WIDTH-1:0]   io_ctrl_done_delay [`$num_io_channels-1`:0];
@@ -111,6 +112,7 @@ assign clk_en = !glc_to_io_stall;
     .num_words(io_ctrl_num_words[`$i`]),
     .num_active(io_ctrl_num_active[`$i`]),
     .num_inactive(io_ctrl_num_inactive[`$i`]),
+    .auto_restart(io_ctrl_auto_restart[`$i`]),
     .mode(io_ctrl_mode[`$i`]),
     .done_delay(io_ctrl_done_delay[`$i`]),
 
@@ -156,6 +158,7 @@ always_ff @(posedge clk or posedge reset) begin
             io_ctrl_num_words[j] <= 0;
             io_ctrl_num_active[j] <= 0;
             io_ctrl_num_inactive[j] <= 0;
+            io_ctrl_auto_restart[j] <= 0;
             io_ctrl_switch_sel[j] <= 0;
             io_ctrl_done_delay[j] <= 0;
             io_ctrl_done_gate[j] <= 0;
@@ -163,6 +166,11 @@ always_ff @(posedge clk or posedge reset) begin
     end
     else begin
         for(integer j=0; j<`$num_io_channels`; j=j+1) begin
+            // TODO: For now, only stays high for 1 cycle.
+            // It would be better to clear it with a signal
+            // coming back from the internal module.
+            io_ctrl_auto_restart[j] <= 0;
+
             if (config_en_io_ctrl[j] && config_wr) begin
                 case (config_reg_addr)
                     0: io_ctrl_mode[j] <= config_wr_data[1:0];
@@ -173,6 +181,7 @@ always_ff @(posedge clk or posedge reset) begin
                     5: io_ctrl_done_gate[j] <= config_wr_data;
                     6: io_ctrl_num_active[j] <= config_wr_data[GLB_ADDR_WIDTH-1:0];
                     7: io_ctrl_num_inactive[j] <= config_wr_data[GLB_ADDR_WIDTH-1:0];
+                    8: io_ctrl_auto_restart[j] <= config_wr_data[0];
                 endcase
             end
         end
@@ -192,6 +201,7 @@ always_comb begin
                 5: config_rd_data = io_ctrl_done_gate[j];
                 6: config_rd_data = io_ctrl_num_active[j];
                 7: config_rd_data = io_ctrl_num_inactive[j];
+                8: config_rd_data = io_ctrl_auto_restart[j];
                 default: config_rd_data = 0;
             endcase
         end

--- a/global_buffer/genesis/io_controller.svp
+++ b/global_buffer/genesis/io_controller.svp
@@ -74,6 +74,8 @@ logic                           io_cgra_start_pulse [`$num_io_channels-1`:0];
 logic                           io_cgra_done_pulse [`$num_io_channels-1`:0];
 logic [GLB_ADDR_WIDTH-1:0]      io_ctrl_start_addr [`$num_io_channels-1`:0];
 logic [GLB_ADDR_WIDTH-1:0]      io_ctrl_num_words [`$num_io_channels-1`:0];
+logic [GLB_ADDR_WIDTH-1:0]      io_ctrl_num_active [`$num_io_channels-1`:0];
+logic [GLB_ADDR_WIDTH-1:0]      io_ctrl_num_inactive [`$num_io_channels-1`:0];
 logic [1:0]                     io_ctrl_mode [`$num_io_channels-1`:0];
 logic [`$banks_per_io-1`:0]     io_ctrl_switch_sel [`$num_io_channels-1`:0];
 logic [CONFIG_DATA_WIDTH-1:0]   io_ctrl_done_delay [`$num_io_channels-1`:0];
@@ -107,6 +109,8 @@ assign clk_en = !glc_to_io_stall;
 
     .start_addr(io_ctrl_start_addr[`$i`]),
     .num_words(io_ctrl_num_words[`$i`]),
+    .num_active(io_ctrl_num_active[`$i`]),
+    .num_inactive(io_ctrl_num_inactive[`$i`]),
     .mode(io_ctrl_mode[`$i`]),
     .done_delay(io_ctrl_done_delay[`$i`]),
 
@@ -150,6 +154,8 @@ always_ff @(posedge clk or posedge reset) begin
             io_ctrl_mode[j] <= 0;
             io_ctrl_start_addr[j] <= 0;
             io_ctrl_num_words[j] <= 0;
+            io_ctrl_num_active[j] <= 0;
+            io_ctrl_num_inactive[j] <= 0;
             io_ctrl_switch_sel[j] <= 0;
             io_ctrl_done_delay[j] <= 0;
             io_ctrl_done_gate[j] <= 0;
@@ -165,6 +171,8 @@ always_ff @(posedge clk or posedge reset) begin
                     3: io_ctrl_switch_sel[j] <= config_wr_data[`$banks_per_io-1`:0];
                     4: io_ctrl_done_delay[j] <= config_wr_data;
                     5: io_ctrl_done_gate[j] <= config_wr_data;
+                    6: io_ctrl_num_active[j] <= config_wr_data[GLB_ADDR_WIDTH-1:0];
+                    7: io_ctrl_num_inactive[j] <= config_wr_data[GLB_ADDR_WIDTH-1:0];
                 endcase
             end
         end
@@ -182,6 +190,8 @@ always_comb begin
                 3: config_rd_data = io_ctrl_switch_sel[j];
                 4: config_rd_data = io_ctrl_done_delay[j];
                 5: config_rd_data = io_ctrl_done_gate[j];
+                6: config_rd_data = io_ctrl_num_active[j];
+                7: config_rd_data = io_ctrl_num_inactive[j];
                 default: config_rd_data = 0;
             endcase
         end

--- a/global_buffer/global_buffer_bs_generator.py
+++ b/global_buffer/global_buffer_bs_generator.py
@@ -181,6 +181,7 @@ class IOAddrGen(GlbFeature):
         self.add_config("done_gate", 1)
         self.add_config("num_active", 32)
         self.add_config("num_inactive", 32)
+        self.add_config("auto_restart", 1)
 
     def name(self):
         return f"{self.core.name()}_IOAddrGen_{self.feature_id}"

--- a/global_buffer/global_buffer_bs_generator.py
+++ b/global_buffer/global_buffer_bs_generator.py
@@ -179,6 +179,8 @@ class IOAddrGen(GlbFeature):
         self.add_config("switch_sel", 4)
         self.add_config("done_delay", switch_size)
         self.add_config("done_gate", 1)
+        self.add_config("num_active", 32)
+        self.add_config("num_inactive", 32)
 
     def name(self):
         return f"{self.core.name()}_IOAddrGen_{self.feature_id}"


### PR DESCRIPTION
Similar to duty cycle or pwm, setting the num_active and num_inactive
will cause the io controller to provide inputs for num_active cycles,
then wait for num_inactive cycles, before continuing with more
inputs. This repeats until num_words is 0.