### PR TITLE
Clk pass

### DIFF
--- a/cgra/util.py
+++ b/cgra/util.py
@@ -11,6 +11,7 @@ from memory_core.memory_core_magma import MemCore
 from peak_core.peak_core import PeakCore
 from typing import Tuple, Dict, List, Tuple
 from tile_id_pass.tile_id_pass import tile_id_physical
+from clk_pass.clk_pass import clk_physical
 
 
 def get_actual_size(width: int, height: int, io_sides: IOSide):
@@ -35,6 +36,7 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
                 add_pd: bool = True,
                 use_sram_stub: bool = True,
                 hi_lo_tile_id: bool = True,
+                pass_through_clk: bool = True,
                 global_signal_wiring: GlobalSignalWiring =
                 GlobalSignalWiring.Meso,
                 standalone: bool = False,
@@ -153,5 +155,8 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
                                           num_cfg=num_parallel_config)
     if add_pd:
         add_aon_read_config_data(interconnect)
+
+    if pass_through_clk:
+        clk_physical(interconnect)
 
     return interconnect

--- a/clk_pass/clk_pass.py
+++ b/clk_pass/clk_pass.py
@@ -28,7 +28,7 @@ def clk_physical(interconnect: Interconnect):
         orig_in_port = tile.ports.clk
         orig_out_port = tile.ports.clk_out
         tile.remove_wire(orig_in_port, orig_out_port)
-        tile.add_port("pass_through_clk", magma.In(magma.Clock))
+        tile.add_port("clk_pass_through", magma.In(magma.Clock))
         pass_through_output = pass_signal_through(tile, tile.ports.pass_through_clk)
         tile.wire(tile.ports.pass_through_clk, orig_out_port)
         if y < 2:

--- a/clk_pass/clk_pass.py
+++ b/clk_pass/clk_pass.py
@@ -3,6 +3,22 @@ from canal.interconnect import Interconnect
 import magma
 from gemstone.common.transform import pass_signal_through
 
+# This pass creates an extra port to pass clock signals through
+# CGRA tiles in the interconnect. This allows us to pass the clock
+# signal through the tile without going through the tile's clock tree.
+
+#            clk                         clk   pt_clk
+#      ---------------                ---------------
+#      |      |      |        \       |   |      |  |
+#      |    |---|    |         \      | |---|    |  |
+#      |   |-| |-|   |   -------\     ||-| |-|   |  |
+#      |       |     |   -------/     |          |  |
+#      |       |     |         /      |      ----|  |
+#      |       |     |        /       |      |   |  |
+#      ---------------                ---------------
+#           clk_out                    clk_out  pt_clk_out  
+#
+
 def clk_physical(interconnect: Interconnect):
     for (x, y) in interconnect.tile_circuits:
         tile = interconnect.tile_circuits[(x, y)]

--- a/clk_pass/clk_pass.py
+++ b/clk_pass/clk_pass.py
@@ -23,20 +23,30 @@ def clk_physical(interconnect: Interconnect):
     for (x, y) in interconnect.tile_circuits:
         tile = interconnect.tile_circuits[(x, y)]
         tile_core = tile.core
+        # We only want to do this on PE and memory tiles
         if isinstance(tile_core, IOCore) or tile_core is None:
             continue
         orig_in_port = tile.ports.clk
         orig_out_port = tile.ports.clk_out
+        # Remove the pass through connection that already exists
         tile.remove_wire(orig_in_port, orig_out_port)
+        # Create a new pass through clock input
         tile.add_port("clk_pass_through", magma.In(magma.Clock))
-        pass_through_output = pass_signal_through(tile, tile.ports.pass_through_clk)
-        tile.wire(tile.ports.pass_through_clk, orig_out_port)
+        pass_through_input = tile.ports.clk_pass_through
+        # Create new pass through output
+        pass_through_output = pass_signal_through(tile, pass_through_input)
+        # Connect new clk pass through input to old pass through output
+        tile.wire(pass_through_input, orig_out_port)
+        # For top row tiles, connect new clk input to global clock
         if y < 2:
             interconnect.wire(interconnect.ports.clk,
-                              tile.ports.pass_through_clk)
+                              pass_through_input)
+        # For other tiles, connect new clk input to 
+        # pass through output of tile above.
         else:
