### PR TITLE
Change global buffer tile rtl for timing.

### DIFF
--- a/global_buffer/dump.tcl
+++ b/global_buffer/dump.tcl
@@ -1,0 +1,3 @@
+dump -aggregates -add /
+run
+exit

--- a/global_buffer/testbench/glb_test.sv
+++ b/global_buffer/testbench/glb_test.sv
@@ -101,6 +101,28 @@ program automatic glb_test (
         $srandom(3);
 
         //=============================================================================
+        // Processor write tile 0, Processor read tile 0
+        //=============================================================================
+        seq = new();
+        my_trans_p[0] = new(0, 128);
+        my_trans_p[0].max_length_c.constraint_mode(0);
+        
+        my_trans_p[1] = new(0, 128, 1);
+        my_trans_p[1].max_length_c.constraint_mode(0);
+        
+        foreach(my_trans_p[i])
+            seq.add(my_trans_p[i]);
+        foreach(my_trans_c[i])
+            seq.add(my_trans_c[i]);
+
+        env = new(seq, p_ifc, r_ifc, s_ifc, c_ifc);
+        env.build();
+        env.run();
+
+        repeat(300) @(posedge clk);
+
+
+        //=============================================================================
         // // Processor write tile 0, Stream read tile 0
         //=============================================================================
         // seq = new();
@@ -206,7 +228,7 @@ program automatic glb_test (
 
 
         //=============================================================================
-        // // Stream write tile 0
+        // Stream write tile 0
         //=============================================================================
         // seq = new();
         // 
@@ -289,55 +311,55 @@ program automatic glb_test (
         //=============================================================================
         // Parallel Configuration test
         //=============================================================================
-        seq = new();
-        
-        my_trans_p[0] = new((15 << (BANK_ADDR_WIDTH+1)), 128);
-        my_trans_p[0].max_length_c.constraint_mode(0);
-        
-        my_trans_c[0] = new(0, 'h00, 'h402);
-        for (int i=1; i<NUM_GLB_TILES-1; i++) begin
-            my_trans_c[i] = new(i, 'h00, 'h2);
-        end
+        // seq = new();
+        // 
+        // my_trans_p[0] = new((15 << (BANK_ADDR_WIDTH+1)), 128);
+        // my_trans_p[0].max_length_c.constraint_mode(0);
+        // 
+        // my_trans_c[0] = new(0, 'h00, 'h402);
+        // for (int i=1; i<NUM_GLB_TILES-1; i++) begin
+        //     my_trans_c[i] = new(i, 'h00, 'h2);
+        // end
 
-        my_trans_c[15] = new(0, 'ha8, (15<<(BANK_ADDR_WIDTH+1)));
-        my_trans_c[16] = new(0, 'hac, 128);
-        my_trans_c[17] = new(0, 'h04, 15<<4);
+        // my_trans_c[15] = new(0, 'ha8, (15<<(BANK_ADDR_WIDTH+1)));
+        // my_trans_c[16] = new(0, 'hac, 128);
+        // my_trans_c[17] = new(0, 'h04, 15<<4);
 
-        foreach(my_trans_p[i])
-            seq.add(my_trans_p[i]);
-        foreach(my_trans_c[i])
-            seq.add(my_trans_c[i]);
+        // foreach(my_trans_p[i])
+        //     seq.add(my_trans_p[i]);
+        // foreach(my_trans_c[i])
+        //     seq.add(my_trans_c[i]);
 
-        top.cgra_stall_in <= 1;
-        top.stall <= 1;
-        env = new(seq, p_ifc, r_ifc, s_ifc, c_ifc);
-        env.build();
-        env.run();
+        // top.cgra_stall_in <= 1;
+        // top.stall <= 1;
+        // env = new(seq, p_ifc, r_ifc, s_ifc, c_ifc);
+        // env.build();
+        // env.run();
 
-        repeat(300) @(posedge clk);
-        top.cgra_cfg_jtag_gc2glb_rd_en <= 1;
-        top.cgra_cfg_jtag_gc2glb_addr <= 'h1234;
-        top.cgra_cfg_jtag_gc2glb_data <= 'h5678;
-        repeat(10) @(posedge clk);
-        top.cgra_cfg_jtag_gc2glb_rd_en <= 0;
-        top.cgra_cfg_jtag_gc2glb_addr <= 0;
-        top.cgra_cfg_jtag_gc2glb_data <= 0;
+        // repeat(300) @(posedge clk);
+        // top.cgra_cfg_jtag_gc2glb_rd_en <= 1;
+        // top.cgra_cfg_jtag_gc2glb_addr <= 'h1234;
+        // top.cgra_cfg_jtag_gc2glb_data <= 'h5678;
+        // repeat(10) @(posedge clk);
+        // top.cgra_cfg_jtag_gc2glb_rd_en <= 0;
+        // top.cgra_cfg_jtag_gc2glb_addr <= 0;
+        // top.cgra_cfg_jtag_gc2glb_data <= 0;
 
 
-        repeat(300) @(posedge clk);
-        c_ifc[0].pcfg_start_pulse <= 1;
-        @(posedge clk);
-        c_ifc[0].pcfg_start_pulse <= 0;
+        // repeat(300) @(posedge clk);
+        // c_ifc[0].pcfg_start_pulse <= 1;
+        // @(posedge clk);
+        // c_ifc[0].pcfg_start_pulse <= 0;
 
-        repeat(2000) @(posedge clk);
-        top.cgra_cfg_jtag_gc2glb_rd_en <= 1;
-        top.cgra_cfg_jtag_gc2glb_addr <= 'h1234;
-        top.cgra_cfg_jtag_gc2glb_data <= 'h5678;
-        repeat(10) @(posedge clk);
-        top.cgra_cfg_jtag_gc2glb_rd_en <= 0;
-        top.cgra_cfg_jtag_gc2glb_addr <= 0;
-        top.cgra_cfg_jtag_gc2glb_data <= 0;
-        repeat(2000) @(posedge clk);
+        // repeat(2000) @(posedge clk);
+        // top.cgra_cfg_jtag_gc2glb_rd_en <= 1;
+        // top.cgra_cfg_jtag_gc2glb_addr <= 'h1234;
+        // top.cgra_cfg_jtag_gc2glb_data <= 'h5678;
+        // repeat(10) @(posedge clk);
+        // top.cgra_cfg_jtag_gc2glb_rd_en <= 0;
+        // top.cgra_cfg_jtag_gc2glb_addr <= 0;
+        // top.cgra_cfg_jtag_gc2glb_data <= 0;
+        // repeat(2000) @(posedge clk);
     end
     
 endprogram

--- a/mflowgen/glb_tile/constraints/constraints.tcl
+++ b/mflowgen/glb_tile/constraints/constraints.tcl
@@ -48,7 +48,7 @@ set_false_path -from {glb_tile_id*}
 
 # set multi cycle path
 #
-set_multicycle_path 3 -through {*sram_array} -to {if_sram_cfg_wst_s_rd_data}
+set_multicycle_path 3 -through {glb_tile_int/glb_core/genblk*/glb_bank_memory} -to {if_sram_cfg_wst_s_rd_data}
 
 # Make all signals limit their fanout
 

--- a/mflowgen/glb_tile/constraints/constraints.tcl
+++ b/mflowgen/glb_tile/constraints/constraints.tcl
@@ -36,11 +36,19 @@ set_driving_cell -no_design_rule \
 #
 # - make this non-zero to avoid hold buffers on input-registered designs
 
-set_input_delay -clock ${clock_name} [expr ${dc_clock_period}/2.0] [all_inputs]
+set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.2] [all_inputs]
 
 # set_output_delay constraints for output ports
 
-set_output_delay -clock ${clock_name} 0 [all_outputs]
+set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.2] [all_outputs]
+
+# set false path
+#
+set_false_path -from {glb_tile_id*}
+
+# set multi cycle path
+#
+set_multicycle_path 3 -through {*sram_array} -to {if_sram_cfg_wst_s_rd_data}
 
 # Make all signals limit their fanout
 

--- a/mflowgen/glb_tile/construct.py
+++ b/mflowgen/glb_tile/construct.py
@@ -2,8 +2,8 @@
 #=========================================================================
 # construct.py
 #=========================================================================
-# Author : 
-# Date   : 
+# Author :
+# Date   :
 #
 
 import os
@@ -25,7 +25,7 @@ def construct():
   parameters = {
     'construct_path' : __file__,
     'design_name'    : 'glb_tile',
-    'clock_period'   : 2.0,
+    'clock_period'   : 1.0,
     'adk'            : adk_name,
     'adk_view'       : adk_view,
     # Synthesis


### PR DESCRIPTION
This PR basically improves channel selection controller within `glb_tile` regarding `stall` signal.
There are three different packets in `glb`; soc packet, parallel configuration packet, and cgra data stream packet.
`stall` signal should not affect soc packet channel and parallel configuration channel.
Previously, combinational logic interprets packet information on the fly and decide whether to stall or not, but I think It causes timing violation.

Now, `glb_tile` has separate channels for each of them and soc packet and parallel configuration channel are not stalled, while cgra data channel is stalled.
Selection among channels only occur at the very last.