### PR TITLE
PE & Memory Tile M8 VDD_SW trimming & tap cells connection

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -132,7 +132,7 @@ def construct():
       postcts_hold.extend_inputs(['conn-aon-cells-vdd.tcl'] )
       route.extend_inputs(['conn-aon-cells-vdd.tcl'] )
       postroute.extend_inputs(['conn-aon-cells-vdd.tcl'] )
-      signoff.extend_inputs(['conn-aon-cells-vdd.tcl'] )
+      signoff.extend_inputs(['conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl'] )
 
   #-----------------------------------------------------------------------
   # Graph -- Add nodes
@@ -349,6 +349,8 @@ def construct():
       # signoff node
       order = signoff.get_param('order')
       order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here 
+      read_idx = order.index( 'generate-results.tcl' ) # find generate_results.tcl 
+      order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
       signoff.update_params( { 'order': order } )
 
 

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -61,7 +61,7 @@ def construct():
   # Power aware setup
   if pwr_aware: 
       power_domains = Step( this_dir + '/../common/power-domains' )
-
+      pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls' )
   # Default steps
 
   info         = Step( 'info',                          default=True )
@@ -101,7 +101,7 @@ def construct():
       route.extend_inputs(['conn-aon-cells-vdd.tcl'] ) 
       postroute.extend_inputs(['conn-aon-cells-vdd.tcl'] )
       signoff.extend_inputs(['conn-aon-cells-vdd.tcl'] ) 
-  
+      pwr_aware_gls.extend_inputs(['design.vcs.pg.v']) 
   #-----------------------------------------------------------------------
   # Graph -- Add nodes
   #-----------------------------------------------------------------------
@@ -132,7 +132,7 @@ def construct():
   # Power aware step
   if pwr_aware:
       g.add_step( power_domains            )
-
+      g.add_step( pwr_aware_gls            )
   #-----------------------------------------------------------------------
   # Graph -- Add edges
   #-----------------------------------------------------------------------
@@ -212,6 +212,8 @@ def construct():
       g.connect_by_name( power_domains,        route        )
       g.connect_by_name( power_domains,        postroute    )
       g.connect_by_name( power_domains,        signoff      )
+      g.connect_by_name( adk,                  pwr_aware_gls)
+      g.connect_by_name( signoff,              pwr_aware_gls)
       #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
   
   #-----------------------------------------------------------------------

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -100,7 +100,7 @@ def construct():
       postcts_hold.extend_inputs(['conn-aon-cells-vdd.tcl'] )
       route.extend_inputs(['conn-aon-cells-vdd.tcl'] ) 
       postroute.extend_inputs(['conn-aon-cells-vdd.tcl'] )
-      signoff.extend_inputs(['conn-aon-cells-vdd.tcl'] ) 
+      signoff.extend_inputs(['conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl'] ) 
       #pwr_aware_gls.extend_inputs(['design.vcs.pg.v']) 
   #-----------------------------------------------------------------------
   # Graph -- Add nodes
@@ -297,8 +297,9 @@ def construct():
       # signoff node
       order = signoff.get_param('order')
       order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here 
+      read_idx = order.index( 'generate-results.tcl' ) # find generate_results.tcl 
+      order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
       signoff.update_params( { 'order': order } )
-
 
   return g
 

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -61,7 +61,7 @@ def construct():
   # Power aware setup
   if pwr_aware: 
       power_domains = Step( this_dir + '/../common/power-domains' )
-      pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls' )
+      #pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls' )
   # Default steps
 
   info         = Step( 'info',                          default=True )
@@ -101,7 +101,7 @@ def construct():
       route.extend_inputs(['conn-aon-cells-vdd.tcl'] ) 
       postroute.extend_inputs(['conn-aon-cells-vdd.tcl'] )
       signoff.extend_inputs(['conn-aon-cells-vdd.tcl'] ) 
-      pwr_aware_gls.extend_inputs(['design.vcs.pg.v']) 
+      #pwr_aware_gls.extend_inputs(['design.vcs.pg.v']) 
   #-----------------------------------------------------------------------
   # Graph -- Add nodes
   #-----------------------------------------------------------------------
@@ -132,7 +132,7 @@ def construct():
   # Power aware step
   if pwr_aware:
       g.add_step( power_domains            )
-      g.add_step( pwr_aware_gls            )
+      #g.add_step( pwr_aware_gls            )
   #-----------------------------------------------------------------------
   # Graph -- Add edges
   #-----------------------------------------------------------------------
