### PR TITLE
Extend leaf-level power straps to design boundary

### DIFF
--- a/mflowgen/common/custom-power-leaf/outputs/power-strategy-dualmesh.tcl
+++ b/mflowgen/common/custom-power-leaf/outputs/power-strategy-dualmesh.tcl
@@ -165,5 +165,6 @@ addStripe -nets {VSS VDD} -layer $pmesh_bot -direction horizontal \
     -max_same_layer_jog_length $pmesh_bot_str_pitch               \
     -padcore_ring_bottom_layer_limit $pmesh_bot                   \
     -padcore_ring_top_layer_limit $pmesh_top                      \
-    -start [expr $pmesh_bot_str_pitch]
+    -start [expr $pmesh_bot_str_pitch]                            \
+    -extend_to design_boundary
 


### PR DESCRIPTION
Small update for leaf-level power strategy to extend M8 power stripes to design boundary. This allows the M8 power grid to connect by abutment between macros.