### PR TITLE
turn order params into a list

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -220,17 +220,23 @@ def construct():
   #-----------------------------------------------------------------------
 
   g.update_params( parameters )
-  # Since we are adding an additional input to the init node, we must add
-  # that input to the order parameter for that node, so it actually gets run
-  init.update_params(
-                     {'order': "\"main.tcl quality-of-life.tcl floorplan.tcl add-endcaps-welltaps.tcl "\
-                               "pin-assignments.tcl make-path-groups.tcl reporting.tcl\""}
-                    )
- 
-  # Adding new input for genlibdb node to run 
+
+  # Since we are adding an additional input script to the generic Innovus
+  # steps, we modify the order parameter for that node which determines
+  # which scripts get run and when they get run.
+
+  # init -- Add 'add-endcaps-welltaps.tcl' after 'floorplan.tcl'
+
+  order = init.get_param('order') # get the default script run order
+  floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
+  order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
+  init.update_params( { 'order': order } )
+
+  # Adding new input for genlibdb node to run
+
   genlibdb.update_params(
-                         {'order': "\"read_design.tcl genlibdb-constraints.tcl extract_model.tcl\""}
-                        )
+    {'order': "\"read_design.tcl genlibdb-constraints.tcl extract_model.tcl\""}
+  )
 
   return g
 

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -181,17 +181,23 @@ def construct():
   #-----------------------------------------------------------------------
 
   g.update_params( parameters )
-  # Since we are adding an additional input to the init node, we must add
-  # that input to the order parameter for that node, so it actually gets run
-  init.update_params(
-                     {'order': "\"main.tcl quality-of-life.tcl floorplan.tcl add-endcaps-welltaps.tcl "\
-                               "pin-assignments.tcl make-path-groups.tcl reporting.tcl\""}
-                    )
-  
-  # Adding new input for genlibdb node to run 
+
+  # Since we are adding an additional input script to the generic Innovus
+  # steps, we modify the order parameter for that node which determines
+  # which scripts get run and when they get run.
+
+  # init -- Add 'add-endcaps-welltaps.tcl' after 'floorplan.tcl'
+
+  order = init.get_param('order') # get the default script run order
+  floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
+  order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
+  init.update_params( { 'order': order } )
+
+  # Adding new input for genlibdb node to run
+
   genlibdb.update_params(
-                         {'order': "\"read_design.tcl genlibdb-constraints.tcl extract_model.tcl\""}
-                        )
+    {'order': "\"read_design.tcl genlibdb-constraints.tcl extract_model.tcl\""}
+  )
 
   return g
 

--- a/mflowgen/glb_tile/construct.py
+++ b/mflowgen/glb_tile/construct.py
@@ -221,12 +221,17 @@ def construct():
   #-----------------------------------------------------------------------
 
   g.update_params( parameters )
-  # Since we are adding an additional input to the init node, we must add
-  # that input to the order parameter for that node, so it actually gets run
-  init.update_params(
-                     {'order': "\"main.tcl quality-of-life.tcl floorplan.tcl add-endcaps-welltaps.tcl "\
-                               "pin-assignments.tcl make-path-groups.tcl reporting.tcl\""}
-                    )
+
+  # Since we are adding an additional input script to the generic Innovus
+  # steps, we modify the order parameter for that node which determines
+  # which scripts get run and when they get run.
+
+  # init -- Add 'add-endcaps-welltaps.tcl' after 'floorplan.tcl'
+
+  order = init.get_param('order') # get the default script run order
+  floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
+  order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
+  init.update_params( { 'order': order } )
 
   return g
 

--- a/mflowgen/glb_top/construct.py
+++ b/mflowgen/glb_top/construct.py
@@ -215,12 +215,17 @@ def construct():
   #-----------------------------------------------------------------------
 
   g.update_params( parameters )
-  # Since we are adding an additional input to the init node, we must add
-  # that input to the order parameter for that node, so it actually gets run
-  init.update_params(
-                     {'order': "\"main.tcl quality-of-life.tcl floorplan.tcl add-endcaps-welltaps.tcl "\
-                               "pin-assignments.tcl make-path-groups.tcl dont_touch.tcl reporting.tcl\""}
-                    )
+
+  # Since we are adding an additional input script to the generic Innovus
+  # steps, we modify the order parameter for that node which determines
+  # which scripts get run and when they get run.
+
+  # init -- Add 'add-endcaps-welltaps.tcl' after 'floorplan.tcl'
+
+  order = init.get_param('order') # get the default script run order
+  floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
+  order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
+  init.update_params( { 'order': order } )
 
   return g
 

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -236,13 +236,17 @@ def construct():
   #-----------------------------------------------------------------------
 
   g.update_params( parameters )
-  
-  # Since we are adding an additional input to the init node, we must add
-  # that input to the order parameter for that node, so it actually gets run
-  init.update_params(
-                     {'order': "\"main.tcl quality-of-life.tcl floorplan.tcl add-endcaps-welltaps.tcl "\
-                               "pin-assignments.tcl make-path-groups.tcl dont-touch.tcl reporting.tcl\""}
-                    )
+
+  # Since we are adding an additional input script to the generic Innovus
+  # steps, we modify the order parameter for that node which determines
+  # which scripts get run and when they get run.
+
+  # init -- Add 'add-endcaps-welltaps.tcl' after 'floorplan.tcl'
+
+  order = init.get_param('order') # get the default script run order
+  floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
+  order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
+  init.update_params( { 'order': order } )
 
   return g
 


### PR DESCRIPTION
For each Innovus node, there is an order parameter that defines the order in which the subscripts of that node are run (e.g., floorplan, adding end caps).

Previously, the order parameter had to be defined explicitly, listing out everything in a super long string. The latest mflowgen commit turns this into a normal-looking Python list. Now you can just call "append()" on the order, etc.

This pull request makes this change to each block's construct.py to insert the "add-endcap-welltaps.tcl" after wherever "floorplan.tcl" is in the Innovus init node.