### PR TITLE
Sram genlibdb

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -87,6 +87,7 @@ def construct():
 
   dc.extend_inputs( ['sram_tt.db'] )
   pt_signoff.extend_inputs( ['sram_tt.db'] )
+  genlibdb.extend_inputs( ['sram_tt.db'] )
 
   # These steps need timing and lef info for srams
 
@@ -171,6 +172,7 @@ def construct():
   g.connect_by_name( gen_sram,      route        )
   g.connect_by_name( gen_sram,      postroute    )
   g.connect_by_name( gen_sram,      signoff      )
+  g.connect_by_name( gen_sram,      genlibdb     )
   g.connect_by_name( gen_sram,      pt_signoff   )
   g.connect_by_name( gen_sram,      gdsmerge     )
   g.connect_by_name( gen_sram,      drc          )

--- a/mflowgen/glb_tile/construct.py
+++ b/mflowgen/glb_tile/construct.py
@@ -94,6 +94,7 @@ def construct():
 
   dc.extend_inputs( ['sram_tt.db'] )
   pt_signoff.extend_inputs( ['sram_tt.db'] )
+  genlibdb.extend_inputs( ['sram_tt.db'] )
 
   # These steps need timing and lef info for srams
 
@@ -172,6 +173,7 @@ def construct():
   g.connect_by_name( gen_sram,      route        )
   g.connect_by_name( gen_sram,      postroute    )
   g.connect_by_name( gen_sram,      signoff      )
+  g.connect_by_name( gen_sram,      genlibdb     )
   g.connect_by_name( gen_sram,      pt_signoff   )
   g.connect_by_name( gen_sram,      gdsmerge     )
   g.connect_by_name( gen_sram,      drc          )


### PR DESCRIPTION
This PR connects the sram db files from gen_sram_macro to the genlibdb nodes in both the memory tile and the glb tile. In conjunction with [this mflowgen PR](https://github.com/cornell-brg/mflowgen/pull/16), this will ensure that the SRAMs are properly linked when extracting the timing models for these blocks.