### PR TITLE
Mflowgen rtl params

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -23,19 +23,21 @@ def construct():
   adk_view = 'stdview'
 
   parameters = {
-    'construct_path' : __file__,
-    'design_name'    : 'Tile_MemCore',
-    'clock_period'   : 20.0,
-    'adk'            : adk_name,
-    'adk_view'       : adk_view,
+    'construct_path'    : __file__,
+    'design_name'       : 'Tile_MemCore',
+    'clock_period'      : 20.0,
+    'adk'               : adk_name,
+    'adk_view'          : adk_view,
     # Synthesis
-    'flatten_effort' : 3,
-    'topographical'  : False,
+    'flatten_effort'    : 3,
+    'topographical'     : False,
     # SRAM macros
-    'num_words'      : 512,
-    'word_size'      : 16,
-    'mux_size'       : 8,
-    'corner'         : "tt0p8v25c",
+    'num_words'         : 512,
+    'word_size'         : 16,
+    'mux_size'          : 8,
+    'corner'            : "tt0p8v25c",
+    # RTL Generation
+    'interconnect_only' : True
   }
 
   #-----------------------------------------------------------------------

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -23,14 +23,16 @@ def construct():
   adk_view = 'stdview'
 
   parameters = {
-    'construct_path' : __file__,
-    'design_name'    : 'Tile_PE',
-    'clock_period'   : 10.0,
-    'adk'            : adk_name,
-    'adk_view'       : adk_view,
+    'construct_path'    : __file__,
+    'design_name'       : 'Tile_PE',
+    'clock_period'      : 10.0,
+    'adk'               : adk_name,
+    'adk_view'          : adk_view,
     # Synthesis
-    'flatten_effort' : 3,
-    'topographical'  : False,
+    'flatten_effort'    : 3,
+    'topographical'     : False,
+    # RTL Generation
+    'interconnect_only' : True
   }
 
   #-----------------------------------------------------------------------

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -6,3 +6,6 @@ commands:
 outputs:
   - design.v
 
+parameters:
+  array_width: 4
+  array_height: 2

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -9,3 +9,4 @@ outputs:
 parameters:
   array_width: 4
   array_height: 2
+  interconnect_only: false

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -5,12 +5,23 @@ if [ -d "genesis_verif/" ]; then
   rm -rf genesis_verif
 fi
 
-python garnet.py  --width $array_width --height $array_height -v --no-sram-stub --no-pd
+cmd="python garnet.py --width $array_width --height $array_height -v --no-sram-stub --no-pd"
 
-cp garnet.v genesis_verif/garnet.sv
+if [ $interconnect_only == True ]; then
+ cmd+=" --interconnect-only"
+fi
 
-cat genesis_verif/* >> $current_dir/outputs/design.v
-#cp garnet.v $current_dir/outputs/design.v
+eval $cmd
+
+# If there are any genesis files, we need to cat those
+# with the magma generated garnet.v
+if [ -d "genesis_verif" ]; then
+  cp garnet.v genesis_verif/garnet.sv
+  cat genesis_verif/* >> $current_dir/outputs/design.v
+# Otherwise, garnet.v contains all rtl
+else
+  cp garnet.v $current_dir/outputs/design.v
+fi
 
 
 cd $current_dir

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -5,7 +5,7 @@ if [ -d "genesis_verif/" ]; then
   rm -rf genesis_verif
 fi
 
-python garnet.py  -v --no-sram-stub --no-pd
+python garnet.py  --width $array_width --height $array_height -v --no-sram-stub --no-pd
 
 cp garnet.v genesis_verif/garnet.sv
 

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -23,17 +23,18 @@ def construct():
   adk_view = 'stdview'
 
   parameters = {
-    'construct_path' : __file__,
-    'design_name'    : 'Interconnect',
-    'clock_period'   : 10.0,
-    'adk'            : adk_name,
-    'adk_view'       : adk_view,
+    'construct_path'    : __file__,
+    'design_name'       : 'Interconnect',
+    'clock_period'      : 10.0,
+    'adk'               : adk_name,
+    'adk_view'          : adk_view,
     # Synthesis
-    'flatten_effort' : 3,
-    'topographical'  : False,
+    'flatten_effort'    : 3,
+    'topographical'     : False,
     # RTL Generation
-    'array_width'    : 4,
-    'array_height'   : 2
+    'array_width'       : 4,
+    'array_height'      : 2,
+    'interconnect_only' : True
   }
 
   #-----------------------------------------------------------------------

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -32,7 +32,7 @@ def construct():
     'flatten_effort'    : 3,
     'topographical'     : False,
     # RTL Generation
-    'array_width'       : 4,
+    'array_width'       : 2,
     'array_height'      : 2,
     'interconnect_only' : True
   }
@@ -147,19 +147,25 @@ def construct():
   g.connect_by_name( adk,      drc          )
   g.connect_by_name( adk,      lvs          )
 
-  g.connect_by_name( Tile_MemCore,      dc           )
-  g.connect_by_name( Tile_MemCore,      iflow        )
-  g.connect_by_name( Tile_MemCore,      init         )
-  g.connect_by_name( Tile_MemCore,      power        )
-  g.connect_by_name( Tile_MemCore,      place        )
-  g.connect_by_name( Tile_MemCore,      cts          )
-  g.connect_by_name( Tile_MemCore,      postcts_hold )
-  g.connect_by_name( Tile_MemCore,      route        )
-  g.connect_by_name( Tile_MemCore,      postroute    )
-  g.connect_by_name( Tile_MemCore,      signoff      )
-  g.connect_by_name( Tile_MemCore,      gdsmerge     )
-  g.connect_by_name( Tile_MemCore,      drc          )
-  g.connect_by_name( Tile_MemCore,      lvs          )
+  # In our CGRA, the tile pattern is:
+  # PE PE PE Mem PE PE PE Mem ...
+  # Thus, if there are < 4 columns, the the array won't contain any
+  # memory tiles. If this is the case, we don't need to run the
+  # memory tile flow.
+  if parameters['array_width'] > 3:
+      g.connect_by_name( Tile_MemCore,      dc           )
+      g.connect_by_name( Tile_MemCore,      iflow        )
+      g.connect_by_name( Tile_MemCore,      init         )
+      g.connect_by_name( Tile_MemCore,      power        )
+      g.connect_by_name( Tile_MemCore,      place        )
+      g.connect_by_name( Tile_MemCore,      cts          )
+      g.connect_by_name( Tile_MemCore,      postcts_hold )
+      g.connect_by_name( Tile_MemCore,      route        )
+      g.connect_by_name( Tile_MemCore,      postroute    )
+      g.connect_by_name( Tile_MemCore,      signoff      )
+      g.connect_by_name( Tile_MemCore,      gdsmerge     )
+      g.connect_by_name( Tile_MemCore,      drc          )
+      g.connect_by_name( Tile_MemCore,      lvs          )
 
   g.connect_by_name( Tile_PE,      dc           )
   g.connect_by_name( Tile_PE,      iflow        )

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -31,6 +31,9 @@ def construct():
     # Synthesis
     'flatten_effort' : 3,
     'topographical'  : False,
+    # RTL Generation
+    'array_width'    : 4,
+    'array_height'   : 2
   }
 
   #-----------------------------------------------------------------------


### PR DESCRIPTION
Small PR to add tile array height, width, and interconnect_only params to common rtl generation node.

Setting the interconnect_only param generates only the array of tiles without the global buffer. When we set this, we can generate the 2x2 array of tiles we want for timing constraints development and testing.