### PR TITLE
Power Domains Flow for Flattened PE & Mem Tiles

### DIFF
--- a/mflowgen/Tile_MemCore/constraints/constraints.tcl
+++ b/mflowgen/Tile_MemCore/constraints/constraints.tcl
@@ -53,3 +53,9 @@ set_max_transition [expr 0.25*${dc_clock_period}] $dc_design_name
 #set_input_transition 1 [all_inputs]
 #set_max_transition 10 [all_outputs]
 
+if $::env(PWR_AWARE) {
+    source inputs/dc-dont-use-constraints.tcl
+    source inputs/mem-constraints.tcl
+    set_dont_touch [get_cells -hierarchical *u_mux_logic*]
+}
+

--- a/mflowgen/Tile_MemCore/custom-init/outputs/floorplan.tcl
+++ b/mflowgen/Tile_MemCore/custom-init/outputs/floorplan.tcl
@@ -15,7 +15,9 @@ set core_density_target 0.70; # Placement density of 70% is reasonable
 # Core height : number of vertical pitches in height of core area
 # We fix this value because the height of the memory and PE tiles
 # must be the same to allow for abutment at the top level
-set core_height 139
+
+# Maintain even row height for power domains
+set core_height 140
 
 set vert_pitch [dbGet top.fPlan.coreSite.size_y]
 set horiz_pitch [dbGet top.fPlan.coreSite.size_x]
@@ -69,7 +71,13 @@ set sram_spacing_y 0
 set sram_spacing_x_odd 0
 # Set spacing between pinned sides of SRAMs to some 
 # reasonable number of pitches
-set sram_spacing_x_even [expr 200 * $horiz_pitch]
+# Spread out further for power domains
+if $::env(PWR_AWARE) {
+  set sram_spacing_x_even [expr 600 * $horiz_pitch]
+} else {
+ set sram_spacing_x_even [expr 200 * $horiz_pitch]
+}
+
 # Parameter for how many SRAMs to stack vertically
 set bank_height 1
 

--- a/mflowgen/Tile_PE/constraints/constraints.tcl
+++ b/mflowgen/Tile_PE/constraints/constraints.tcl
@@ -53,4 +53,5 @@ set_max_transition [expr 0.25*${dc_clock_period}] $dc_design_name
 if $::env(PWR_AWARE) {
     source inputs/dc-dont-use-constraints.tcl
     source inputs/pe-constraints.tcl
+    set_dont_touch [get_cells -hierarchical *u_mux_logic*]
 } 

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -30,7 +30,7 @@ def construct():
     'adk'               : adk_name,
     'adk_view'          : adk_view,
     # Synthesis
-    'flatten_effort'    : 0,
+    'flatten_effort'    : 3,
     'topographical'     : False,
     # RTL Generation
     'interconnect_only' : True,
@@ -93,7 +93,7 @@ def construct():
   # Power aware setup
   if pwr_aware: 
       dc.extend_inputs(['upf_Tile_PE.tcl', 'pe-constraints.tcl', 'dc-dont-use-constraints.tcl'])
