### PR TITLE
Garnet top script enhancements

### DIFF
--- a/garnet.py
+++ b/garnet.py
@@ -261,7 +261,7 @@ def main():
     parser.add_argument("-v", "--verilog", action="store_true")
     parser.add_argument("--no-pd", "--no-power-domain", action="store_true")
     parser.add_argument("--interconnect-only", action="store_true")
-    parser.add_argument("--no_sram_stub", action="store_true")
+    parser.add_argument("--no-sram-stub", action="store_true")
     args = parser.parse_args()
 
     if not args.interconnect_only:

--- a/mflowgen/Tile_MemCore/rtl/gen_rtl.sh
+++ b/mflowgen/Tile_MemCore/rtl/gen_rtl.sh
@@ -5,7 +5,7 @@ if [ -d "genesis_verif/" ]; then
   rm -rf genesis_verif
 fi
 
-python garnet.py  -v --no_sram_stub --no-pd
+python garnet.py  -v --no-sram-stub --no-pd
 
 cp garnet.v genesis_verif/garnet.sv
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -5,7 +5,7 @@ if [ -d "genesis_verif/" ]; then
   rm -rf genesis_verif
 fi
 
-python garnet.py  -v --no_sram_stub --no-pd
+python garnet.py  -v --no-sram-stub --no-pd
 
 cp garnet.v genesis_verif/garnet.sv
 


### PR DESCRIPTION
Added Added the flag --standalone to garnet.py. If this flag is specified IO cores are not added to the CGRA fabric.

Also renamed `no_sram_stub` option to `no-sram-stub`.