### PR TITLE
Migrate to peak assembler type

### DIFF
--- a/peak_core/peak_core.py
+++ b/peak_core/peak_core.py
@@ -68,7 +68,7 @@ class _PeakWrapper(metaclass=_PeakWrapperMeta):
         return self.__asm.width
 
     def assemble(self, instr):
-        return self.__asm(instr)
+        return self.__asm.assemble(instr)
 
 
 class PassThroughReg(Generator):

--- a/peak_core/peak_core.py
+++ b/peak_core/peak_core.py
@@ -2,6 +2,7 @@ import math
 import hwtypes
 import magma
 import peak
+from peak.assembler import Assembler
 import mantle
 from gemstone.common.core import ConfigurableCore, PnRTag
 from gemstone.common.configurable import ConfigurationType
@@ -41,7 +42,7 @@ class _PeakWrapper(metaclass=_PeakWrapperMeta):
         self.__inputs = pe._peak_inputs_
         self.__outputs = pe._peak_outputs_
         circuit = peak_generator(magma.get_family())
-        self.__asm = peak.assembler.Assembler(self.__instr_type)
+        self.__asm = Assembler(self.__instr_type)
         instr_magma_type = type(circuit.interface.ports[self.__instr_name])
         self.__circuit = peak.wrap_with_disassembler(
             circuit, self.__asm.disassemble, self.__asm.width,

--- a/peak_core/peak_core.py
+++ b/peak_core/peak_core.py
@@ -41,11 +41,11 @@ class _PeakWrapper(metaclass=_PeakWrapperMeta):
         self.__inputs = pe._peak_inputs_
         self.__outputs = pe._peak_outputs_
         circuit = peak_generator(magma.get_family())
-        self.__asm, disasm, self.__instr_width, layout = \
-            peak.auto_assembler.generate_assembler(self.__instr_type)
+        self.__asm = peak.assembler.Assembler(self.__instr_type)
         instr_magma_type = type(circuit.interface.ports[self.__instr_name])
         self.__circuit = peak.wrap_with_disassembler(
-            circuit, disasm, self.__instr_width, HashableDict(layout),
+            circuit, self.__asm.disassemble, self.__asm.width,
+            HashableDict(self.__asm.layout),
             instr_magma_type)
 
     def rtl(self):
@@ -64,7 +64,7 @@ class _PeakWrapper(metaclass=_PeakWrapperMeta):
         return self.__instr_type
 
     def instruction_width(self):
-        return self.__instr_width
+        return self.__asm.width
 
     def assemble(self, instr):
         return self.__asm(instr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
 -e git://github.com/StanfordAHA/canal.git#egg=canal
--e git://github.com/phanrahan/peak.git#egg=peak
+-e git://github.com/phanrahan/peak.git@assembled-adt#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper
 -e git://github.com/Kuree/karst.git#egg=karst


### PR DESCRIPTION
Removes dependency on `auto_assembler`