### PR TITLE
Dc topo

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -31,7 +31,7 @@ def construct():
     'adk_view'          : adk_view,
     # Synthesis
     'flatten_effort'    : 3,
-    'topographical'     : False,
+    'topographical'     : True,
     # SRAM macros
     'num_words'         : 512,
     'word_size'         : 16,

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -31,7 +31,7 @@ def construct():
     'adk_view'          : adk_view,
     # Synthesis
     'flatten_effort'    : 3,
-    'topographical'     : False,
+    'topographical'     : True,
     # RTL Generation
     'interconnect_only' : True,
     # Power Domains

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -30,7 +30,7 @@ def construct():
     'adk_view'          : adk_view,
     # Synthesis
     'flatten_effort'    : 3,
-    'topographical'     : False,
+    'topographical'     : True,
     # RTL Generation
     'array_width'       : 32,
     'array_height'      : 16,

--- a/mflowgen/glb_tile/construct.py
+++ b/mflowgen/glb_tile/construct.py
@@ -30,7 +30,7 @@ def construct():
     'adk_view'       : adk_view,
     # Synthesis
     'flatten_effort' : 3,
-    'topographical'  : False,
+    'topographical'  : True,
     # Floorplan
     'bank_height'    : 8,
     # SRAM macros

--- a/mflowgen/glb_top/construct.py
+++ b/mflowgen/glb_top/construct.py
@@ -30,7 +30,7 @@ def construct():
     'adk_view'       : adk_view,
     # Synthesis
     'flatten_effort' : 3,
-    'topographical'  : False,
+    'topographical'  : True,
   }
 
   #-----------------------------------------------------------------------

--- a/mflowgen/global_controller/construct.py
+++ b/mflowgen/global_controller/construct.py
@@ -30,7 +30,7 @@ def construct():
     'adk_view'          : adk_view,
     # Synthesis
     'flatten_effort'    : 3,
-    'topographical'     : False,
+    'topographical'     : True,
     # RTL Generation
     'interconnect_only' : False,
     # Power Domains (leave this false)

--- a/mflowgen/soc/construct.py
+++ b/mflowgen/soc/construct.py
@@ -30,7 +30,7 @@ def construct():
     'adk_view'          : adk_view,
     # Synthesis
     'flatten_effort'    : 3,
-    'topographical'     : False,
+    'topographical'     : True,
     # RTL Generation
     'array_width'       : 32,
     'array_height'      : 16,

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -30,7 +30,7 @@ def construct():
     'adk_view'          : adk_view,
     # Synthesis
     'flatten_effort'    : 3,
-    'topographical'     : False,
+    'topographical'     : True,
     # RTL Generation
     'array_width'       : 32,
     'array_height'      : 16,


### PR DESCRIPTION
@ctorng fixed the ADK so that we can now use DC in topo mode. This should allow us to use the `create_scenario` command in our timing constraints.

To use this, you must pull the latest version of the TSMC16 adk.