-      init.extend_inputs(['upf_Tile_PE.tcl', 'pe-load-upf.tcl', 'pd-pe-floorplan.tcl', 'pe-add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'pe-power-switches-setup.tcl', 'add-power-switches.tcl'])
+      init.extend_inputs(['upf_Tile_PE.tcl', 'pe-load-upf.tcl', 'dont-touch-constraints.tcl', 'pd-pe-floorplan.tcl', 'pe-add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'pe-power-switches-setup.tcl', 'add-power-switches.tcl'])
       place.extend_inputs(['place-dont-use-constraints.tcl'])
       power.extend_inputs(['pd-globalnetconnect.tcl'] )
       cts.extend_inputs(['conn-aon-cells-vdd.tcl'])

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -224,6 +224,7 @@ def construct():
   if pwr_aware:
       dc.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
       init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
+      init.update_params( { 'flatten_effort': parameters['flatten_effort'] }, True )
       power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
   
   # Since we are adding an additional input script to the generic Innovus

--- a/mflowgen/common/power-domains/configure.yml
+++ b/mflowgen/common/power-domains/configure.yml
@@ -28,4 +28,7 @@ outputs:
   - place-dont-use-constraints.tcl
   - dont-touch-constraints.tcl
   - upf_Tile_MemCore.tcl
-  - upf_Tile_PE.tcl 
+  - upf_Tile_PE.tcl
+
+
+ 

--- a/mflowgen/common/power-domains/configure.yml
+++ b/mflowgen/common/power-domains/configure.yml
@@ -8,22 +8,24 @@ name: power-domains
 # Inputs and Outputs
 #-------------------------------------------------------------------------
 
+
 outputs:
   - conn-aon-cells-vdd.tcl 
   - add-power-switches.tcl
   - pe-load-upf.tcl
   - mem-load-upf.tcl 
   - pd-mem-floorplan.tcl
-  - pd-globalnetconnect.tcl            
+  - pd-globalnetconnect.tcl        
   - pe-constraints.tcl
   - mem-add-endcaps-welltaps-setup.tcl  
   - mem-power-switches-setup.tcl  
-  - pd-pe-floorplan.tcl                
+  - pd-pe-floorplan.tcl        
   - pe-power-switches-setup.tcl
   - dc-dont-use-constraints.tcl  
   - mem-constraints.tcl 
   - pd-add-endcaps-welltaps.tcl   
   - pe-add-endcaps-welltaps-setup.tcl 
   - place-dont-use-constraints.tcl
+  - dont-touch-constraints.tcl
   - upf_Tile_MemCore.tcl
   - upf_Tile_PE.tcl 

--- a/mflowgen/common/power-domains/outputs/dont-touch-constraints.tcl
+++ b/mflowgen/common/power-domains/outputs/dont-touch-constraints.tcl
@@ -1,0 +1,14 @@
+
+
+
+#----------------------------------------------------------------
+# Don't touch constraints 
+#----------------------------------------------------------------
+
+# Set dont_touch constraints on the clamping modules in SB/CBs
+set_dont_touch [get_cells -hierarchical *u_mux_logic*]
+
+# Set this so that the clamping modules in SB/CBs
+# that have dont_touch attribute are uniquified
+set init_design_uniquify 1
+

--- a/mflowgen/common/power-domains/outputs/mem-add-endcaps-welltaps-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/mem-add-endcaps-welltaps-setup.tcl
@@ -1,0 +1,44 @@
+
+#-------------------------------------------------------------------------
+# Endcap and well tap specification
+#-------------------------------------------------------------------------
+
+
+# TSMC16 requires specification of different taps/caps for different
+# locations/orientations, which the foundation flow does not natively support
+
+if {[expr {$ADK_END_CAP_CELL == ""} && {$ADK_WELL_TAP_CELL == ""}]} {
+
+    deleteInst *TAP*
+    deleteInst *ENDCAP*
+    deleteInst *tap*
+
+    set edge_offset 12.91
+    
+    #TODO: No. of instances can change based on tile width. Review DRC report
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_1
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_2
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_3
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_4
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_5
+   
+    placeInstance top_endcap_tap_1 -fixed [expr $edge_offset + 0*28      ] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
+    placeInstance top_endcap_tap_2 -fixed [expr $edge_offset + 1*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
+    placeInstance top_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
+    placeInstance top_endcap_tap_4 -fixed [expr $edge_offset + 3*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
+    placeInstance top_endcap_tap_5 -fixed [expr $edge_offset + 4*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
+
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_1
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_2
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_3
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_4
+    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_5
+    
+    placeInstance bot_endcap_tap_1 -fixed [expr $edge_offset + 0*28      ] $polypitch_y
+    placeInstance bot_endcap_tap_2 -fixed [expr $edge_offset + 1*28 + 1.4] $polypitch_y
+    placeInstance bot_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] $polypitch_y
+    placeInstance bot_endcap_tap_4 -fixed [expr $edge_offset + 3*28 + 1.4] $polypitch_y
+    placeInstance bot_endcap_tap_5 -fixed [expr $edge_offset + 4*28 + 1.4] $polypitch_y
+}
+
+

--- a/mflowgen/common/power-domains/outputs/mem-constraints.tcl
+++ b/mflowgen/common/power-domains/outputs/mem-constraints.tcl
@@ -1,0 +1,19 @@
+
+
+
+#=========================================================================
+# Design Constraints File
+#=========================================================================
+
+
+# Constraints needed for power domains
+# Load UPF file
+
+set voltage_vdd 0.8
+set voltage_gnd 0
+set upf_create_implicit_supply_sets false
+set_design_attributes -elements {.} -attribute enable_state_propagation_in_add_power_state TRUE
+load_upf inputs/upf_Tile_MemCore.tcl 
+set_voltage ${voltage_vdd} -object_list {VDD VDD_SW}
+set_voltage ${voltage_gnd} -object_list {VSS}
+save_upf upf_${dc_design_name}.upf

--- a/mflowgen/common/power-domains/outputs/mem-load-upf.tcl
+++ b/mflowgen/common/power-domains/outputs/mem-load-upf.tcl
@@ -1,0 +1,11 @@
+
+
+#------------------------------------------------------------------------
+# Load UPF 
+# ------------------------------------------------------------------------
+
+
+read_power_intent -1801 inputs/upf_Tile_MemCore.tcl
+commit_power_intent
+write_power_intent -1801 upf.out
+

--- a/mflowgen/common/power-domains/outputs/mem-power-switches-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/mem-power-switches-setup.tcl
@@ -1,0 +1,11 @@
+
+#------------------------------------------------------------------------
+# Power switches setup 
+# ------------------------------------------------------------------------
+
+# MEM TILE SETUP ####
+set horiz_pitch [expr 420 * $polypitch_x]
+#set left_offset 20
+set left_offset 11
+
+

--- a/mflowgen/common/power-domains/outputs/pd-mem-floorplan.tcl
+++ b/mflowgen/common/power-domains/outputs/pd-mem-floorplan.tcl
@@ -1,0 +1,29 @@
+
+#=========================================================================
+# Create always-on domain region 
+#=========================================================================
+
+
+#Dont dont_touch constraints
+source inputs/dont-touch-constraints.tcl
+
+# create always on domain region
+   ##AON Region Bounding Box
+   puts "##AON Region Bounding Box"
+   set offset 7.1
+   set aon_width 14
+   set aon_height 11
+   
+   set polypitch_y [dbGet top.fPlan.coreSite.size_y]
+   set polypitch_x [dbGet top.fPlan.coreSite.size_x] 
+   
+   set aon_height_snap [expr ceil($aon_height/$polypitch_y)*$polypitch_y]
+   set aon_lx [expr $width/2 - $aon_width/2 + $offset - 0.18]
+   set aon_lx_snap [expr ceil($aon_lx/$polypitch_x)*$polypitch_x]
+   set aon_ux [expr $width/2 + $aon_width/2 + $offset - 3]
+   set aon_ux_snap [expr ceil($aon_ux/$polypitch_x)*$polypitch_x]
+   modifyPowerDomainAttr AON -box $aon_lx_snap  [expr $height - $aon_height_snap - 10*$polypitch_y] $aon_ux_snap [expr $height - 10*$polypitch_y]  -minGaps $polypitch_y $polypitch_y [expr $polypitch_x*6] [expr $polypitch_x*6]
+
+
+
+

--- a/mflowgen/common/power-domains/outputs/pd-pe-floorplan.tcl
+++ b/mflowgen/common/power-domains/outputs/pd-pe-floorplan.tcl
@@ -4,6 +4,9 @@
 # Create always-on domain region 
 #=========================================================================
 
+# Dont dont_touch constraints
+source inputs/dont-touch-constraints.tcl
+
 # AON Region Bounding Box
 puts "##AON Region Bounding Box"
 set offset     4.7

--- a/mflowgen/common/power-domains/outputs/pd-pe-floorplan.tcl
+++ b/mflowgen/common/power-domains/outputs/pd-pe-floorplan.tcl
@@ -17,7 +17,7 @@ set polypitch_y [dbGet top.fPlan.coreSite.size_y]
 set polypitch_x [dbGet top.fPlan.coreSite.size_x]
 
 set aon_height_snap [expr ceil($aon_height/$polypitch_y)*$polypitch_y]
-set aon_lx [expr $width/2 - $aon_width/2 + $offset -10 - 0.18]
+set aon_lx [expr $width/2 - $aon_width/2 + $offset -10 - 0.38]
 set aon_lx_snap [expr ceil($aon_lx/$polypitch_x)*$polypitch_x]
 set aon_ux [expr $width/2 + $aon_width/2 + $offset - 3]
 set aon_ux_snap [expr ceil($aon_ux/$polypitch_x)*$polypitch_x]

--- a/mflowgen/common/power-domains/outputs/pe-add-endcaps-welltaps-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/pe-add-endcaps-welltaps-setup.tcl
@@ -13,22 +13,27 @@ if {[expr {$ADK_END_CAP_CELL == ""} && {$ADK_WELL_TAP_CELL == ""}]} {
     deleteInst *TAP*
     deleteInst *ENDCAP*
     deleteInst *tap* 
+
+    set flatten_effort $::env(flatten_effort) 
+    set edge_offset    12.91
+
     addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_1
     addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_2
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_3
     
-    set edge_offset 12.91
     placeInstance top_endcap_tap_1 -fixed [expr $edge_offset + 0*28      ] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
     placeInstance top_endcap_tap_2 -fixed [expr $edge_offset + 1*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
-    placeInstance top_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y] 
     
     addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_1
     addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_2
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_3
     
     placeInstance bot_endcap_tap_1 -fixed [expr $edge_offset + 0*28      ] $polypitch_y 
     placeInstance bot_endcap_tap_2 -fixed [expr $edge_offset + 1*28 + 1.4] $polypitch_y 
-    placeInstance bot_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] $polypitch_y 
 
-}
+    if [expr $flatten_effort == 0] {
+       addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_3
+       placeInstance top_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
+       addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_3
+       placeInstance bot_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] $polypitch_y
+    }
+} 
 

--- a/mflowgen/common/power-domains/outputs/pe-add-endcaps-welltaps-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/pe-add-endcaps-welltaps-setup.tcl
@@ -14,7 +14,8 @@ if {[expr {$ADK_END_CAP_CELL == ""} && {$ADK_WELL_TAP_CELL == ""}]} {
     deleteInst *ENDCAP*
     deleteInst *tap* 
 
-    set flatten_effort $::env(flatten_effort) 
+    #set flatten_effort $::env(flatten_effort) 
+    set flatten_effort 3 
     set edge_offset    12.91
 
     addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_1

--- a/mflowgen/common/power-domains/outputs/pe-add-endcaps-welltaps-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/pe-add-endcaps-welltaps-setup.tcl
@@ -14,8 +14,7 @@ if {[expr {$ADK_END_CAP_CELL == ""} && {$ADK_WELL_TAP_CELL == ""}]} {
     deleteInst *ENDCAP*
     deleteInst *tap* 
 
-    #set flatten_effort $::env(flatten_effort) 
-    set flatten_effort 3 
+    set flatten_effort $::env(flatten_effort) 
     set edge_offset    12.91
 
     addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_1

--- a/mflowgen/common/power-domains/outputs/pe-power-switches-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/pe-power-switches-setup.tcl
@@ -5,9 +5,7 @@
 # ------------------------------------------------------------------------
 
 ## PE TILE SETUP ####
-#set flatten_effort $::env(flatten_effort)
-
-set flatten_effort 3
+set flatten_effort $::env(flatten_effort)
 
 if [expr $flatten_effort == 0] {
     set horiz_pitch [expr 260 * $polypitch_x]

--- a/mflowgen/common/power-domains/outputs/pe-power-switches-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/pe-power-switches-setup.tcl
@@ -5,6 +5,16 @@
 # ------------------------------------------------------------------------
 
 ## PE TILE SETUP ####
+#set flatten_effort $::env(flatten_effort)
+
+set flatten_effort 3
+
+if [expr $flatten_effort == 0] {
+    set horiz_pitch [expr 260 * $polypitch_x]
+} else {
+    set horiz_pitch [expr 320 * $polypitch_x]
+}
+
 set horiz_pitch [expr 260 * $polypitch_x]
 set left_offset 8
 

--- a/mflowgen/common/power-domains/outputs/pe-power-switches-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/pe-power-switches-setup.tcl
@@ -15,7 +15,6 @@ if [expr $flatten_effort == 0] {
     set horiz_pitch [expr 320 * $polypitch_x]
 }
 
-set horiz_pitch [expr 260 * $polypitch_x]
 set left_offset 8
 
 

--- a/mflowgen/common/power-domains/outputs/upf_Tile_MemCore.tcl
+++ b/mflowgen/common/power-domains/outputs/upf_Tile_MemCore.tcl
@@ -1,0 +1,49 @@
+######## Create Power Domains ###########
+# Default Power Domain - SD when tile not used 
+create_power_domain TOP -include_scope
+#create_power_domain TOP
+# AON Domain - Modules that stay ON when tile is OFF  
+# PS configuration logic and tie cells for hi/lo outputs that drive the tile_id
+create_power_domain AON -elements { PowerDomainOR DECODE_FEATURE_15 coreir_eq_16_inst0 and_inst1 FEATURE_AND_15 PowerDomainConfigReg_inst0 const_511_9 const_0_8}
+
+### Toplevel Connections ######
+## VDD 
+create_supply_port VDD
+create_supply_net  VDD -domain TOP
+create_supply_net  VDD -domain AON -reuse
+
+connect_supply_net VDD -ports  VDD
+
+## VSS (0.0V)
+create_supply_port VSS
+create_supply_net  VSS -domain TOP
+create_supply_net  VSS -domain AON -reuse
+
+connect_supply_net VSS -ports  VSS
+
+#### TOP SD Domain Power Connections ##########
+create_supply_net VDD_SW -domain TOP 
+
+#### Establish Connections ################
+set_domain_supply_net AON -primary_power_net VDD -primary_ground_net VSS
+set_domain_supply_net TOP -primary_power_net VDD_SW -primary_ground_net VSS
+
+########### Set all Global Signals as AON
+set_related_supply_net -object_list {tile_id hi lo clk clk_pass_through reset config_config_addr config_config_data config_read config_write read_config_data_in stall} -power VDD -ground VSS
+set_related_supply_net -object_list {clk_out clk_pass_through_out reset_out config_out_config_addr config_out_config_data config_out_read config_out_write read_config_data stall_out} -power VDD -ground VSS
+
+
+########### Create Shut-Down Logic for SD #######
+create_power_switch SD_sw \
+-domain TOP \
+-input_supply_port {in VDD} \
+-output_supply_port {out VDD_SW} \
+-control_port {SD_sd PowerDomainConfigReg_inst0/read_config_data[0]} \
+-on_state {ON_STATE in !SD_sd}
+
+#### Create Power State Table ##################
+add_port_state VDD -state {HighVoltage 0.8}
+add_port_state SD_sw/out -state {HighVoltage 0.8} -state {SD_OFF off}
+create_pst lvds_system_pst -supplies {VDD VDD_SW}
+add_pst_state LOGIC_ON -pst lvds_system_pst -state {HighVoltage SD_OFF}
+add_pst_state ALL_ON -pst lvds_system_pst -state {HighVoltage HighVoltage}


### PR DESCRIPTION
This PR includes following updates:
   - All scripts for Mem tile power aware flow
   - Updates to PE and Mem tile power aware flow with hierarchies flattened (flatten_effort=3)
   - Clamping logic in the SB/CB is maintained but the rest of the logic is flattened
   - GLS passing with flattening
   - 2-4 random DRCs 
   - LVS clean

Remnant Updates:
  - Trim M8 VDD_SW from the edges
  - Tie_hi/lo cells handling for tile_id 
