### PR TITLE
Add back dont_touch script to init order param

### DIFF
--- a/mflowgen/glb_top/construct.py
+++ b/mflowgen/glb_top/construct.py
@@ -225,6 +225,9 @@ def construct():
   order = init.get_param('order') # get the default script run order
   floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
   order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
+  reporting_idx = order.index( 'reporting.tcl' ) # find reporting.tcl
+  # Add dont_touch before reporting
+  order.insert ( reporting_idx, 'dont_touch.tcl' )
   init.update_params( { 'order': order } )
 
   return g

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -246,6 +246,9 @@ def construct():
   order = init.get_param('order') # get the default script run order
   floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
   order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
+  reporting_idx = order.index( 'reporting.tcl' ) # find reporting.tcl
+  # Add dont_touch before reporting
+  order.insert ( reporting_idx, 'dont_touch.tcl' )
   init.update_params( { 'order': order } )
 
   return g


### PR DESCRIPTION
Fix bug in #435 that left out dont_touch for init order param in hierarchical blocks.