-            interconnect.wire(interconnect.tile_circuits[(x, y-1)].ports.pass_through_clk_out,
-                              tile.ports.pass_through_clk)
+            tile_above = interconnect.tile_circuits[(x, y-1)]
+            interconnect.wire(tile_above.ports.clk_pass_through_out,
+                              pass_through_input)
        
         
     

--- a/mflowgen/Tile_MemCore/custom-init/outputs/pin-assignments.tcl
+++ b/mflowgen/Tile_MemCore/custom-init/outputs/pin-assignments.tcl
@@ -35,10 +35,10 @@ if { $clock_ports != 0 } {
 # Buses with more than 10 bits will be out of order after the sort, but shouldn't be a big issue since
 # the whole bus will still be together.
 set north1 [sort_collection [get_ports SB_*_NORTH_SB_IN*] hierarchical_name]
-set north2 [sort_collection [get_ports {SB_*_NORTH_SB_OUT* clk reset stall config_config_* config_read config_write read_config_data_in}] hierarchical_name]
+set north2 [sort_collection [get_ports {SB_*_NORTH_SB_OUT* clk pass_through_clk reset stall config_config_* config_read config_write read_config_data_in}] hierarchical_name]
 set north [concat $north1 $north2]
 set south1 [sort_collection [get_ports SB_*_SOUTH_SB_OUT*] hierarchical_name]
-set south2 [sort_collection [get_ports {SB_*_SOUTH_SB_IN* clk_out reset_out stall_out config_out_config_* config_out_read config_out_write read_config_data}] hierarchical_name]
+set south2 [sort_collection [get_ports {SB_*_SOUTH_SB_IN* clk_out pass_through_clk_out reset_out stall_out config_out_config_* config_out_read config_out_write read_config_data}] hierarchical_name]
 set south [concat $south1 $south2]
 set east1 [sort_collection [get_ports SB_*_EAST_SB_OUT*] hierarchical_name]
 set east2 [sort_collection [get_ports SB_*_EAST_SB_IN*] hierarchical_name]

--- a/mflowgen/Tile_MemCore/custom-init/outputs/pin-assignments.tcl
+++ b/mflowgen/Tile_MemCore/custom-init/outputs/pin-assignments.tcl
@@ -35,10 +35,10 @@ if { $clock_ports != 0 } {
 # Buses with more than 10 bits will be out of order after the sort, but shouldn't be a big issue since
 # the whole bus will still be together.
 set north1 [sort_collection [get_ports SB_*_NORTH_SB_IN*] hierarchical_name]
-set north2 [sort_collection [get_ports {SB_*_NORTH_SB_OUT* clk pass_through_clk reset stall config_config_* config_read config_write read_config_data_in}] hierarchical_name]
+set north2 [sort_collection [get_ports {SB_*_NORTH_SB_OUT* clk clk_pass_through reset stall config_config_* config_read config_write read_config_data_in}] hierarchical_name]
 set north [concat $north1 $north2]
 set south1 [sort_collection [get_ports SB_*_SOUTH_SB_OUT*] hierarchical_name]
-set south2 [sort_collection [get_ports {SB_*_SOUTH_SB_IN* clk_out pass_through_clk_out reset_out stall_out config_out_config_* config_out_read config_out_write read_config_data}] hierarchical_name]
+set south2 [sort_collection [get_ports {SB_*_SOUTH_SB_IN* clk_out clk_pass_through_out reset_out stall_out config_out_config_* config_out_read config_out_write read_config_data}] hierarchical_name]
 set south [concat $south1 $south2]
 set east1 [sort_collection [get_ports SB_*_EAST_SB_OUT*] hierarchical_name]
 set east2 [sort_collection [get_ports SB_*_EAST_SB_IN*] hierarchical_name]

--- a/mflowgen/Tile_PE/custom-init/outputs/pin-assignments.tcl
+++ b/mflowgen/Tile_PE/custom-init/outputs/pin-assignments.tcl
@@ -35,10 +35,10 @@ if { $clock_ports != 0 } {
 # Buses with more than 10 bits will be out of order after the sort, but shouldn't be a big issue since
 # the whole bus will still be together.
 set north1 [sort_collection [get_ports SB_*_NORTH_SB_IN*] hierarchical_name]
-set north2 [sort_collection [get_ports {SB_*_NORTH_SB_OUT* clk reset stall config_config_* config_read config_write read_config_data_in}] hierarchical_name]
+set north2 [sort_collection [get_ports {SB_*_NORTH_SB_OUT* clk pass_through_clk reset stall config_config_* config_read config_write read_config_data_in}] hierarchical_name]
 set north [concat $north1 $north2]
 set south1 [sort_collection [get_ports SB_*_SOUTH_SB_OUT*] hierarchical_name]
-set south2 [sort_collection [get_ports {SB_*_SOUTH_SB_IN* clk_out reset_out stall_out config_out_config_* config_out_read config_out_write read_config_data}] hierarchical_name]
+set south2 [sort_collection [get_ports {SB_*_SOUTH_SB_IN* clk_out pass_through_clk_out reset_out stall_out config_out_config_* config_out_read config_out_write read_config_data}] hierarchical_name]
 set south [concat $south1 $south2]
 set east1 [sort_collection [get_ports SB_*_EAST_SB_OUT*] hierarchical_name]
 set east2 [sort_collection [get_ports SB_*_EAST_SB_IN*] hierarchical_name]

--- a/mflowgen/Tile_PE/custom-init/outputs/pin-assignments.tcl
+++ b/mflowgen/Tile_PE/custom-init/outputs/pin-assignments.tcl
@@ -35,10 +35,10 @@ if { $clock_ports != 0 } {
 # Buses with more than 10 bits will be out of order after the sort, but shouldn't be a big issue since
 # the whole bus will still be together.
 set north1 [sort_collection [get_ports SB_*_NORTH_SB_IN*] hierarchical_name]
-set north2 [sort_collection [get_ports {SB_*_NORTH_SB_OUT* clk pass_through_clk reset stall config_config_* config_read config_write read_config_data_in}] hierarchical_name]
+set north2 [sort_collection [get_ports {SB_*_NORTH_SB_OUT* clk clk_pass_through reset stall config_config_* config_read config_write read_config_data_in}] hierarchical_name]
 set north [concat $north1 $north2]
 set south1 [sort_collection [get_ports SB_*_SOUTH_SB_OUT*] hierarchical_name]
-set south2 [sort_collection [get_ports {SB_*_SOUTH_SB_IN* clk_out pass_through_clk_out reset_out stall_out config_out_config_* config_out_read config_out_write read_config_data}] hierarchical_name]
+set south2 [sort_collection [get_ports {SB_*_SOUTH_SB_IN* clk_out clk_pass_through_out reset_out stall_out config_out_config_* config_out_read config_out_write read_config_data}] hierarchical_name]
 set south [concat $south1 $south2]
 set east1 [sort_collection [get_ports SB_*_EAST_SB_OUT*] hierarchical_name]
 set east2 [sort_collection [get_ports SB_*_EAST_SB_IN*] hierarchical_name]


### PR DESCRIPTION
This PR introduces a small pass that creates an extra port on each tile to pass the clock through. This allows us to pass the clock through each tile without going through the tile's clock tree, which will both minimize the delay of the clock through each tile, and allow us to closely match the skew between the clock and the other pass_through global signals. For an [illustration](https://github.com/StanfordAHA/garnet/blob/b5508dba0e86fe2512a1c6a378da696a8a4088cb/clk_pass/clk_pass.py#L10), see the comment at the top of clk_pass.py. 