### PR TITLE
Export parameters to package files which systemverilog and systemRTL use

### DIFF
--- a/global_buffer/Makefile
+++ b/global_buffer/Makefile
@@ -57,16 +57,25 @@ SIMV = ./simv \
 	   -l vcs.log
 
 
-.PHONY: rdl clean compile html
+.PHONY: rdl_param rdl_final rdl_pre clean compile html param_files
 
-rdl: systemRDL/rdl_models/glb.rdl systemRDL/ordt_params/glb.parms
-	../systemRDL/perlpp.pl systemRDL/rdl_models/glb.rdl -o systemRDL/rdl_models/glb.rdl.final
+param_files: global_buffer_main.py
+	cd .. && \
+	python -m global_buffer.global_buffer_main -p
+
+rdl_param: param_files systemRDL/rdl_models/glb.rdl systemRDL/rdl_models/glb.rdl.param
+	cat systemRDL/rdl_models/glb.rdl.param systemRDL/rdl_models/glb.rdl > systemRDL/rdl_models/glb.rdl.pre
+
+rdl_pre: rdl_param
+	../systemRDL/perlpp.pl systemRDL/rdl_models/glb.rdl.pre -o systemRDL/rdl_models/glb.rdl.final
+
+rdl_final: rdl_pre
 	java -jar ../systemRDL/Ordt.jar -parms systemRDL/ordt_params/glb.parms -systemverilog systemRDL/output/ systemRDL/rdl_models/glb.rdl.final
 
-html: rdl
+html: rdl_final
 	python ../systemRDL/gen_html.py systemRDL/rdl_models/glb.rdl.final
 
-compile: rdl
+compile: rdl_final
 	$(NCSIM) 
 
 run: compile

--- a/global_buffer/global_buffer_magma.py
+++ b/global_buffer/global_buffer_magma.py
@@ -46,7 +46,7 @@ class GlobalBuffer(Generator):
         self.max_num_words_width = (self.glb_addr_width - self.bank_byte_offset
                                     + magma.bitutils.clog2(bank_data_width
                                                            // cgra_data_width))
-        self.max_stride_width = self.axi_data_width = self.max_num_words_width
+        self.max_stride_width = self.axi_data_width - self.max_num_words_width
         self.max_num_cfgs_width = self.glb_addr_width - self.bank_byte_offset
         self.queue_depth = 4
         self.loop_level = 4

--- a/global_buffer/global_buffer_magma.py
+++ b/global_buffer/global_buffer_magma.py
@@ -3,14 +3,15 @@ from gemstone.generator.from_magma import FromMagma
 from gemstone.common.configurable import ConfigurationType
 from gemstone.generator.generator import Generator
 from cgra.ifc_struct import ProcPacketIfc, GlbCfgIfc
-from global_buffer.global_buffer_magma_helper import *
+from .global_buffer_magma_helper import *
 
 
 class GlobalBuffer(Generator):
     def __init__(self, num_glb_tiles, num_cgra_cols, banks_per_tile=2,
                  bank_addr_width=17, bank_data_width=64, cgra_data_width=16,
                  axi_addr_width=12, axi_data_width=32,
-                 cfg_addr_width=32, cfg_data_width=32):
+                 cfg_addr_width=32, cfg_data_width=32,
+                 parameter_only: bool = False):
 
         super().__init__()
 
@@ -73,24 +74,29 @@ class GlobalBuffer(Generator):
         )
 
         # parameter