@@ -212,8 +212,8 @@ def construct():
       g.connect_by_name( power_domains,        route        )
       g.connect_by_name( power_domains,        postroute    )
       g.connect_by_name( power_domains,        signoff      )
-      g.connect_by_name( adk,                  pwr_aware_gls)
-      g.connect_by_name( signoff,              pwr_aware_gls)
+      #g.connect_by_name( adk,                  pwr_aware_gls)
+      #g.connect_by_name( signoff,              pwr_aware_gls)
       #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
   
   #-----------------------------------------------------------------------

--- a/mflowgen/common/custom-power-leaf/outputs/power-strategy-dualmesh.tcl
+++ b/mflowgen/common/custom-power-leaf/outputs/power-strategy-dualmesh.tcl
@@ -17,6 +17,8 @@
 
 if $::env(PWR_AWARE) {
  set power_nets {VDD_SW VSS VDD}
+ set aon_power_nets {VDD VSS}
+ set sw_power_nets {VDD_SW}
  sroute -nets $power_nets
 } else {
  set power_nets {VDD VSS} 
@@ -179,10 +181,33 @@ if $::env(PWR_AWARE) {
    setAddStripeMode -stacked_via_bottom_layer 3 \
                  -stacked_via_top_layer    $pmesh_top \
                  -ignore_nondefault_domains true
+
+addStripe -nets $aon_power_nets -layer $pmesh_bot -direction horizontal \
+    -width $pmesh_bot_str_width                                   \
+    -spacing $pmesh_bot_str_intraset_spacing                      \
+    -set_to_set_distance $pmesh_bot_str_interset_pitch            \
+    -max_same_layer_jog_length $pmesh_bot_str_pitch               \
+    -padcore_ring_bottom_layer_limit $pmesh_bot                   \
+    -padcore_ring_top_layer_limit $pmesh_top                      \
+    -start [expr $pmesh_bot_str_pitch]                            \
+    -extend_to design_boundary
+
+# VDD_SW - Don't creat pins
+# Don't extend VDD_SW to boundary
+addStripe -nets $sw_power_nets -layer $pmesh_bot -direction horizontal \
+    -width $pmesh_bot_str_width                                   \
+    -spacing $pmesh_bot_str_intraset_spacing                      \
+    -set_to_set_distance $pmesh_bot_str_interset_pitch            \
+    -max_same_layer_jog_length $pmesh_bot_str_pitch               \
+    -padcore_ring_bottom_layer_limit $pmesh_bot                   \
+    -padcore_ring_top_layer_limit $pmesh_top                      \
+    -start [expr $pmesh_bot_str_pitch + ($pmesh_bot_str_intraset_spacing + $pmesh_bot_str_width)*2] \
+    -create_pins 0
+
 } else {
    setAddStripeMode -stacked_via_bottom_layer 3 \
                  -stacked_via_top_layer    $pmesh_top
-}
+
 
 # Add the stripes
 #
@@ -200,6 +225,7 @@ addStripe -nets $power_nets -layer $pmesh_bot -direction horizontal \
     -padcore_ring_top_layer_limit $pmesh_top                      \
     -start [expr $pmesh_bot_str_pitch]                            \
     -extend_to design_boundary
+}
 
 if $::env(PWR_AWARE) {
 sroute -allowJogging 0 -allowLayerChange 0 -connect  {secondaryPowerPin} -secondaryPinNet VDD -powerDomains TOP

--- a/mflowgen/common/power-domains/configure.yml
+++ b/mflowgen/common/power-domains/configure.yml
@@ -27,6 +27,7 @@ outputs:
   - pe-add-endcaps-welltaps-setup.tcl 
   - place-dont-use-constraints.tcl
   - dont-touch-constraints.tcl
+  - pd-generate-lvs-netlist.tcl
   - upf_Tile_MemCore.tcl
   - upf_Tile_PE.tcl
 

--- a/mflowgen/common/power-domains/outputs/mem-add-endcaps-welltaps-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/mem-add-endcaps-welltaps-setup.tcl
@@ -5,7 +5,7 @@
 
 
 # TSMC16 requires specification of different taps/caps for different
-# locations/orientations, which the foundation flow does not natively support
+# locations/orientations, which the foundation flow doeps not natively support
 
 if {[expr {$ADK_END_CAP_CELL == ""} && {$ADK_WELL_TAP_CELL == ""}]} {
 
@@ -13,32 +13,48 @@ if {[expr {$ADK_END_CAP_CELL == ""} && {$ADK_WELL_TAP_CELL == ""}]} {
     deleteInst *ENDCAP*
     deleteInst *tap*
 
-    set edge_offset 12.91
-    
-    #TODO: No. of instances can change based on tile width. Review DRC report
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_1
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_2
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_3
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_4
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_5
-   
-    placeInstance top_endcap_tap_1 -fixed [expr $edge_offset + 0*28      ] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
-    placeInstance top_endcap_tap_2 -fixed [expr $edge_offset + 1*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
-    placeInstance top_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
-    placeInstance top_endcap_tap_4 -fixed [expr $edge_offset + 3*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
-    placeInstance top_endcap_tap_5 -fixed [expr $edge_offset + 4*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
+    # Align tap cells with M3 pitch so that the M1 VPP pin is directly aligned with the M3 VDD net
 
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_1
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_2
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_3
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_4
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_5
+    # Get M3 min width and signal routing pitch as defined in the LEF
+
+    set M3_min_width    [dbGet [dbGetLayerByZ 3].minWidth]
+    set M3_route_pitchX [dbGet [dbGetLayerByZ 3].pitchX]
+
+    # Set M3 stripe variables
+
+    set M3_str_width            [expr  3 * $M3_min_width]
+    set M3_str_pitch            [expr 10 * $M3_route_pitchX]
+
+    set M3_str_intraset_spacing [expr ($M3_str_pitch - 2*$M3_str_width)/2]
+    set M3_str_interset_pitch   [expr 2*$M3_str_pitch]
+    set M3_str_offset           [expr $M3_str_pitch + $M3_route_pitchX/2 - $M3_str_width/2]
     
-    placeInstance bot_endcap_tap_1 -fixed [expr $edge_offset + 0*28      ] $polypitch_y
-    placeInstance bot_endcap_tap_2 -fixed [expr $edge_offset + 1*28 + 1.4] $polypitch_y
-    placeInstance bot_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] $polypitch_y
-    placeInstance bot_endcap_tap_4 -fixed [expr $edge_offset + 3*28 + 1.4] $polypitch_y
-    placeInstance bot_endcap_tap_5 -fixed [expr $edge_offset + 4*28 + 1.4] $polypitch_y
+    # Aligned with M3 power straps
+    # If ordering of the power straps change, the multiplication factor needs to change 
+    set edge_offset [expr $M3_str_offset + ($M3_str_intraset_spacing + $M3_str_width)*36]
+   
+    # Align with power switches pitch 
+    set pitch_offset 27
+    
+    # Right edge offset to cell is not placed
+    # too close to the right edge of the tile
+    set right_edge_offset [expr $pitch_offset + 5] 
+ 
+    set tap_cell_cnt [expr floor(([dbGet top.fPlan.coreBox_urx] - $right_edge_offset) / $pitch_offset)]  
+    
+    set i 0
+    while {$i < $tap_cell_cnt} {
+       set cell_name_top endcap_tap_top_${i}
+       addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst $cell_name_top 
+       placeInstance $cell_name_top -fixed [expr $edge_offset + $i*$pitch_offset*$M3_str_interset_pitch ] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
+      
+       set cell_name_bot endcap_tap_bot_${i}
+       addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst $cell_name_bot
+       placeInstance $cell_name_bot -fixed [expr $edge_offset + $i*$pitch_offset*$M3_str_interset_pitch ]  $polypitch_y
+ 
+       set i [expr $i + 1]
+     }
+
 }
 
 

--- a/mflowgen/common/power-domains/outputs/pd-generate-lvs-netlist.tcl
+++ b/mflowgen/common/power-domains/outputs/pd-generate-lvs-netlist.tcl
@@ -1,0 +1,28 @@
+#=========================================================================
+# generate-lvs-netlist.tcl
+#=========================================================================
+
+# Write netlist for LVS
+#
+# Exclude physical cells that have no devices in them (or else LVS will
+# have issues). Specifically for filler cells, the extracted layout will
+# not have any trace of the fillers because there are no devices in them.
+# Meanwhile, the schematic generated from the netlist will show filler
+# cells instances with VDD/VSS ports, and this will cause LVS to flag a
+# "mismatch" with the layout.
+
+# Exclude VDD_SW from top PG port
+
+foreach x $ADK_LVS_EXCLUDE_CELL_LIST {
+  append lvs_exclude_list [dbGet -u -e top.insts.cell.name $x] " "
+}
+
+
+saveNetlist -excludeLeafCell                   \
+            -phys                              \
+            -excludeCellInst $lvs_exclude_list \
+            -excludeTopCellPGPort {VDD_SW}   \
+            $vars(results_dir)/$vars(design).lvs.v
+
+
+

--- a/mflowgen/common/power-domains/outputs/pe-add-endcaps-welltaps-setup.tcl
+++ b/mflowgen/common/power-domains/outputs/pe-add-endcaps-welltaps-setup.tcl
@@ -1,5 +1,4 @@
 
-
 #-------------------------------------------------------------------------
 # Endcap and well tap specification
 #-------------------------------------------------------------------------
@@ -9,31 +8,53 @@
 # locations/orientations, which the foundation flow does not natively support
 
 if {[expr {$ADK_END_CAP_CELL == ""} && {$ADK_WELL_TAP_CELL == ""}]} {
-    
+
     deleteInst *TAP*
     deleteInst *ENDCAP*
-    deleteInst *tap* 
+    deleteInst *tap*
 
-    set flatten_effort $::env(flatten_effort) 
-    set edge_offset    12.91
+    # Align tap cells with M3 pitch so that the M1 VPP pin is directly aligned with the M3 VDD net
 
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_1
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_2
-    
-    placeInstance top_endcap_tap_1 -fixed [expr $edge_offset + 0*28      ] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
-    placeInstance top_endcap_tap_2 -fixed [expr $edge_offset + 1*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
-    
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_1
-    addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_2
-    
-    placeInstance bot_endcap_tap_1 -fixed [expr $edge_offset + 0*28      ] $polypitch_y 
-    placeInstance bot_endcap_tap_2 -fixed [expr $edge_offset + 1*28 + 1.4] $polypitch_y 
+    # Get M3 min width and signal routing pitch as defined in the LEF
 
-    if [expr $flatten_effort == 0] {
-       addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst top_endcap_tap_3
-       placeInstance top_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
-       addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst bot_endcap_tap_3
-       placeInstance bot_endcap_tap_3 -fixed [expr $edge_offset + 2*28 + 1.4] $polypitch_y
-    }
-} 
+    set M3_min_width    [dbGet [dbGetLayerByZ 3].minWidth]
+    set M3_route_pitchX [dbGet [dbGetLayerByZ 3].pitchX]
+
+    # Set M3 stripe variables
+
+    set M3_str_width            [expr  3 * $M3_min_width]
+    set M3_str_pitch            [expr 10 * $M3_route_pitchX]
+
+    set M3_str_intraset_spacing [expr ($M3_str_pitch - 2*$M3_str_width)/2]
+    set M3_str_interset_pitch   [expr 2*$M3_str_pitch]
+    set M3_str_offset           [expr $M3_str_pitch + $M3_route_pitchX/2 - $M3_str_width/2]
+    
+    # Aligned with M3 power straps
+    # If ordering of the power straps change, the multiplication factor needs to change  
+    set edge_offset [expr $M3_str_offset + ($M3_str_intraset_spacing + $M3_str_width)*28]
+    
+    # Align with power switches pitch 
+    set pitch_offset 20
+    
+    # Right edge offset to cell is not placed
+    # too close to the right edge of the tile
+    #set right_edge_offset [expr $pitch_offset + 5] 
+    set right_edge_offset 10 
+    set tap_cell_cnt [expr floor(([dbGet top.fPlan.coreBox_urx] - $right_edge_offset) / $pitch_offset)]  
+    
+    set i 0
+    while {$i < $tap_cell_cnt} {
+       set cell_name_top endcap_tap_top_${i}
+       addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst $cell_name_top 
+       placeInstance $cell_name_top -fixed [expr $edge_offset + $i*$pitch_offset*$M3_str_interset_pitch ] [expr [dbGet top.fplan.coreBox_ury] - $polypitch_y]
+      
+       set cell_name_bot endcap_tap_bot_${i}
+       addInst -cell BOUNDARY_PTAPBWP16P90_VPP_VSS -inst $cell_name_bot
+       placeInstance $cell_name_bot -fixed [expr $edge_offset + $i*$pitch_offset*$M3_str_interset_pitch ]  $polypitch_y
+ 
+       set i [expr $i + 1]
+     }
+
+}
+
 


### PR DESCRIPTION
This PR includes following updates:
- VDD_SW M8 stripe is pulled back such that it's not abutted across tiles, so every tile can be individually turned on/off
- LVS Softcheck fixes for PE/memory tile for unconnected tap cells substrate
- Update LVS netlist generation to remove VDD_SW port from top PG ports
- DRCs are random DRCs
- LVS is clean

