### PR TITLE
Icovl2

### DIFF
--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,62 +1,50 @@
 steps:
 
+###########################################################
+
+- label: 'Tile_PE'
+  command: mflowgen/test/test_module.sh --verbose Tile_PE
+  agents: { jobsize: "hours" }
+
+- wait: ~
+  continue_on_failure: true
+
+###########################################################
+
 - label: 'icovl'
   command: mflowgen/test/test_module.sh icovl
   agents: { jobsize: "hours" }
 
+- wait: ~
+  continue_on_failure: true
 
-# 
-# 
-# 
-# 
-# 
-# 
-# 
-# ###########################################################
-# 
-# - label: 'Tile_PE'
-#   command: mflowgen/test/test_module.sh --verbose Tile_PE
-#   agents: { jobsize: "hours" }
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# ###########################################################
-# 
-# - label: 'icovl'
-#   command: mflowgen/test/test_module.sh icovl
-#   agents: { jobsize: "hours" }
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# ###########################################################
-# 
-# - label: 'pad_frame'
-#   command: mflowgen/test/test_module.sh pad_frame
-#   agents: { jobsize: "hours" }
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# ###########################################################
-# 
-# - label: 'Tile_MemCore'
-#   command: mflowgen/test/test_module.sh Tile_MemCore
-#   agents: { jobsize: "hours" }
-# 
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# ###########################################################
-# 
-# - label: 'glb_tile'
-#   command: mflowgen/test/test_module.sh glb_tile
-#   agents: { jobsize: "hours" }
-# 
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# ###########################################################
+###########################################################
+
+- label: 'pad_frame'
+  command: mflowgen/test/test_module.sh pad_frame
+  agents: { jobsize: "hours" }
+
+- wait: ~
+  continue_on_failure: true
+
+###########################################################
+
+- label: 'Tile_MemCore'
+  command: mflowgen/test/test_module.sh Tile_MemCore
+  agents: { jobsize: "hours" }
+
+
+- wait: ~
+  continue_on_failure: true
+
+###########################################################
+
+- label: 'glb_tile'
+  command: mflowgen/test/test_module.sh glb_tile
+  agents: { jobsize: "hours" }
+
+
+- wait: ~
+  continue_on_failure: true
+
+###########################################################

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,50 +1,62 @@
 steps:
 
-###########################################################
-
-- label: 'Tile_PE'
-  command: mflowgen/test/test_module.sh --verbose Tile_PE
-  agents: { jobsize: "hours" }
-
-- wait: ~
-  continue_on_failure: true
-
-###########################################################
-
 - label: 'icovl'
   command: mflowgen/test/test_module.sh icovl
   agents: { jobsize: "hours" }
 
-- wait: ~
-  continue_on_failure: true
 
-###########################################################
-
-- label: 'pad_frame'
-  command: mflowgen/test/test_module.sh pad_frame
-  agents: { jobsize: "hours" }
-
-- wait: ~
-  continue_on_failure: true
-
-###########################################################
-
-- label: 'Tile_MemCore'
-  command: mflowgen/test/test_module.sh Tile_MemCore
-  agents: { jobsize: "hours" }
-
-
-- wait: ~
-  continue_on_failure: true
-
-###########################################################
-
-- label: 'glb_tile'
-  command: mflowgen/test/test_module.sh glb_tile
-  agents: { jobsize: "hours" }
-
-
-- wait: ~
-  continue_on_failure: true
-
-###########################################################
+# 
+# 
+# 
+# 
+# 
+# 
+# 
+# ###########################################################
+# 
+# - label: 'Tile_PE'
+#   command: mflowgen/test/test_module.sh --verbose Tile_PE
+#   agents: { jobsize: "hours" }
+# 
+# - wait: ~
+#   continue_on_failure: true
+# 
+# ###########################################################
+# 
+# - label: 'icovl'
+#   command: mflowgen/test/test_module.sh icovl
+#   agents: { jobsize: "hours" }
+# 
+# - wait: ~
+#   continue_on_failure: true
+# 
+# ###########################################################
+# 
+# - label: 'pad_frame'
+#   command: mflowgen/test/test_module.sh pad_frame
+#   agents: { jobsize: "hours" }
+# 
+# - wait: ~
+#   continue_on_failure: true
+# 
+# ###########################################################
+# 
+# - label: 'Tile_MemCore'
+#   command: mflowgen/test/test_module.sh Tile_MemCore
+#   agents: { jobsize: "hours" }
+# 
+# 
+# - wait: ~
+#   continue_on_failure: true
+# 
+# ###########################################################
+# 
+# - label: 'glb_tile'
+#   command: mflowgen/test/test_module.sh glb_tile
+#   agents: { jobsize: "hours" }
+# 
+# 
+# - wait: ~
+#   continue_on_failure: true
+# 
+# ###########################################################

--- a/mflowgen/common/init-fullchip/outputs/alignment-cell-notes.txt
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cell-notes.txt
@@ -1,4 +1,84 @@
 ##############################################################################
