### PR TITLE
Nofail pipeline for buildkite

### DIFF
--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -15,7 +15,7 @@ steps:
 - wait ###########################################################
 
 - label: 'icovl'
-  command: 'mflowgen/test/test_module.sh icovl \
+  command: mflowgen/test/test_module.sh icovl \
         || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE
   agents: { jobsize: "hours" }
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -9,28 +9,28 @@ steps:
 
 - label: 'Tile_PE'
   command: mflowgen/test/test_module.sh --verbose Tile_PE \
-           || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE
+        || echo FAILED in step $$BUILDKITE_LABEL >> $$ERRFILE
   agents: { jobsize: "hours" }
 
 - wait ###########################################################
 
 - label: 'icovl'
   command: mflowgen/test/test_module.sh icovl \
-        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE
+        || echo FAILED in step $$BUILDKITE_LABEL >> $$ERRFILE
   agents: { jobsize: "hours" }
 
 - wait ###########################################################
 
 - label: 'pad_frame'
   command: mflowgen/test/test_module.sh pad_frame \
-        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE
+        || echo FAILED in step $$BUILDKITE_LABEL >> $$ERRFILE
   agents: { jobsize: "hours" }
 
 - wait ###########################################################
 
 - label: 'Tile_MemCore'
   command: mflowgen/test/test_module.sh Tile_MemCore \
-        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE
+        || echo FAILED in step $$BUILDKITE_LABEL >> $$ERRFILE
   agents: { jobsize: "hours" }
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -9,31 +9,35 @@ steps:
 
 - label: 'Tile_PE'
   command: mflowgen/test/test_module.sh --verbose Tile_PE \
-      || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
+           || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
   agents: { jobsize: "hours" }
 
 - wait ###########################################################
 
-- label: 'CHECK'
-  command: grep FAIL $ERRFILE && exit 13
-
-- wait ###########################################################
-
 - label: 'icovl'
-  command: mflowgen/test/test_module.sh icovl
+  command: mflowgen/test/test_module.sh icovl \
+        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
   agents: { jobsize: "hours" }
 
 - wait ###########################################################
 
 - label: 'pad_frame'
-  command: mflowgen/test/test_module.sh pad_frame
+  command: mflowgen/test/test_module.sh pad_frame \
+        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
   agents: { jobsize: "hours" }
 
 - wait ###########################################################
 
 - label: 'Tile_MemCore'
-  command: mflowgen/test/test_module.sh Tile_MemCore
+  command: mflowgen/test/test_module.sh Tile_MemCore \
+        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
   agents: { jobsize: "hours" }
+
+
+- wait ###########################################################
+
+- label: 'CHECK'
+  command: grep FAIL $ERRFILE && exit 13
 
 # Not needed (yet)
 # - wait ###########################################################

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,25 +1,21 @@
+env:
+    ERRFILE: /tmp/bklog.$BUILDKITE_BUILD_NUMBER
+
 # [sr 2002] Added waits between each step.
 # Each one seems to try and max out resources.
 # Why make them run in parallel??
-#
-steps:
 
-# - label: 'pip'
-#   # command: /usr/local/bin/pip3 install --user -r requirements.txt --upgrade
-#   commands:
-#   - /usr/local/bin/python3 --version
-#   - /usr/local/bin/python3 -m virtualenv env; source env/bin/activate
-#   - which python; which python3; which pip3
-#   - pip3 install virtualenv
-#   - python3 -m virtualenv env; source env/bin/activate
-#   - pip3 install -r requirements.txt
-#
-#
-# - wait ###########################################################
+steps:
 
 - label: 'Tile_PE'
   command: mflowgen/test/test_module.sh --verbose Tile_PE
+      || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
   agents: { jobsize: "hours" }
+
+- wait ###########################################################
+
+- label: 'CHECK'
+  command: grep FAIL $ERRFILE && exit 13
 
 - wait ###########################################################
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -8,7 +8,7 @@ env:
 steps:
 
 - label: 'Tile_PE'
-  command: mflowgen/test/test_module.sh --verbose Tile_PE
+  command: mflowgen/test/test_module.sh --verbose Tile_PE \
       || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
   agents: { jobsize: "hours" }
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -9,28 +9,28 @@ steps:
 
 - label: 'Tile_PE'
   command: mflowgen/test/test_module.sh --verbose Tile_PE \
-           || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
+           || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE
   agents: { jobsize: "hours" }
 
 - wait ###########################################################
 
 - label: 'icovl'
-  command: mflowgen/test/test_module.sh icovl \
-        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
+  command: 'mflowgen/test/test_module.sh icovl \
+        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE
   agents: { jobsize: "hours" }
 
 - wait ###########################################################
 
 - label: 'pad_frame'
   command: mflowgen/test/test_module.sh pad_frame \
-        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
+        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE
   agents: { jobsize: "hours" }
 
 - wait ###########################################################
 
 - label: 'Tile_MemCore'
   command: mflowgen/test/test_module.sh Tile_MemCore \
-        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE'
+        || echo $$BUILDKITE_LABEL FAILED >> $$ERRFILE
   agents: { jobsize: "hours" }
 
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+echo FAIL FAIL FAIL
+exit 13
+
+
+
+
 # Exit on error in any stage of any pipeline
 set -eo pipefail
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-echo FAIL FAIL FAIL
-exit 13
-
-
-
-
 # Exit on error in any stage of any pipeline
 set -eo pipefail
 


### PR DESCRIPTION
Okay, sorry this took so long. As requested we now have a way of continuing through a complete buildkite pipeline, whether or not an individual step fails, and then reporting all the errors with a final PASS/FAIL at the end.

You can see it in action here, where I artificially failed the steps:
https://buildkite.com/tapeout-aha/mflowgen/builds/994

The changes are small and I think will be easy to understand, let me know if you have questions.