-        params = GlobalBufferParams(NUM_GLB_TILES=self.num_glb_tiles,
-                                    TILE_SEL_ADDR_WIDTH=(
-                                        self.tile_sel_addr_width),
-                                    NUM_CGRA_TILES=self.num_cgra_cols,
-                                    CGRA_PER_GLB=self.cgra_per_glb,
-                                    BANKS_PER_TILE=self.banks_per_tile,
-                                    BANK_SEL_ADDR_WIDTH=(
-                                        self.bank_sel_addr_width),
-                                    BANK_DATA_WIDTH=self.bank_data_width,
-                                    BANK_ADDR_WIDTH=self.bank_addr_width,
-                                    GLB_ADDR_WIDTH=self.glb_addr_width,
-                                    CGRA_DATA_WIDTH=self.cgra_data_width,
-                                    AXI_ADDR_WIDTH=self.axi_addr_width,
-                                    AXI_DATA_WIDTH=self.axi_data_width,
-                                    CGRA_CFG_ADDR_WIDTH=self.cfg_addr_width,
-                                    CGRA_CFG_DATA_WIDTH=self.cfg_data_width)
+        self.param = GlobalBufferParams(NUM_GLB_TILES=self.num_glb_tiles,
+                                        TILE_SEL_ADDR_WIDTH=(
+                                            self.tile_sel_addr_width),
+                                        NUM_CGRA_TILES=self.num_cgra_cols,
+                                        CGRA_PER_GLB=self.cgra_per_glb,
+                                        BANKS_PER_TILE=self.banks_per_tile,
+                                        BANK_SEL_ADDR_WIDTH=(
+                                            self.bank_sel_addr_width),
+                                        BANK_DATA_WIDTH=self.bank_data_width,
+                                        BANK_ADDR_WIDTH=self.bank_addr_width,
+                                        GLB_ADDR_WIDTH=self.glb_addr_width,
+                                        CGRA_DATA_WIDTH=self.cgra_data_width,
+                                        AXI_ADDR_WIDTH=self.axi_addr_width,
+                                        AXI_DATA_WIDTH=self.axi_data_width,
+                                        CGRA_CFG_ADDR_WIDTH=self.cfg_addr_width,
+                                        CGRA_CFG_DATA_WIDTH=self.cfg_data_width)
 
-        self.underlying = FromMagma(GlobalBufferDeclarationGenerator(params))
+        if parameter_only:
+            gen_param_files(self.param)
+            return
+
+        self.underlying = FromMagma(GlobalBufferDeclarationGenerator(
+            self.param))
 
         # wiring
         self.wire(self.ports.clk, self.underlying.ports.clk)

--- a/global_buffer/global_buffer_magma_helper.py
+++ b/global_buffer/global_buffer_magma_helper.py
@@ -138,7 +138,9 @@ def _flatten(types):
     return {k: _map(t) for k, t in types.items()}
 
 
-def gen_param_files(params: GlobalBufferParams):
+def gen_param_files(params: GlobalBufferParams = None):
+    if params is None:
+        params = GlobalBufferParams()
     mod_params = dataclasses.asdict(params)
     # parameter pass to systemverilog package
     f = open("global_buffer/rtl/global_buffer_param.svh", "w")
@@ -159,7 +161,9 @@ def gen_param_files(params: GlobalBufferParams):
 
 
 class GlobalBufferDeclarationGenerator(m.Generator2):
-    def __init__(self, params: GlobalBufferParams):
+    def __init__(self, params: GlobalBufferParams = None):
+        if params is None:
+            params = GlobalBufferParams()
         self.params = params
         self.name = "global_buffer"
         gen_param_files(self.params)

--- a/global_buffer/global_buffer_main.py
+++ b/global_buffer/global_buffer_main.py
@@ -5,8 +5,8 @@ from .global_buffer_magma import GlobalBuffer
 
 def main():
     parser = argparse.ArgumentParser(description='Garnet Global Buffer')
-    parser.add_argument('--num_glb_tiles', type=int, default=2)
-    parser.add_argument('--num_cgra_cols', type=int, default=4)
+    parser.add_argument('--num_glb_tiles', type=int, default=16)
+    parser.add_argument('--num_cgra_cols', type=int, default=32)
     parser.add_argument("-v", "--verilog", action="store_true")
     parser.add_argument("-p", "---parameter_only", action="store_true")
     args = parser.parse_args()