+# ROUND 2 NOTES/EXPERIMENTS
+
+
+proc add_core_fiducials {} {
+  # stylus: delete_inst -inst ifid*cc*
+  deleteInst ifid*cc*
+
+  # I'll probably regret this...
+  set_proc_verbose gen_fiducial_set
+
+########################################################################
+# # baseline says "no errors' although ICOVL (like many other cells) has
+# # multiple USER GUIDE 'results'
+#   gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
+
+
+########################################################################
+# Duplicate earlier errors, see what that looks like
+# BASELINE LAYOUT: 21x2 vertical strip in center of chip: 6 DTCD errors
+# gen_fiducial_set [snap_to_grid 2274.00 0.09 99.99] 2700.00 cc true 0
+# Got the six errors, things are good!
+
+########################################################################
+# NEXT: raise original grid by 300u, see what happens
+#   set x [snap_to_grid 1800.00 0.09 99.99]; set y 3500.00
+#   gen_fiducial_set $x $y cc true 5 3.0
+# looks good!!!
+# DTCD=(3036.15,3878.0) maybe works
+
+# THEN: try 2x21 but leave DTCD where it was for successful run above
+
+
+
+#   # Using HORIZONTAL STRIPE EXPERIMENT 7 (see below);
+#   # should have no ICOVL or DTCD errors
+#   # 6x7 horiz grid of cells, LL (x,y)=(1800,3200)
+#   # FIXME note if you want 7 cols you have to ask for 5 etc
+#   gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
+
+
+
+  # For alignment cell layout history and experiment details,
+  # see "alignment-cell-notes.txt" in this directory
+
+  # 6/2019 ORIG SPACING and layout 21x2 (21 rows x 2 columns)
+  # gen_fiducial_set [snap_to_grid 2346.30 0.09 99.99] 2700.00 cc true 0
+
+  # Horizontal stripe experiments, March 2020:
+  # 
+  # BASELINE LAYOUT: 21x2 vertical strip in center of chip: 6 DTCD errors
+  # gen_fiducial_set [snap_to_grid 2274.00 0.09 99.99] 2700.00 cc true 0
+  # 
+  # ***HORIZONTAL STRIPE EXPERIMENT 1 (icovl3): 2x21: : NO ERRORS***
+  # gen_fiducial_set [snap_to_grid 1500.00 0.09 99.99] 2700.00 cc true 19
+  # 
+  # HS EXP 2 (icovl4): 1x42, one row of 42 cells: 14 DTCD errors
+  # gen_fiducial_set [snap_to_grid  700.00 0.09 99.99] 2700.00 cc true 40
+  # 
+  # EXP 3 (icovl5): 2x21@2, 2x horiz spacing: 14 DTCD errors
+  # gen_fiducial_set [snap_to_grid  750.00 0.09 99.99] 2700.00 cc true 20 2.0
+  # 
+  # EXP 4 (icovl6.3x7): 3x14, evenly spaced: 14 DTCD errors, 1 ICOVL error
+  # gen_fiducial_set [snap_to_grid  750.00 0.09 99.99] 2700.00 cc true 13 3.0
+  # 
+  # EXP 5 (icovl8.6x7-1500) 6x7, tighter pattern maybe: 1 ICOVL error 
+  # gen_fiducial_set [snap_to_grid 1500.00 0.09 99.99] 2700.00 cc true 5 3.0
+  # 
+  # EXP 6 (icovl9.6x7-1650) 6x7, try for better centering: 2 ICOVL errors
+  # gen_fiducial_set [snap_to_grid 1650.00 0.09 99.99] 2700.00 cc true 5 3.0
+  # 
+  # ***EXP 7 (icovla.6x7-3200y) 6x7, higher up: NO ERRORS***
+  # gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
+  # 
+  # EXP 8 (icovlb.6x7-3600y) 6x7, higher still: 6 DTCD errors
+  # gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3600.00 cc true 5 3.0
+
+}
+
+##############################################################################
+# ROUND 1
 proc add_core_fiducials {} {
   # stylus: delete_inst -inst ifid*cc*
   deleteInst ifid*cc*

--- a/mflowgen/common/init-fullchip/outputs/alignment-cell-notes.txt
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cell-notes.txt
@@ -1,4 +1,114 @@
 ##############################################################################
+# ROUND 3 NOTES/EXPERIMENTS
+proc add_core_fiducials {} {
+  # [Blank comment to establish indentation pattern for emacs?]
+  puts "+++ @file_info begin ICOVL"
+  
+  deleteInst ifid*cc*; # stylus: delete_inst -inst ifid*cc*
+  set_proc_verbose gen_fiducial_set
+
+#   # New default placement
+#   # 1x42 @ y=3800, custom DTCD placement (auto fails @ y=3800); no DRC errors
+#   puts "@file_info 1x42 ICOVL array @ y=3800"
+#   set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) 3878.0
+#   set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
+#   gen_fiducial_set $x $y cc true $cols
+
+
+  ##############################################################################
+  ##############################################################################
+
+  # Some quick experiments.
+  # Round 1 experiments
+  # - Move icovl and dtcd cells up 10,20,40,80,160,240u (above)
+  # 
+  #   # Keep array size and x-offset constant
+  #   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
+  #   set ::env(DTCD_X) 2450
+  # 
+  #   set offset 240.0
+  #   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
+  #   gen_fiducial_set $x $y cc true $cols
+  #   
+  # NOTES/RESULTS
+  # Tried moving everything up 10,20,40,80,160,240u (above)
+  # Broke at 80u; 120 and 240 also failed
+  # All errors were DTCD related
+  # Looks like DTCD cannot be closer than about 1mm from chip edge
+
+
+#   # Round 2 experiments: try moving ICOVL up while leaving DTCD at 40
+#   # 
+#   # Keep array size and x-offset constant
+#   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
+#   set ::env(DTCD_X) 2450
+#   # 
+#   set offset_dtcd   40.0
+#   set offset_icovl 240.0
+#   # 
+#   set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
+#   set y [expr 3800 + $offset_icovl]
+#   gen_fiducial_set $x $y cc true $cols
+#   # RESULTS/NOTES: All experiments succeeded!
+#   # Final placement for offsets 40,240 y=4040, dtcd=(2450,3918)
+
+
+  # Round 3 experiments: Final placement
+  # Standard x-offset to center a 1x42 array
+  set x [snap_to_grid  700.00 0.09 99.99]
+  # Put icovl array between bump rows near top of die
+  set y [expr 4040 - 32]
+  # Put dtcd between four bumps and as close to UR corner as it can get
+  set ::env(DTCD_X) 3840; set ::env(DTCD_Y) 3840
+  set cols [expr 42 - 2]; # 42 columns, this is how you do it :(
+  gen_fiducial_set $x $y cc true $cols
+
+
+#   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
+#   set ::env(DTCD_X) 2450
+#   # 
+#   set offset_icovl 160.0
+#   set offset_dtcd   40.0
+#   # 
+#   set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
+#   set y [expr 3800 + $offset_icovl]
+#   gen_fiducial_set $x $y cc true $cols
+
+
+
+
+# OLD
+#   # Maybe try 250u higher ?
+#   # 1x42 @ y=4050, custom DTCD placement
+#   set y 4050; 
+#   puts "@file_info 1x42 ICOVL array @ y=4050"
+# 
+# # set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 250.0]; # too high?
+# #  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+# 
+# # other things to try: lower still
+# # set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 150.0]
+# 
+# # centered horizontally maybe
+# # set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
+# 
+# # Then raise it up again
+# # set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+# 
+#  set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 160.0]
+#   gen_fiducial_set $x $y cc true $cols
+# OLD
+
+
+
+  ##############################################################################
+  ##############################################################################
+}
+
+
+
+
+##############################################################################
 # ROUND 2 NOTES/EXPERIMENTS
 
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -15,96 +15,40 @@ proc add_core_fiducials {} {
   # I'll probably regret this...
   set_proc_verbose gen_fiducial_set
 
-
-########################################################################
-# # baseline says "no errors' although ICOVL (like many other cells) has
-# # multiple USER GUIDE 'results'
-#   gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
-
-
-########################################################################
-# Duplicate earlier errors, see what that looks like
-# BASELINE LAYOUT: 21x2 vertical strip in center of chip: 6 DTCD errors
-# gen_fiducial_set [snap_to_grid 2274.00 0.09 99.99] 2700.00 cc true 0
-# Got the six errors, things are good!
-
-########################################################################
-# NEXT: raise original grid by 300u, see what happens
-#   set x [snap_to_grid 1800.00 0.09 99.99]; set y 3500.00
-#   gen_fiducial_set $x $y cc true 5 3.0
-# looks good!!!
-# DTCD=(3036.15,3878.0) maybe works
-
-########################################################################
-# NEXT: try 2x21 @ y=3800
-#   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
-#   gen_fiducial_set $x $y cc true $cols
-# manual: seems to have passed !!? see build 1184
-
-# auto: seems to have passed !!? see build 1185
-
-
-########################################################################
-# NEXT: try 1x42 @ y=3800
-  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
-  gen_fiducial_set $x $y cc true $cols
-# manual:
-# auto:
-
-
-
-
-
-
-# THEN: try 2x21 but leave DTCD where it was for successful run above
-
-
-
-#   # Using HORIZONTAL STRIPE EXPERIMENT 7 (see below);
-#   # should have no ICOVL or DTCD errors
-#   # 6x7 horiz grid of cells, LL (x,y)=(1800,3200)
-#   # FIXME note if you want 7 cols you have to ask for 5 etc
-#   gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
-
-
-
-
-
-
-  # For alignment cell layout history and experiment details,
-  # see "alignment-cell-notes.txt" in this directory
+  puts "+++ @file_info begin ICOVL"
 
   # 6/2019 ORIG SPACING and layout 21x2 (21 rows x 2 columns)
   # gen_fiducial_set [snap_to_grid 2346.30 0.09 99.99] 2700.00 cc true 0
 
-  # Horizontal stripe experiments, March 2020:
+  # For alignment cell layout history and experiment details,
+  # see "alignment-cell-notes.txt" in this directory
+
+  # New default placement
+  # 1x42 @ y=3800, custom DTCD placement (auto fails @ y=3800); no DRC errors
+  puts "@file_info 1x42 ICOVL array, DTCD @ ($::env(DTCD_X),$::env(DTCD_Y)"
+  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) 3878.0
+  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
+  gen_fiducial_set $x $y cc true $cols
+
+  puts "--- @file_info end ICOVL"
+  return
+
+  # Other valid options; also see "alignment-cell-notes.txt".
   # 
-  # BASELINE LAYOUT: 21x2 vertical strip in center of chip: 6 DTCD errors
-  # gen_fiducial_set [snap_to_grid 2274.00 0.09 99.99] 2700.00 cc true 0
+  #   # 2x21 @ y=3800, auto DTCD placement; no DRC errors
+  #   puts "@file_info 2x21 ICOVL array, DTCD auto-placed in array"
+  #   set ::env(DTCD_X) "auto"; set ::env(DTCD_Y) "auto"
+  #   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
+  #   gen_fiducial_set $x $y cc true $cols
   # 
-  # ***HORIZONTAL STRIPE EXPERIMENT 1 (icovl3): 2x21: : NO ERRORS***
-  # gen_fiducial_set [snap_to_grid 1500.00 0.09 99.99] 2700.00 cc true 19
   # 
-  # HS EXP 2 (icovl4): 1x42, one row of 42 cells: 14 DTCD errors
-  # gen_fiducial_set [snap_to_grid  700.00 0.09 99.99] 2700.00 cc true 40
-  # 
-  # EXP 3 (icovl5): 2x21@2, 2x horiz spacing: 14 DTCD errors
-  # gen_fiducial_set [snap_to_grid  750.00 0.09 99.99] 2700.00 cc true 20 2.0
-  # 
-  # EXP 4 (icovl6.3x7): 3x14, evenly spaced: 14 DTCD errors, 1 ICOVL error
-  # gen_fiducial_set [snap_to_grid  750.00 0.09 99.99] 2700.00 cc true 13 3.0
-  # 
-  # EXP 5 (icovl8.6x7-1500) 6x7, tighter pattern maybe: 1 ICOVL error 
-  # gen_fiducial_set [snap_to_grid 1500.00 0.09 99.99] 2700.00 cc true 5 3.0
-  # 
-  # EXP 6 (icovl9.6x7-1650) 6x7, try for better centering: 2 ICOVL errors
-  # gen_fiducial_set [snap_to_grid 1650.00 0.09 99.99] 2700.00 cc true 5 3.0
-  # 
-  # ***EXP 7 (icovla.6x7-3200y) 6x7, higher up: NO ERRORS***
-  # gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
-  # 
-  # EXP 8 (icovlb.6x7-3600y) 6x7, higher still: 6 DTCD errors
-  # gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3600.00 cc true 5 3.0
+  #   # 6x7 @ y=3800, auto DTCD placement; no DRC errors
+  #   puts "@file_info 6x7 array, DTCD auto-placed in array"
+  #   set ::env(DTCD_X) "auto"; set ::env(DTCD_Y) "auto"
+  #   #   gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
+  #   set x [snap_to_grid 1800.00 0.09 99.99]; set y 3200; set cols [expr 7 - 2]
+  #   set x_spacing_factor 3.0
+  #   gen_fiducial_set $x $y cc true $cols $x_spacing_factor
 }
 
 ##############################################################################
