### PR TITLE
Mem/PE Tile genlibdb order param

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -248,7 +248,7 @@ def construct():
   order = genlibdb.get_param('order') # get the default script run order
   read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
   order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
-  gendlibdb.update_params( { 'order': order } )
+  genlibdb.update_params( { 'order': order } )
 
   return g
 

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -245,10 +245,10 @@ def construct():
   init.update_params( { 'order': order } )
 
   # Adding new input for genlibdb node to run
-
-  genlibdb.update_params(
-    {'order': "\"read_design.tcl genlibdb-constraints.tcl extract_model.tcl\""}
-  )
+  order = genlibdb.get_param('order') # get the default script run order
+  read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
+  order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
+  gendlibdb.update_params( { 'order': order } )
 
   return g
 

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -197,7 +197,7 @@ def construct():
   order = genlibdb.get_param('order') # get the default script run order
   read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
   order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
-  gendlibdb.update_params( { 'order': order } )
+  genlibdb.update_params( { 'order': order } )
 
   return g
 

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -194,10 +194,10 @@ def construct():
   init.update_params( { 'order': order } )
 
   # Adding new input for genlibdb node to run
-
-  genlibdb.update_params(
-    {'order': "\"read_design.tcl genlibdb-constraints.tcl extract_model.tcl\""}
-  )
+  order = genlibdb.get_param('order') # get the default script run order
+  read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
+  order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
+  gendlibdb.update_params( { 'order': order } )
 
   return g
 


### PR DESCRIPTION
This PR changes how the genlibdb order param is modified to insert our `set_case_analysis` constraints. Instead of overwriting the existing order param, we insert the script we want at a known point in the order.