--- a/global_buffer/global_buffer_main.py
+++ b/global_buffer/global_buffer_main.py
@@ -1,0 +1,26 @@
+import magma
+import argparse
+from .global_buffer_magma import GlobalBuffer
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Garnet Global Buffer')
+    parser.add_argument('--num_glb_tiles', type=int, default=2)
+    parser.add_argument('--num_cgra_cols', type=int, default=4)
+    parser.add_argument("-v", "--verilog", action="store_true")
+    parser.add_argument("-p", "---parameter_only", action="store_true")
+    args = parser.parse_args()
+
+    if args.parameter_only:
+        assert not args.verilog
+
+    global_buffer = GlobalBuffer(num_glb_tiles=args.num_glb_tiles,
+                                 num_cgra_cols=args.num_cgra_cols,
+                                 parameter_only=args.parameter_only)
+
+    if args.verilog:
+        global_buffer_circ = global_buffer.circuit()
+        magma.compile("global_buffer", global_buffer_circ, output="coreir-verilog")
+
+if __name__ == "__main__":
+    main()

--- a/global_buffer/rtl/glb_bank.sv
+++ b/global_buffer/rtl/glb_bank.sv
@@ -6,6 +6,7 @@
 ** Change history:  02/25/2020 - Implement first version of glb core bank
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_bank (
     input  logic                        clk,

--- a/global_buffer/rtl/glb_bank_ctrl.sv
+++ b/global_buffer/rtl/glb_bank_ctrl.sv
@@ -7,6 +7,7 @@
 ** Change history:  10/08/2019 - Implement first version of bank controller
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_bank_ctrl  (
     input  logic                        clk,

--- a/global_buffer/rtl/glb_bank_memory.sv
+++ b/global_buffer/rtl/glb_bank_memory.sv
@@ -6,6 +6,7 @@
 ** Change history:  10/08/2019 - Implement first version of memory core
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_bank_memory (
     input  logic                        clk,

--- a/global_buffer/rtl/glb_core.sv
+++ b/global_buffer/rtl/glb_core.sv
@@ -6,6 +6,7 @@
 ** Change history: 01/27/2020 - Implement first version of global buffer core
 **===========================================================================*/
 import  global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core (
     input  logic                            clk,
@@ -51,8 +52,8 @@ module glb_core (
     input  logic [1:0]                      cfg_ld_dma_mode,
     input  logic [1:0]                      cfg_st_dma_mode,
     input  logic                            cfg_pc_dma_mode,
-    input  logic [3:0]                      cfg_latency,
-    input  logic [3:0]                      cfg_pc_latency,
+    input  logic [LATENCY_WIDTH-1:0]        cfg_latency,
+    input  logic [LATENCY_WIDTH-1:0]        cfg_pc_latency,
     input  dma_st_header_t                  cfg_st_dma_header [QUEUE_DEPTH],
     input  dma_ld_header_t                  cfg_ld_dma_header [QUEUE_DEPTH],
     input  dma_pc_header_t                  cfg_pc_dma_header,

--- a/global_buffer/rtl/glb_core_load_dma.sv
+++ b/global_buffer/rtl/glb_core_load_dma.sv
@@ -8,6 +8,7 @@
 **          - Implement first version of global buffer core load DMA
 **===========================================================================*/
 import  global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core_load_dma (
     input  logic                            clk,
@@ -26,7 +27,7 @@ module glb_core_load_dma (
 
     // Configuration registers
     input  logic [1:0]                      cfg_ld_dma_mode,
-    input  logic [TILE_SEL_ADDR_WIDTH-1:0]  cfg_latency,
+    input  logic [LATENCY_WIDTH-1:0]        cfg_latency,
     input  dma_ld_header_t                  cfg_ld_dma_header [QUEUE_DEPTH],
 
     // glb internal signal
@@ -68,8 +69,8 @@ rdrq_packet_t strm_rdrq_internal;
 logic last_strm;
 logic [GLB_ADDR_WIDTH-1:0] start_addr_internal;
 loop_ctrl_t iter_internal;
-logic [MAX_RANGE_WIDTH-1:0] itr [LOOP_LEVEL];
-logic [MAX_RANGE_WIDTH-1:0] itr_next [LOOP_LEVEL];
+logic [MAX_NUM_WORDS_WIDTH-1:0] itr [LOOP_LEVEL];
+logic [MAX_NUM_WORDS_WIDTH-1:0] itr_next [LOOP_LEVEL];
 logic done_pulse_internal;
 logic bank_addr_eq;
 rdrq_packet_t bank_rdrq_internal;

--- a/global_buffer/rtl/glb_core_pc_dma.sv
+++ b/global_buffer/rtl/glb_core_pc_dma.sv
@@ -8,6 +8,7 @@
 **          - Implement first version of global buffer core parallel config DMA
 **===========================================================================*/
 import  global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core_pc_dma (
     input  logic                            clk,
@@ -26,7 +27,7 @@ module glb_core_pc_dma (
     // Configuration registers
     input  logic                            cfg_pc_dma_mode,
     input  dma_pc_header_t                  cfg_pc_dma_header,
-    input  logic [3:0]                      cfg_pc_latency,     
+    input  logic [LATENCY_WIDTH-1:0]        cfg_pc_latency,     
 
     // interrupt pulse
     input  logic                            pc_start_pulse,

--- a/global_buffer/rtl/glb_core_pc_router.sv
+++ b/global_buffer/rtl/glb_core_pc_router.sv
@@ -9,6 +9,7 @@
 **            tile router
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core_pc_router (
     input  logic                            clk,

--- a/global_buffer/rtl/glb_core_proc_router.sv
+++ b/global_buffer/rtl/glb_core_proc_router.sv
@@ -10,6 +10,7 @@
 **          - Add read packet router
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core_proc_router (
     input  logic                            clk,

--- a/global_buffer/rtl/glb_core_sram_cfg_ctrl.sv
+++ b/global_buffer/rtl/glb_core_sram_cfg_ctrl.sv
@@ -8,6 +8,7 @@
 **          - Implement first version of memory core
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core_sram_cfg_ctrl (
     input  logic                            clk,

--- a/global_buffer/rtl/glb_core_store_dma.sv
+++ b/global_buffer/rtl/glb_core_store_dma.sv
@@ -8,6 +8,7 @@
 **          - Implement first version of global buffer core store DMA
 **===========================================================================*/
 import  global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core_store_dma (
     input  logic                            clk,
@@ -24,7 +25,7 @@ module glb_core_store_dma (
     // Configuration registers
     input  logic [1:0]                      cfg_st_dma_mode,
     input  dma_st_header_t                  cfg_st_dma_header [QUEUE_DEPTH],
-    input  logic [TILE_SEL_ADDR_WIDTH-1:0]  cfg_latency,
+    input  logic [LATENCY_WIDTH-1:0]        cfg_latency,
 
     // glb internal signal
     output logic                            cfg_store_dma_invalidate_pulse [QUEUE_DEPTH],

--- a/global_buffer/rtl/glb_core_strm_mux.sv
+++ b/global_buffer/rtl/glb_core_strm_mux.sv
@@ -8,6 +8,7 @@
 **          - Implement first version of global buffer core stream data mux
 **===========================================================================*/
 import  global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core_strm_mux (
     input  logic [CGRA_DATA_WIDTH-1:0] stream_data_g2f_dma,

--- a/global_buffer/rtl/glb_core_strm_router.sv
+++ b/global_buffer/rtl/glb_core_strm_router.sv
@@ -12,6 +12,7 @@
 **          - Packetize everything into struct
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core_strm_router (
     input  logic                            clk,

--- a/global_buffer/rtl/glb_core_switch.sv
+++ b/global_buffer/rtl/glb_core_switch.sv
@@ -7,6 +7,7 @@
 **      - Implement first version of global buffer core channel switch
 **===========================================================================*/
 import  global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_core_switch (
     input  logic                            clk,

--- a/global_buffer/rtl/glb_dummy_end.sv
+++ b/global_buffer/rtl/glb_dummy_end.sv
@@ -6,6 +6,7 @@
 ** Change history: 02/02/2020 - Implement first version of global buffer tile
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_dummy_end (
     input  logic            clk,

--- a/global_buffer/rtl/glb_dummy_start.sv
+++ b/global_buffer/rtl/glb_dummy_start.sv
@@ -6,6 +6,7 @@
 ** Change history: 02/02/2020 - Implement first version of global buffer tile
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_dummy_start (
     // proc

--- a/global_buffer/rtl/glb_tile.sv
+++ b/global_buffer/rtl/glb_tile.sv
@@ -6,6 +6,7 @@
 ** Change history: 01/08/2020 - Implement first version of global buffer tile
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_tile (
     input  logic                                                clk,

--- a/global_buffer/rtl/glb_tile_cfg.sv
+++ b/global_buffer/rtl/glb_tile_cfg.sv
@@ -6,6 +6,7 @@
 ** Change history: 02/06/2020 - Implement first version
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_tile_cfg (
     input  logic                            clk,
@@ -28,8 +29,8 @@ module glb_tile_cfg (
     output logic [1:0]                      cfg_ld_dma_mode,
     output logic [1:0]                      cfg_st_dma_mode,
     output logic                            cfg_pc_dma_mode,
-    output logic [3:0]                      cfg_latency,
-    output logic [3:0]                      cfg_pc_latency,
+    output logic [LATENCY_WIDTH-1:0]        cfg_latency,
+    output logic [LATENCY_WIDTH-1:0]        cfg_pc_latency,
     output dma_st_header_t                  cfg_st_dma_header [QUEUE_DEPTH],
     output dma_ld_header_t                  cfg_ld_dma_header [QUEUE_DEPTH],
     output dma_pc_header_t                  cfg_pc_dma_header

--- a/global_buffer/rtl/glb_tile_cfg_ctrl.sv
+++ b/global_buffer/rtl/glb_tile_cfg_ctrl.sv
@@ -7,6 +7,7 @@
 **  - Implement first version of control logic
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_tile_cfg_ctrl #(
     parameter REG_ADDR_WIDTH = 6

--- a/global_buffer/rtl/glb_tile_int.sv
+++ b/global_buffer/rtl/glb_tile_int.sv
@@ -6,6 +6,7 @@
 ** Change history: 01/08/2020 - Implement first version of global buffer tile
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_tile_int (
     input  logic                            clk,
@@ -86,17 +87,17 @@ cgra_cfg_t      cgra_cfg_c2sw;
 //============================================================================//
 // Configuration registers
 //============================================================================//
-logic           cfg_tile_connected_prev;
-logic           cfg_tile_connected_next;
-logic           cfg_pc_tile_connected_prev;
-logic           cfg_pc_tile_connected_next;
-logic [1:0]     cfg_strm_g2f_mux;
-logic [1:0]     cfg_strm_f2g_mux;
-logic [1:0]     cfg_ld_dma_mode;
-logic [1:0]     cfg_st_dma_mode;
-logic           cfg_pc_dma_mode;
-logic [3:0]     cfg_latency;
-logic [3:0]     cfg_pc_latency;
+logic                       cfg_tile_connected_prev;
+logic                       cfg_tile_connected_next;
+logic                       cfg_pc_tile_connected_prev;
+logic                       cfg_pc_tile_connected_next;
+logic [1:0]                 cfg_strm_g2f_mux;
+logic [1:0]                 cfg_strm_f2g_mux;
+logic [1:0]                 cfg_ld_dma_mode;
+logic [1:0]                 cfg_st_dma_mode;
+logic                       cfg_pc_dma_mode;
+logic [LATENCY_WIDTH-1:0]   cfg_latency;
+logic [LATENCY_WIDTH-1:0]   cfg_pc_latency;
 dma_st_header_t cfg_st_dma_header [QUEUE_DEPTH];
 dma_ld_header_t cfg_ld_dma_header [QUEUE_DEPTH];
 dma_pc_header_t cfg_pc_dma_header;

--- a/global_buffer/rtl/glb_tile_pc_switch.sv
+++ b/global_buffer/rtl/glb_tile_pc_switch.sv
@@ -6,6 +6,7 @@
 ** Change history: 03/02/2020 - Implement first version of global buffer tile
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module glb_tile_pc_switch (
     input  logic                            clk,

--- a/global_buffer/rtl/global_buffer.filelist
+++ b/global_buffer/rtl/global_buffer.filelist
@@ -1,5 +1,6 @@
 ../rtl/axil_ifc.sv
 ../rtl/cfg_ifc.sv
+../rtl/global_buffer_param.svh
 ../rtl/global_buffer_pkg.svh
 ../rtl/global_buffer.sv
 ../rtl/glb_tile.sv

--- a/global_buffer/rtl/global_buffer.sv
+++ b/global_buffer/rtl/global_buffer.sv
@@ -6,6 +6,7 @@
 ** Change history: 02/01/2020 - Implement first version of global buffer
 **===========================================================================*/
 import global_buffer_pkg::*;
+import global_buffer_param::*;
 
 module global_buffer (
 

--- a/global_buffer/rtl/global_buffer_pkg.svh
+++ b/global_buffer/rtl/global_buffer_pkg.svh
@@ -1,50 +1,6 @@
 package global_buffer_pkg;
 
-//============================================================================//
-// Parameter definition
-//============================================================================//
-// Tile parameters
-localparam int NUM_GLB_TILES = 16;
-localparam int TILE_SEL_ADDR_WIDTH = $clog2(NUM_GLB_TILES); // 4
-
-// CGRA Tiles
-localparam int NUM_CGRA_TILES = 32;
-
-// CGRA tiles per GLB tile
-localparam int CGRA_PER_GLB = NUM_CGRA_TILES / NUM_GLB_TILES; // 2
-
-// Bank parameters
-localparam int BANKS_PER_TILE = 2;
-localparam int BANK_SEL_ADDR_WIDTH = $clog2(BANKS_PER_TILE); // 1
-localparam int BANK_DATA_WIDTH = 64;
-localparam int BANK_ADDR_WIDTH = 17;
-localparam int BANK_BYTE_OFFSET = $clog2(BANK_DATA_WIDTH/8); // 3
-
-// Glb parameters
-localparam int GLB_ADDR_WIDTH = BANK_ADDR_WIDTH + BANK_SEL_ADDR_WIDTH + TILE_SEL_ADDR_WIDTH; // 22
-
-// CGRA data parameters
-localparam int CGRA_DATA_WIDTH = 16;
-localparam int CGRA_BYTE_OFFSET = $clog2(CGRA_DATA_WIDTH/8); // 1
-
-// MAX_NUM_WORDS
-localparam int MAX_NUM_WORDS_WIDTH = GLB_ADDR_WIDTH - BANK_BYTE_OFFSET + $clog2(BANK_DATA_WIDTH/CGRA_DATA_WIDTH); // 21
-// MAX_NUM_CFG
-localparam int MAX_NUM_CFGS_WIDTH = GLB_ADDR_WIDTH - BANK_BYTE_OFFSET; // 19
-
-// Glb config parameters
-localparam int AXI_ADDR_WIDTH = 12;
-localparam int AXI_DATA_WIDTH = 32;
-localparam int AXI_STRB_WIDTH = (AXI_DATA_WIDTH / 8);
-localparam int AXI_BYTE_OFFSET = $clog2(AXI_DATA_WIDTH/8);
-localparam int CFG_REG_SEL_WIDTH = AXI_ADDR_WIDTH - TILE_SEL_ADDR_WIDTH - AXI_BYTE_OFFSET;
-
-// CGRA config parameters
-localparam int CGRA_CFG_ADDR_WIDTH = 32;
-localparam int CGRA_CFG_DATA_WIDTH = 32;
-
-// DMA header queue depth
-localparam int QUEUE_DEPTH = 4;
+import global_buffer_param::*;
 
 //============================================================================//
 // Packet struct definition
@@ -98,10 +54,6 @@ typedef struct packed
 //============================================================================//
 // DMA register struct definition
 //============================================================================//
-localparam int MAX_RANGE_WIDTH = MAX_NUM_WORDS_WIDTH; // 21
-localparam int MAX_STRIDE_WIDTH = AXI_DATA_WIDTH - MAX_RANGE_WIDTH; // 11
-localparam int LOOP_LEVEL = 4;
-
 localparam [1:0] OFF        = 2'b00;
 localparam [1:0] NORMAL     = 2'b01;
 localparam [1:0] REPEAT     = 2'b10;
@@ -110,7 +62,7 @@ localparam [1:0] AUTO_INCR  = 2'b11;
 
 typedef struct packed
 {
-    logic [MAX_RANGE_WIDTH-1:0]     range;
+    logic [MAX_NUM_WORDS_WIDTH-1:0]     range;
     logic [MAX_STRIDE_WIDTH-1:0]    stride;
 } loop_ctrl_t;
 
@@ -140,14 +92,5 @@ typedef struct packed
     logic [GLB_ADDR_WIDTH-1:0]      start_addr;
     logic [MAX_NUM_CFGS_WIDTH-1:0]  num_cfgs;
 } dma_pc_header_t;
-
-//============================================================================//
-// Address map
-//============================================================================//
-localparam int AXI_ADDR_IER_1       = 'h00;
-localparam int AXI_ADDR_IER_2       = 'h04;
-localparam int AXI_ADDR_ISR_1       = 'h08;
-localparam int AXI_ADDR_ISR_2       = 'h0c;
-localparam int AXI_ADDR_STRM_START  = 'h10;
 
 endpackage

--- a/global_buffer/systemRDL/rdl_models/glb.rdl
+++ b/global_buffer/systemRDL/rdl_models/glb.rdl
@@ -1,17 +1,4 @@
 // ========================================================================
-// Perl Embedding
-// ========================================================================
-<% 
-use constant NUM_GLB_TILES => 16;
-use constant GLB_ADDR_WIDTH => 22;
-use constant MAX_RANGE_WIDTH => 21;
-use constant MAX_CFG_WIDTH => 19;
-use constant NUM_QUEUE => 4;
-use constant LOOP_LEVEL => 4;
-use constant LATENCY_WIDTH => 4;
-%>
-
-// ========================================================================
 // Address map
 // ========================================================================
 addrmap glb {
@@ -82,14 +69,14 @@ addrmap glb {
     reg num_words_r {
         name = "Num Words";
         desc = "Number of words of DMA header";
-        field {} num_words[<%=MAX_RANGE_WIDTH%>] = 0;
+        field {} num_words[<%=MAX_NUM_WORDS_WIDTH%>] = 0;
     };
 
     reg iter_ctrl_r {
         name = "Iteration Control";
         desc = "Iteration control registers";
-        field {} range[<%=MAX_RANGE_WIDTH%>] = 0;
-        field {} stride[<%=(32-MAX_RANGE_WIDTH)%>] = 0;
+        field {} range[<%=MAX_NUM_WORDS_WIDTH%>] = 0;
+        field {} stride[<%=MAX_STRIDE_WIDTH%>] = 0;
     };
 
     reg active_ctrl_r {
@@ -121,7 +108,7 @@ addrmap glb {
     reg num_cfg_r {
         name = "Num Cfgs";
         desc = "Number of configuration bitstream";
-        field {} num_cfgs[<%=MAX_CFG_WIDTH%>] = 0;
+        field {} num_cfgs[<%=MAX_NUM_CFGS_WIDTH%>] = 0;
     };
 
     regfile pc_dma_header_rf {
@@ -133,10 +120,10 @@ addrmap glb {
 
     tile_ctrl_r tile_ctrl;
     latency_r latency;
-    <% for ($i = 0; $i < NUM_QUEUE; $i += 1) { %>
+    <% for ($i = 0; $i < QUEUE_DEPTH; $i += 1) { %>
     st_dma_header_rf st_dma_header_<%=$i%>;
     <% } %>
-    <% for ($i = 0; $i < NUM_QUEUE; $i += 1) { %>
+    <% for ($i = 0; $i < QUEUE_DEPTH; $i += 1) { %>
     ld_dma_header_rf ld_dma_header_<%=$i%>;
     <% } %>
     pc_dma_header_rf pc_dma_header;


### PR DESCRIPTION
Instead of instantiating `global_buffer` module with parameters concatenated, I dumped package file with all parameters defined in that file.
I think it is preferred for two reasons.
1. systemverilog `struct` types are defined in a package file, and they also use parameters. However, there is no way to pass parameters to package file.
2. This method doesn't require adding parameters to all rtl modules and passing them when instantiating submodules.  
3. `systemRDL` (an addressmap generation file that I am working with Gedeon) currently does not support parameter passing. With this way, I can also export a file with parameters defined, which can be later appended into `systemRDL` file.

If @rsetaluri think this is fine, I prefer to use this way of passing parameters.