@@ -124,22 +68,21 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     set iy [ lindex $i_ix_iy 2]
 
     if {$id == "cc"} {
-        puts "+++ @file_info begin"
-        puts "@file_info first CC ICOVL cell x,y=($pos_x, $pos_y)"
-        puts "@file_info last  CC ICOVL cell x,y=($ix, $iy)"
+        puts "@file_info CC ICOVL array bbox LL=($pos_x, $pos_y)"
+        puts "@file_info CC ICOVL array bbox UR=($ix, $iy)"
+        
+        # Use env vars to choose auto or manual DTCD placement for cc area
+        if {$::env(DTCD_X) == "auto"} {
+            puts "@file_info CC DTCD cells going in at x,y=$ix,$iy"
+        } else {
+            # Directed manual DTCD placement, overrides ix, iy
+            # E.g. (3036.15,3878.0) seems to work always
+            set ix $::env(DTCD_X); set iy $::env(DTCD_Y)
+            puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
+        }
     }
-
-    # DTCD cells
-    # There's one feol cell and many beol cells, all stacked in one (ix,iy) place (!!?)
-    if {$id == "cc"} {
-        set ix 3036.15; set iy 3878.0
-        puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
-
-#         puts "@file_info CC DTCD cells going in at x,y=$ix,$iy"
-
-        puts "--- @file_info end"
-        # (3036.15,3878.0) maybe works
-    }
+    # DTCD cells: there's one feol cell and many beol cells,
+    # all stacked in one (ix,iy) place (!!?)
     set i [ place_DTCD_cell_feol  $i $ix $iy "ifid_dtcd_feol_${id}" $grid ]
     set i [ place_DTCD_cells_beol $i $ix $iy "ifid_dtcd_beol_${id}"       ]
 }

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -39,11 +39,17 @@ proc add_core_fiducials {} {
 # NEXT: try 2x21 @ y=3800
 #   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
 #   gen_fiducial_set $x $y cc true $cols
+# manual: seems to have passed !!? see build 1184
+
+# auto: seems to have passed !!? see build 1185
+
 
 ########################################################################
 # NEXT: try 1x42 @ y=3800
   set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
   gen_fiducial_set $x $y cc true $cols
+# manual:
+# auto:
 
 
 
@@ -125,8 +131,12 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     # DTCD cells
     # There's one feol cell and many beol cells, all stacked in one (ix,iy) place (!!?)
     if {$id == "cc"} {
-        set ix 3036.15; set iy 3878.0
-        puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
+#         set ix 3036.15; set iy 3878.0
+#         puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
+
+        puts "@file_info CC DTCD cells going in at x,y=$ix,$iy"
+
+
         # (3036.15,3878.0) maybe works
     }
     set i [ place_DTCD_cell_feol  $i $ix $iy "ifid_dtcd_feol_${id}" $grid ]

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -17,6 +17,14 @@ proc add_core_fiducials {} {
 
 
 
+# # baseline says "no errors' although ICOVL (like many other cells) has
+# # multiple USER GUIDE 'results'
+#   gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
+
+
+# Duplicate earlier errors, see what that looks like
+# BASELINE LAYOUT: 21x2 vertical strip in center of chip: 6 DTCD errors
+gen_fiducial_set [snap_to_grid 2274.00 0.09 99.99] 2700.00 cc true 0
 
 
 
@@ -26,13 +34,16 @@ proc add_core_fiducials {} {
 
 
 
+#   # Using HORIZONTAL STRIPE EXPERIMENT 7 (see below);
+#   # should have no ICOVL or DTCD errors
+#   # 6x7 horiz grid of cells, LL (x,y)=(1800,3200)
+#   # FIXME note if you want 7 cols you have to ask for 5 etc
+#   gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
 
 
-  # Using HORIZONTAL STRIPE EXPERIMENT 7 (see below);
-  # should have no ICOVL or DTCD errors
-  # 6x7 horiz grid of cells, LL (x,y)=(1800,3200)
-  # FIXME note if you want 7 cols you have to ask for 5 etc
-  gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
+
+
+
 
   # For alignment cell layout history and experiment details,
   # see "alignment-cell-notes.txt" in this directory

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -42,7 +42,7 @@ proc add_core_fiducials {} {
 
 ########################################################################
 # NEXT: try 1x42 @ y=3800
-#  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
+#   set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
 #   gen_fiducial_set $x $y cc true $cols
 
 
@@ -125,7 +125,7 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     # DTCD cells
     # There's one feol cell and many beol cells, all stacked in one (ix,iy) place (!!?)
     if {$id == "cc"} {
-        set ix 3036.15; set iy 3878.0
+        # set ix 3036.15; set iy 3878.0
         puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
         # (3036.15,3878.0) maybe works
     }

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -28,12 +28,21 @@ proc add_core_fiducials {} {
 # gen_fiducial_set [snap_to_grid 2274.00 0.09 99.99] 2700.00 cc true 0
 # Got the six errors, things are good!
 
+########################################################################
 # NEXT: raise original grid by 300u, see what happens
-  set x [snap_to_grid 1800.00 0.09 99.99]; set y 3500.00
-  gen_fiducial_set $x $y cc true 5 3.0
+#   set x [snap_to_grid 1800.00 0.09 99.99]; set y 3500.00
+#   gen_fiducial_set $x $y cc true 5 3.0
+# looks good!!!
+# DTCD=(3036.15,3878.0) maybe works
+
+########################################################################
+# NEXT: try 2x21 @ y=3800
+  set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
+  gen_fiducial_set $x $y cc true $cols
 
 
 
+# THEN: try 2x21 but leave DTCD where it was for successful run above
 
 
 
@@ -90,10 +99,16 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     # delete_inst -inst ifid_*
     # set fid_name "init"; # NEVER USED...riiiiiight?
     # set cols 8
-    
+
     # ICOVL cells
     set width 12.6; # [stevo]: avoid db access by hard-coding width
     set i_ix_iy [ place_ICOVL_cells $pos_x $pos_y $xsepfactor $id $width $grid $cols ]
+
+    if {$id == "cc"} {
+        puts "@file_info first CC ICOVL cell x,y=($pos_x, $pos_y)"
+        puts "@file_info last  CC ICOVL cell x,y=($ix, $iy)"
+    }
+
 
     # Unpack return values
     set i  [ lindex $i_ix_iy 0]
@@ -102,7 +117,10 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
 
     # DTCD cells
     # There's one feol cell and many beol cells, all stacked in one (ix,iy) place (!!?)
-    puts "@file_info DTCD cells going in at x,y=$ix,$iy"
+    if {$id == "cc"} {
+        puts "@file_info CC DTCD cells going in at x,y=$ix,$iy"
+        # (3036.15,3878.0) maybe works
+    }
     set i [ place_DTCD_cell_feol  $i $ix $iy "ifid_dtcd_feol_${id}" $grid ]
     set i [ place_DTCD_cells_beol $i $ix $iy "ifid_dtcd_beol_${id}"       ]
 }

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -47,7 +47,11 @@ proc add_core_fiducials {} {
 # set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
 
 # Then raise it up again
-set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+# set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+
+# 10
+ set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 10.0]
+
 
 
   set x [snap_to_grid  700.00 0.09 99.99]; set y 4050; set cols [expr 42 - 2]

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -16,17 +16,24 @@ proc add_core_fiducials {} {
   set_proc_verbose gen_fiducial_set
 
 
-
+########################################################################
 # # baseline says "no errors' although ICOVL (like many other cells) has
 # # multiple USER GUIDE 'results'
 #   gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
 
 
+########################################################################
 # Duplicate earlier errors, see what that looks like
 # BASELINE LAYOUT: 21x2 vertical strip in center of chip: 6 DTCD errors
-gen_fiducial_set [snap_to_grid 2274.00 0.09 99.99] 2700.00 cc true 0
+# gen_fiducial_set [snap_to_grid 2274.00 0.09 99.99] 2700.00 cc true 0
+# Got the six errors, things are good!
 
 
+
+
+# NEXT: raise original grid by 300u, see what happens
+  set x [snap_to_grid 1800.00 0.09 99.99]; set y 3500.00
+  gen_fiducial_set $x $y cc true 5 3.0
 
 
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -37,8 +37,8 @@ proc add_core_fiducials {} {
 
 ########################################################################
 # NEXT: try 2x21 @ y=3800
-  set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
-  gen_fiducial_set $x $y cc true $cols
+#   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
+#   gen_fiducial_set $x $y cc true $cols
 
 ########################################################################
 # NEXT: try 1x42 @ y=3800

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -41,10 +41,10 @@ proc add_core_fiducials {} {
 #  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
 
 # other things to try: lower still
- set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 150.0]
+# set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 150.0]
 
 # centered horizontally maybe
-# set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
+set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
 
 # Then raise it up again
 # set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -49,7 +49,7 @@ proc add_core_fiducials {} {
 # Then raise it up again
 # set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
 
- set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 40.0]
+ set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 80.0]
 
 
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -48,7 +48,7 @@ proc add_core_fiducials {} {
   # Try moving ICOVL 80, but leave DTCD at 40
 
   set offset_dtcd   40.0
-  set offset_icovl 160.0
+  set offset_icovl 240.0
 
   set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
   set y [expr 3800 + $offset_icovl]

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -28,13 +28,9 @@ proc add_core_fiducials {} {
 # gen_fiducial_set [snap_to_grid 2274.00 0.09 99.99] 2700.00 cc true 0
 # Got the six errors, things are good!
 
-
-
-
 # NEXT: raise original grid by 300u, see what happens
   set x [snap_to_grid 1800.00 0.09 99.99]; set y 3500.00
   gen_fiducial_set $x $y cc true 5 3.0
-
 
 
 
@@ -106,6 +102,7 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
 
     # DTCD cells
     # There's one feol cell and many beol cells, all stacked in one (ix,iy) place (!!?)
+    puts "@file_info DTCD cells going in at x,y=$ix,$iy"
     set i [ place_DTCD_cell_feol  $i $ix $iy "ifid_dtcd_feol_${id}" $grid ]
     set i [ place_DTCD_cells_beol $i $ix $iy "ifid_dtcd_beol_${id}"       ]
 }

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -44,10 +44,10 @@ proc add_core_fiducials {} {
 # set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 150.0]
 
 # centered horizontally maybe
-set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
+# set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
 
 # Then raise it up again
-# set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
 
 
   set x [snap_to_grid  700.00 0.09 99.99]; set y 4050; set cols [expr 42 - 2]

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -47,8 +47,8 @@ proc add_core_fiducials {} {
   # Broke at 80u
   # Try moving ICOVL 80, but leave DTCD at 40
 
-  set offset_icovl 80.0
-  set offset_dtcd  40.0
+  set offset_dtcd   40.0
+  set offset_icovl 160.0
 
   set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
   set y [expr 3800 + $offset_icovl]

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -34,25 +34,61 @@ proc add_core_fiducials {} {
   ##############################################################################
   ##############################################################################
 
-  # Some quick experiments. Keep array size and x-offset constant
-  set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
-  set ::env(DTCD_X) 2450
-
-#   set offset 240.0
-#   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
-#   gen_fiducial_set $x $y cc true $cols
-
-  # NOTES
+  # Some quick experiments.
+  # Round 1 experiments
+  # - Move icovl and dtcd cells up 10,20,40,80,160,240u (above)
+  # 
+  #   # Keep array size and x-offset constant
+  #   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
+  #   set ::env(DTCD_X) 2450
+  # 
+  #   set offset 240.0
+  #   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
+  #   gen_fiducial_set $x $y cc true $cols
+  #   
+  # NOTES/RESULTS
   # Tried moving everything up 10,20,40,80,160,240u (above)
-  # Broke at 80u
-  # Try moving ICOVL 80, but leave DTCD at 40
+  # Broke at 80u; 120 and 240 also failed
+  # All errors were DTCD related
+  # Looks like DTCD cannot be closer than about 1mm from chip edge
 
-  set offset_dtcd   40.0
-  set offset_icovl 240.0
 
-  set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
-  set y [expr 3800 + $offset_icovl]
+#   # Round 2 experiments: try moving ICOVL up while leaving DTCD at 40
+#   # 
+#   # Keep array size and x-offset constant
+#   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
+#   set ::env(DTCD_X) 2450
+#   # 
+#   set offset_dtcd   40.0
+#   set offset_icovl 240.0
+#   # 
+#   set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
+#   set y [expr 3800 + $offset_icovl]
+#   gen_fiducial_set $x $y cc true $cols
+#   # RESULTS/NOTES: All experiments succeeded!
+#   # Final placement for offsets 40,240 y=4040, dtcd=(2450,3918)
+
+
+  # Round 3 experiments: Final placement
+  # Standard x-offset to center a 1x42 array
+  set x [snap_to_grid  700.00 0.09 99.99]
+  # Put icovl array between bump rows near top of die
+  set y [expr 4040 - 32]
+  # Put dtcd between four bumps and as close to UR corner as it can get
+  set ::env(DTCD_X) 3780; set ::env(DTCD_Y) 3780
+  set cols [expr 42 - 2]; # 42 columns, this is how you do it :(
   gen_fiducial_set $x $y cc true $cols
+
+
+#   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
+#   set ::env(DTCD_X) 2450
+#   # 
+#   set offset_icovl 160.0
+#   set offset_dtcd   40.0
+#   # 
+#   set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
+#   set y [expr 3800 + $offset_icovl]
+#   gen_fiducial_set $x $y cc true $cols
 
 
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -37,8 +37,8 @@ proc add_core_fiducials {} {
 
 ########################################################################
 # NEXT: try 2x21 @ y=3800
-#   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
-#   gen_fiducial_set $x $y cc true $cols
+  set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
+  gen_fiducial_set $x $y cc true $cols
 # manual: seems to have passed !!? see build 1184
 
 # auto: seems to have passed !!? see build 1185
@@ -46,8 +46,8 @@ proc add_core_fiducials {} {
 
 ########################################################################
 # NEXT: try 1x42 @ y=3800
-  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
-  gen_fiducial_set $x $y cc true $cols
+#   set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
+#   gen_fiducial_set $x $y cc true $cols
 # manual:
 # auto:
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -33,27 +33,40 @@ proc add_core_fiducials {} {
 
   ##############################################################################
   ##############################################################################
-  # Maybe try 250u higher ?
-  # 1x42 @ y=4050, custom DTCD placement
-  puts "@file_info 1x42 ICOVL array @ y=4050"
 
-# set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 250.0]; # too high?
-#  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
-
-# other things to try: lower still
-# set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 150.0]
-
-# centered horizontally maybe
-# set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
-
-# Then raise it up again
-# set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
-
- set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 160.0]
+  # Some quick experiments. Keep array size and x-offset constant
+  set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
+  set ::env(DTCD_X) 2450
 
 
+  set offset 10.0
 
-  set x [snap_to_grid  700.00 0.09 99.99]; set y 4050; set cols [expr 42 - 2]
+  set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
+  gen_fiducial_set $x $y cc true $cols
+
+# OLD
+#   # Maybe try 250u higher ?
+#   # 1x42 @ y=4050, custom DTCD placement
+#   set y 4050; 
+#   puts "@file_info 1x42 ICOVL array @ y=4050"
+# 
+# # set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 250.0]; # too high?
+# #  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+# 
+# # other things to try: lower still
+# # set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 150.0]
+# 
+# # centered horizontally maybe
+# # set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
+# 
+# # Then raise it up again
+# # set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+# 
+#  set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 160.0]
+# OLD
+
+
+
   gen_fiducial_set $x $y cc true $cols
   ##############################################################################
   ##############################################################################

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -39,7 +39,7 @@ proc add_core_fiducials {} {
   set ::env(DTCD_X) 2450
 
 
-  set offset 40.0
+  set offset 80.0
 
   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
   gen_fiducial_set $x $y cc true $cols

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -39,7 +39,7 @@ proc add_core_fiducials {} {
   set ::env(DTCD_X) 2450
 
 
-  set offset 80.0
+  set offset 160.0
 
   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
   gen_fiducial_set $x $y cc true $cols

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -75,7 +75,7 @@ proc add_core_fiducials {} {
   # Put icovl array between bump rows near top of die
   set y [expr 4040 - 32]
   # Put dtcd between four bumps and as close to UR corner as it can get
-  set ::env(DTCD_X) 3780; set ::env(DTCD_Y) 3780
+  set ::env(DTCD_X) 3840; set ::env(DTCD_Y) 3840
   set cols [expr 42 - 2]; # 42 columns, this is how you do it :(
   gen_fiducial_set $x $y cc true $cols
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -38,7 +38,17 @@ proc add_core_fiducials {} {
   puts "@file_info 1x42 ICOVL array @ y=4050"
 
 # set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 250.0]; # too high?
-  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+#  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+
+# other things to try: lower still
+ set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 150.0]
+
+# centered horizontally maybe
+# set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
+
+# Then raise it up again
+# set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+
 
   set x [snap_to_grid  700.00 0.09 99.99]; set y 4050; set cols [expr 42 - 2]
   gen_fiducial_set $x $y cc true $cols

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -37,8 +37,8 @@ proc add_core_fiducials {} {
 
 ########################################################################
 # NEXT: try 2x21 @ y=3800
-  set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
-  gen_fiducial_set $x $y cc true $cols
+#   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
+#   gen_fiducial_set $x $y cc true $cols
 # manual: seems to have passed !!? see build 1184
 
 # auto: seems to have passed !!? see build 1185
@@ -46,8 +46,8 @@ proc add_core_fiducials {} {
 
 ########################################################################
 # NEXT: try 1x42 @ y=3800
-#   set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
-#   gen_fiducial_set $x $y cc true $cols
+  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
+  gen_fiducial_set $x $y cc true $cols
 # manual:
 # auto:
 
@@ -124,7 +124,7 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     set iy [ lindex $i_ix_iy 2]
 
     if {$id == "cc"} {
-        puts "+++ begin @file_info"
+        puts "+++ @file_info begin"
         puts "@file_info first CC ICOVL cell x,y=($pos_x, $pos_y)"
         puts "@file_info last  CC ICOVL cell x,y=($ix, $iy)"
     }
@@ -132,13 +132,12 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     # DTCD cells
     # There's one feol cell and many beol cells, all stacked in one (ix,iy) place (!!?)
     if {$id == "cc"} {
-#         set ix 3036.15; set iy 3878.0
-#         puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
+        set ix 3036.15; set iy 3878.0
+        puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
 
-        puts "@file_info CC DTCD cells going in at x,y=$ix,$iy"
-        puts "--- end @file_info"
+#         puts "@file_info CC DTCD cells going in at x,y=$ix,$iy"
 
-
+        puts "--- @file_info end"
         # (3036.15,3878.0) maybe works
     }
     set i [ place_DTCD_cell_feol  $i $ix $iy "ifid_dtcd_feol_${id}" $grid ]

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -49,7 +49,7 @@ proc add_core_fiducials {} {
 # Then raise it up again
 # set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
 
- set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 80.0]
+ set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 160.0]
 
 
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -126,7 +126,8 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     # DTCD cells
     # There's one feol cell and many beol cells, all stacked in one (ix,iy) place (!!?)
     if {$id == "cc"} {
-        puts "@file_info CC DTCD cells going in at x,y=$ix,$iy"
+        set ix 3036.15; set iy 3878.0
+        puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
         # (3036.15,3878.0) maybe works
     }
     set i [ place_DTCD_cell_feol  $i $ix $iy "ifid_dtcd_feol_${id}" $grid ]

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -49,8 +49,7 @@ proc add_core_fiducials {} {
 # Then raise it up again
 # set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
 
-# 10
- set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 10.0]
+ set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 20.0]
 
 
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -42,8 +42,8 @@ proc add_core_fiducials {} {
 
 ########################################################################
 # NEXT: try 1x42 @ y=3800
-#   set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
-#   gen_fiducial_set $x $y cc true $cols
+  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
+  gen_fiducial_set $x $y cc true $cols
 
 
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -39,7 +39,7 @@ proc add_core_fiducials {} {
   set ::env(DTCD_X) 2450
 
 
-  set offset 10.0
+  set offset 20.0
 
   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
   gen_fiducial_set $x $y cc true $cols

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -39,7 +39,7 @@ proc add_core_fiducials {} {
   set ::env(DTCD_X) 2450
 
 
-  set offset 160.0
+  set offset 240.0
 
   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
   gen_fiducial_set $x $y cc true $cols

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -23,11 +23,19 @@ proc add_core_fiducials {} {
   # For alignment cell layout history and experiment details,
   # see "alignment-cell-notes.txt" in this directory
 
-  # New default placement
-  # 1x42 @ y=3800, custom DTCD placement (auto fails @ y=3800); no DRC errors
-  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) 3878.0
-  puts "@file_info 1x42 ICOVL array, DTCD @ ($::env(DTCD_X),$::env(DTCD_Y)"
-  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
+#   # New default placement
+#   # 1x42 @ y=3800, custom DTCD placement (auto fails @ y=3800); no DRC errors
+#   puts "@file_info 1x42 ICOVL array @ y=3800"
+#   set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) 3878.0
+#   set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
+#   gen_fiducial_set $x $y cc true $cols
+
+
+  # Maybe try 250u higher ?
+  # 1x42 @ y=4050, custom DTCD placement
+  puts "@file_info 1x42 ICOVL array @ y=4050"
+  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 250.0 + 3878.0]
+  set x [snap_to_grid  700.00 0.09 99.99]; set y 4050; set cols [expr 42 - 2]
   gen_fiducial_set $x $y cc true $cols
 
   puts "--- @file_info end ICOVL"
@@ -36,8 +44,8 @@ proc add_core_fiducials {} {
   # Other valid options; also see "alignment-cell-notes.txt".
   # 
   #   # 2x21 @ y=3800, auto DTCD placement; no DRC errors
+  #   puts "@file_info 2x21 ICOVL array"
   #   set ::env(DTCD_X) "auto"; set ::env(DTCD_Y) "auto"
-  #   puts "@file_info 2x21 ICOVL array, DTCD auto-placed in array"
   #   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
   #   gen_fiducial_set $x $y cc true $cols
   # 
@@ -73,7 +81,7 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
         
         # Use env vars to choose auto or manual DTCD placement for cc area
         if {$::env(DTCD_X) == "auto"} {
-            puts "@file_info CC DTCD cells going in at x,y=$ix,$iy"
+            puts "@file_info CC DTCD  cells going in at x,y=$ix,$iy"
         } else {
             # Directed manual DTCD placement, overrides ix, iy
             # E.g. (3036.15,3878.0) seems to work always

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -7,120 +7,30 @@ proc snap_to_grid {input granularity {edge_offset 0}} {
    return $new_value
 }
 
-##############################################################################
 proc add_core_fiducials {} {
-  # stylus: delete_inst -inst ifid*cc*
-  deleteInst ifid*cc*
-
-  # I'll probably regret this...
-  set_proc_verbose gen_fiducial_set
-
+  # [Blank comment to establish indentation pattern for emacs?]
   puts "+++ @file_info begin ICOVL"
-
-  # 6/2019 ORIG SPACING and layout 21x2 (21 rows x 2 columns)
-  # gen_fiducial_set [snap_to_grid 2346.30 0.09 99.99] 2700.00 cc true 0
+  
+  deleteInst ifid*cc*; # stylus: delete_inst -inst ifid*cc*
+  set_proc_verbose gen_fiducial_set
 
   # For alignment cell layout history and experiment details,
   # see "alignment-cell-notes.txt" in this directory
 
-#   # New default placement
-#   # 1x42 @ y=3800, custom DTCD placement (auto fails @ y=3800); no DRC errors
-#   puts "@file_info 1x42 ICOVL array @ y=3800"
-#   set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) 3878.0
-#   set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
-#   gen_fiducial_set $x $y cc true $cols
+  # 6/2019 ORIG SPACING and layout 21x2 (21 rows x 2 columns)
+  # gen_fiducial_set [snap_to_grid 2346.30 0.09 99.99] 2700.00 cc true 0
 
-
-  ##############################################################################
-  ##############################################################################
-
-  # Some quick experiments.
-  # Round 1 experiments
-  # - Move icovl and dtcd cells up 10,20,40,80,160,240u (above)
-  # 
-  #   # Keep array size and x-offset constant
-  #   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
-  #   set ::env(DTCD_X) 2450
-  # 
-  #   set offset 240.0
-  #   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
-  #   gen_fiducial_set $x $y cc true $cols
-  #   
-  # NOTES/RESULTS
-  # Tried moving everything up 10,20,40,80,160,240u (above)
-  # Broke at 80u; 120 and 240 also failed
-  # All errors were DTCD related
-  # Looks like DTCD cannot be closer than about 1mm from chip edge
-
-
-#   # Round 2 experiments: try moving ICOVL up while leaving DTCD at 40
-#   # 
-#   # Keep array size and x-offset constant
-#   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
-#   set ::env(DTCD_X) 2450
-#   # 
-#   set offset_dtcd   40.0
-#   set offset_icovl 240.0
-#   # 
-#   set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
-#   set y [expr 3800 + $offset_icovl]
-#   gen_fiducial_set $x $y cc true $cols
-#   # RESULTS/NOTES: All experiments succeeded!
-#   # Final placement for offsets 40,240 y=4040, dtcd=(2450,3918)
-
-
-  # Round 3 experiments: Final placement
+  # New default placement:
+  # 1x42 @ y=4008, custom DTCD placement; no DRC errors
+  # puts "@file_info 1x42 ICOVL array @ y=4008"
   # Standard x-offset to center a 1x42 array
   set x [snap_to_grid  700.00 0.09 99.99]
   # Put icovl array between bump rows near top of die
-  set y [expr 4040 - 32]
+  set y 4008
   # Put dtcd between four bumps and as close to UR corner as it can get
   set ::env(DTCD_X) 3840; set ::env(DTCD_Y) 3840
-  set cols [expr 42 - 2]; # 42 columns, this is how you do it :(
+  set cols [expr 42 - 2]; # 42 columns, this is how we do it :(
   gen_fiducial_set $x $y cc true $cols
-
-
-#   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
-#   set ::env(DTCD_X) 2450
-#   # 
-#   set offset_icovl 160.0
-#   set offset_dtcd   40.0
-#   # 
-#   set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
-#   set y [expr 3800 + $offset_icovl]
-#   gen_fiducial_set $x $y cc true $cols
-
-
-
-
-# OLD
-#   # Maybe try 250u higher ?
-#   # 1x42 @ y=4050, custom DTCD placement
-#   set y 4050; 
-#   puts "@file_info 1x42 ICOVL array @ y=4050"
-# 
-# # set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 250.0]; # too high?
-# #  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
-# 
-# # other things to try: lower still
-# # set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 150.0]
-# 
-# # centered horizontally maybe
-# # set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 0.0]
-# 
-# # Then raise it up again
-# # set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
-# 
-#  set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 160.0]
-#   gen_fiducial_set $x $y cc true $cols
-# OLD
-
-
-
-  ##############################################################################
-  ##############################################################################
-
-
 
   puts "--- @file_info end ICOVL"
   return

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -37,13 +37,13 @@ proc add_core_fiducials {} {
 
 ########################################################################
 # NEXT: try 2x21 @ y=3800
-#   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
-#   gen_fiducial_set $x $y cc true $cols
+  set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
+  gen_fiducial_set $x $y cc true $cols
 
 ########################################################################
 # NEXT: try 1x42 @ y=3800
-  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
-  gen_fiducial_set $x $y cc true $cols
+#  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
+#   gen_fiducial_set $x $y cc true $cols
 
 
 
@@ -112,16 +112,15 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     set width 12.6; # [stevo]: avoid db access by hard-coding width
     set i_ix_iy [ place_ICOVL_cells $pos_x $pos_y $xsepfactor $id $width $grid $cols ]
 
-    if {$id == "cc"} {
-        puts "@file_info first CC ICOVL cell x,y=($pos_x, $pos_y)"
-        puts "@file_info last  CC ICOVL cell x,y=($ix, $iy)"
-    }
-
-
     # Unpack return values
     set i  [ lindex $i_ix_iy 0]
     set ix [ lindex $i_ix_iy 1]
     set iy [ lindex $i_ix_iy 2]
+
+    if {$id == "cc"} {
+        puts "@file_info first CC ICOVL cell x,y=($pos_x, $pos_y)"
+        puts "@file_info last  CC ICOVL cell x,y=($ix, $iy)"
+    }
 
     # DTCD cells
     # There's one feol cell and many beol cells, all stacked in one (ix,iy) place (!!?)

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -124,6 +124,7 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     set iy [ lindex $i_ix_iy 2]
 
     if {$id == "cc"} {
+        puts "+++ begin @file_info"
         puts "@file_info first CC ICOVL cell x,y=($pos_x, $pos_y)"
         puts "@file_info last  CC ICOVL cell x,y=($ix, $iy)"
     }
@@ -135,6 +136,7 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
 #         puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
 
         puts "@file_info CC DTCD cells going in at x,y=$ix,$iy"
+        puts "--- end @file_info"
 
 
         # (3036.15,3878.0) maybe works

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -38,11 +38,24 @@ proc add_core_fiducials {} {
   set x [snap_to_grid  700.00 0.09 99.99]; set cols [expr 42 - 2]
   set ::env(DTCD_X) 2450
 
+#   set offset 240.0
+#   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
+#   gen_fiducial_set $x $y cc true $cols
 
-  set offset 240.0
+  # NOTES
+  # Tried moving everything up 10,20,40,80,160,240u (above)
+  # Broke at 80u
+  # Try moving ICOVL 80, but leave DTCD at 40
 
-  set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
+  set offset_icovl 80.0
+  set offset_dtcd  40.0
+
+  set ::env(DTCD_Y) [expr 3878.0 + $offset_dtcd]
+  set y [expr 3800 + $offset_icovl]
   gen_fiducial_set $x $y cc true $cols
+
+
+
 
 # OLD
 #   # Maybe try 250u higher ?

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -25,8 +25,8 @@ proc add_core_fiducials {} {
 
   # New default placement
   # 1x42 @ y=3800, custom DTCD placement (auto fails @ y=3800); no DRC errors
-  puts "@file_info 1x42 ICOVL array, DTCD @ ($::env(DTCD_X),$::env(DTCD_Y)"
   set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) 3878.0
+  puts "@file_info 1x42 ICOVL array, DTCD @ ($::env(DTCD_X),$::env(DTCD_Y)"
   set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
   gen_fiducial_set $x $y cc true $cols
 
@@ -36,15 +36,15 @@ proc add_core_fiducials {} {
   # Other valid options; also see "alignment-cell-notes.txt".
   # 
   #   # 2x21 @ y=3800, auto DTCD placement; no DRC errors
-  #   puts "@file_info 2x21 ICOVL array, DTCD auto-placed in array"
   #   set ::env(DTCD_X) "auto"; set ::env(DTCD_Y) "auto"
+  #   puts "@file_info 2x21 ICOVL array, DTCD auto-placed in array"
   #   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
   #   gen_fiducial_set $x $y cc true $cols
   # 
   # 
   #   # 6x7 @ y=3800, auto DTCD placement; no DRC errors
-  #   puts "@file_info 6x7 array, DTCD auto-placed in array"
   #   set ::env(DTCD_X) "auto"; set ::env(DTCD_Y) "auto"
+  #   puts "@file_info 6x7 array, DTCD auto-placed in array"
   #   #   gen_fiducial_set [snap_to_grid 1800.00 0.09 99.99] 3200.00 cc true 5 3.0
   #   set x [snap_to_grid 1800.00 0.09 99.99]; set y 3200; set cols [expr 7 - 2]
   #   set x_spacing_factor 3.0
@@ -400,6 +400,8 @@ proc test_vars {} {
 
 proc add_boundary_fiducials {} {
   delete_inst -inst ifid*ul*
+
+  set ::env(DTCD_X) "auto"; set ::env(DTCD_Y) "auto"
 
   gen_fiducial_set 100 4824.0 ul false
   select_obj [get_db insts ifid*ul*]

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -63,11 +63,11 @@ proc add_core_fiducials {} {
 # # set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
 # 
 #  set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 160.0]
+#   gen_fiducial_set $x $y cc true $cols
 # OLD
 
 
 
-  gen_fiducial_set $x $y cc true $cols
   ##############################################################################
   ##############################################################################
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -31,12 +31,21 @@ proc add_core_fiducials {} {
 #   gen_fiducial_set $x $y cc true $cols
 
 
+  ##############################################################################
+  ##############################################################################
   # Maybe try 250u higher ?
   # 1x42 @ y=4050, custom DTCD placement
   puts "@file_info 1x42 ICOVL array @ y=4050"
-  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 250.0 + 3878.0]
+
+# set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 250.0]; # too high?
+  set ::env(DTCD_X) 3036.15; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
+
   set x [snap_to_grid  700.00 0.09 99.99]; set y 4050; set cols [expr 42 - 2]
   gen_fiducial_set $x $y cc true $cols
+  ##############################################################################
+  ##############################################################################
+
+
 
   puts "--- @file_info end ICOVL"
   return

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -39,7 +39,7 @@ proc add_core_fiducials {} {
   set ::env(DTCD_X) 2450
 
 
-  set offset 20.0
+  set offset 40.0
 
   set ::env(DTCD_Y) [expr 3878.0 + $offset]; set y [expr 3800 + $offset]
   gen_fiducial_set $x $y cc true $cols

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -15,6 +15,19 @@ proc add_core_fiducials {} {
   # I'll probably regret this...
   set_proc_verbose gen_fiducial_set
 
+
+
+
+
+
+
+
+
+
+
+
+
+
   # Using HORIZONTAL STRIPE EXPERIMENT 7 (see below);
   # should have no ICOVL or DTCD errors
   # 6x7 horiz grid of cells, LL (x,y)=(1800,3200)

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -125,7 +125,7 @@ proc gen_fiducial_set {pos_x pos_y {id ul} grid {cols 8} {xsepfactor 1.0}} {
     # DTCD cells
     # There's one feol cell and many beol cells, all stacked in one (ix,iy) place (!!?)
     if {$id == "cc"} {
-        # set ix 3036.15; set iy 3878.0
+        set ix 3036.15; set iy 3878.0
         puts "@file_info CC DTCD cells going in at x,y=$ix,$iy (forced)"
         # (3036.15,3878.0) maybe works
     }

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -49,7 +49,7 @@ proc add_core_fiducials {} {
 # Then raise it up again
 # set ::env(DTCD_X) 4500; set ::env(DTCD_Y) [expr 3878.0 + 200.0]
 
- set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 20.0]
+ set ::env(DTCD_X) 2450; set ::env(DTCD_Y) [expr 3878.0 + 40.0]
 
 
 

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -37,8 +37,16 @@ proc add_core_fiducials {} {
 
 ########################################################################
 # NEXT: try 2x21 @ y=3800
-  set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
+#   set x [snap_to_grid 1500.00 0.09 99.99]; set y 3800; set cols [expr 21 - 2]
+#   gen_fiducial_set $x $y cc true $cols
+
+########################################################################
+# NEXT: try 1x42 @ y=3800
+  set x [snap_to_grid  700.00 0.09 99.99]; set y 3800; set cols [expr 42 - 2]
   gen_fiducial_set $x $y cc true $cols
+
+
+
 
 
 

--- a/mflowgen/icovl/README.md
+++ b/mflowgen/icovl/README.md
@@ -10,6 +10,15 @@ To do an experiment, edit the "gen_fiducial_set{}" call
 in "proc add_core_fiducials{}" in file<br/>
 [garnet/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl](../common/init-fullchip/outputs/alignment-cells.tcl).
 
+Check in the changes and buildkite runs automatically; in the buildkite log you will see placement info e.g.
+```
+  @file_info CC ICOVL array bbox LL=(700,4008)
+  @file_info CC ICOVL array bbox UR=(4080,4008)
+  @file_info CC DTCD cells going in at x,y=(3840,3840) (forced)
+  ...
+  GOOD ENOUGH
+  PASS
+```
 
 E.g. currently the below call builds a 6x7 array of cells near the top
 of the chip, with no DRC errors related to ICOVL or DTCD placement:

--- a/mflowgen/icovl/construct.py
+++ b/mflowgen/icovl/construct.py
@@ -261,7 +261,11 @@ def construct():
       'main.tcl','quality-of-life.tcl',
       'stylus-compatibility-procs.tcl','floorplan.tcl','io-fillers.tcl',
       'alignment-cells.tcl',
-      'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
+
+      # Let's try it without the bump routing maybe?
+      # 'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
+      'gen-bumps.tcl',
+
       'sealring.tcl',
       'innovus-foundation-flow/custom-scripts/stream-out.tcl',
       'attach-results-to-outputs.tcl',

--- a/mflowgen/test/post-rtl-filter.awk
+++ b/mflowgen/test/post-rtl-filter.awk
@@ -33,6 +33,10 @@ BEGIN { phase = "unknown" }
 ########################################################################
 # These messages always get to print regardless of phase
 /^@file_info/ { print; next }
+# Allow e.g. "+++ @file_info" (kind of a hack, like this entire file!)
+/^--- @file_info/ { print; next }
+/^+++ @file_info/ { print; next }
+
 
 ########################################################################
 # Annoyingly, lines starting with '--- ' or '+++ ' are control sequences


### PR DESCRIPTION
Raised the alignment cells to provide more room for central logic i.e. large global buffer. ICOVL cells are spread out as a single 1x42 cell row at approximately y=4008u i.e. 4mm up from the bottom of the chip and 0.9mm down from the top. See image below.

The DTCD cell was placed separately, aout 1.1mm in from the right edge and 1.1mm down from the top. I'm pretty sure that is close to the farthest it will go, away fro the center of the chip, without DRC errors. See second image below for detail.

If/when the analog PHY block needs more room at the top, it's easy to move the cells down, but for now Im leaving this as the default.

![final](https://user-images.githubusercontent.com/838026/80293977-7845e480-8719-11ea-85d9-bdd42099473e.png)

![final-detail-ur](https://user-images.githubusercontent.com/838026/80293980-7e3bc580-8719-11ea-94bd-7ec4a1837791.png)
