### PR TITLE
Move parallel config meso wiring from canal to garnet

### DIFF
--- a/cgra/util.py
+++ b/cgra/util.py
@@ -150,7 +150,7 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
     elif global_signal_wiring == GlobalSignalWiring.Fanout:
         apply_global_fanout_wiring(interconnect, io_sides=io_sides)
     elif global_signal_wiring == GlobalSignalWiring.ParallelMeso:
-        apply_global_parallel_meso_wiring(interconnect, io_sides=io_sides)
+        apply_global_meso_wiring(interconnect, io_sides=io_sides)
     if add_pd:
         add_aon_read_config_data(interconnect)
 

--- a/garnet.py
+++ b/garnet.py
@@ -33,6 +33,8 @@ class Garnet(Generator):
         # configuration parameters
         config_addr_width = 32
         config_data_width = 32
+        self.config_addr_width = config_addr_width
+        self.config_data_width = config_data_width
         axi_addr_width = 13
         glb_axi_addr_width = 12
         axi_data_width = 32

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git@par_meso#egg=canal
+-e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper


### PR DESCRIPTION
As requested, I moved `parallel_meso_wiring` from `canal` to `garnet`.
After it is merged, `par_meso` branch in `canal` can be deleted.