### PR TITLE
retarget tbg to Interconnect top module

### DIFF
--- a/tbg.py
+++ b/tbg.py
@@ -68,12 +68,14 @@ class TestBenchGenerator:
             self.use_ncsim = False
         # if it's ncsim, rename copy it to .sv extension
         if self.use_ncsim:
-            new_filename = os.path.splitext(stub_filename)[0] + ".sv"
-            shutil.copy2(stub_filename, new_filename)
-            stub_filename = new_filename
-        self.circuit = m.DefineFromVerilogFile(stub_filename,
-                                               target_modules=["Garnet"],
-                                               type_map=type_map)[0]
+            new_filename = os.path.splitext(top_filename)[0] + ".sv"
+            shutil.copy2(top_filename, new_filename)
+            top_filename = new_filename
+        self.circuit = m.define_from_verilog_file(
+            top_filename,
+            target_modules=["Interconnect"],
+            type_map=type_map
+        )[0]
 
         with open(config_file) as f:
             config = json.load(f)
@@ -247,10 +249,10 @@ class TestBenchGenerator:
             # coreir always outputs as verilog even though we have system-
             # verilog component
             copy_file(self.top_filename,
-                      os.path.join(tempdir, "Garnet.sv"))
+                      os.path.join(tempdir, "Interconnect.sv"))
         else:
             copy_file(self.top_filename,
-                      os.path.join(tempdir, "Garnet.v"))
+                      os.path.join(tempdir, "Interconnect.v"))
         dw_files = ["DW_fp_add.v", "DW_fp_mult.v", "DW_fp_addsub.v"]
         base_dir = os.path.abspath(os.path.dirname(__file__))
         cad_dir = "/cad/synopsys/dc_shell/J-2014.09-SP3/dw/sim_ver/"
@@ -286,12 +288,12 @@ class TestBenchGenerator:
             verilogs += list(glob.glob(os.path.join(tempdir, "*.sv")))
             verilog_libraries = [os.path.basename(f) for f in verilogs]
             # sanity check since we just copied
-            assert "Garnet.sv" in verilog_libraries
-            if "Garnet.v" in verilog_libraries:
+            assert "Interconnect.sv" in verilog_libraries
+            if "Interconnect.v" in verilog_libraries:
                 # ncsim will freak out if the system verilog file has .v
                 # extension
-                verilog_libraries.remove("Garnet.v")
-                os.remove(os.path.join(tempdir, "Garnet.v"))
+                verilog_libraries.remove("Interconnect.v")
+                os.remove(os.path.join(tempdir, "Interconnect.v"))
             tester.compile_and_run(target="system-verilog",
                                    skip_compile=True,
                                    simulator="ncsim",


### PR DESCRIPTION
`tbg.py` is really testing the `Interconnect` rather than `Garnet`, so this PR makes that a bit more explicit, primarily in order to match with the physical design flows. 

It's done in the most minimal way for now, and defines from `garnet.v` instead of `garnet_stub.v` to avoid breaking other code that calls `tbg.py` (e.g. CI scripts). 

`stub_filename` is now unused inside the testbench generation, it copies things over to `Interconnect.*` instead of `Garnet.*`, and the final testbench is `Interconnect_tb.sv` as generated by fault.