### PR TITLE
Remove duplicate endcap-welltap steps

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -237,13 +237,6 @@ def construct():
   # steps, we modify the order parameter for that node which determines
   # which scripts get run and when they get run.
 
-  # init -- Add 'add-endcaps-welltaps.tcl' after 'floorplan.tcl'
-
-  order = init.get_param('order') # get the default script run order
-  floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
-  order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
-  init.update_params( { 'order': order } )
-
   # Adding new input for genlibdb node to run
   order = genlibdb.get_param('order') # get the default script run order
   read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -186,13 +186,6 @@ def construct():
   # steps, we modify the order parameter for that node which determines
   # which scripts get run and when they get run.
 
-  # init -- Add 'add-endcaps-welltaps.tcl' after 'floorplan.tcl'
-
-  order = init.get_param('order') # get the default script run order
-  floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
-  order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
-  init.update_params( { 'order': order } )
-
   # Adding new input for genlibdb node to run
   order = genlibdb.get_param('order') # get the default script run order
   read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl

--- a/mflowgen/glb_tile/construct.py
+++ b/mflowgen/glb_tile/construct.py
@@ -232,17 +232,6 @@ def construct():
 
   g.update_params( parameters )
 
-  # Since we are adding an additional input script to the generic Innovus
-  # steps, we modify the order parameter for that node which determines
-  # which scripts get run and when they get run.
-
-  # init -- Add 'add-endcaps-welltaps.tcl' after 'floorplan.tcl'
-
-  order = init.get_param('order') # get the default script run order
-  floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
-  order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
-  init.update_params( { 'order': order } )
-
   # Add bank height param to init
   init.update_params( { 'bank_height': parameters['bank_height'] }, True )
 


### PR DESCRIPTION
Removes old code that manually added 'add-endcaps-welltaps.tcl' to the init order for multiple mflowgen flows. No longer necessary because it's part of the default init order now.