### PR TITLE
Remove 16bit multiplier from data gate test

### DIFF
--- a/tests/test_peak_core/test_pe_config.py
+++ b/tests/test_peak_core/test_pe_config.py
@@ -91,7 +91,6 @@ def _make_random(cls):
 _CAD_DIR = "/cad/synopsys/syn/P-2019.03/dw/sim_ver/"
 _EXPENSIVE = {
     "bits32.mul": ((umult0(),), "magma_Bits_32_mul_inst0", hwtypes.UIntVector[16]),  # noqa
-    "bits16.mul": ((fcnvexp2f(), fcnvsint2f(), fcnvuint2f()), "magma_Bits_16_mul_inst0", BFloat16_fc(PyFamily())),  # noqa
     "bfloat16.mul": ((fp_mul(),), "magma_BFloat_16_mul_inst0", BFloat16_fc(PyFamily())),  # noqa
     "bfloat16.add": ((fp_add(),), "magma_BFloat_16_add_inst0", BFloat16_fc(PyFamily())),  # noqa
 }


### PR DESCRIPTION
The peak description of lassen has changed.

See: https://github.com/StanfordAHA/lassen/pull/169.