### PR TITLE
fixes for full_chip lvs

### DIFF
--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -157,9 +157,11 @@ def construct():
 
   # Need extracted spice files for both tile types to do LVS
 
-  lvs.extend_inputs( ['tile_array.schematic.spi'] )
-  lvs.extend_inputs( ['glb_top.schematic.spi'] )
-  lvs.extend_inputs( ['global_controller.schematic.spi'] )
+  lvs.extend_inputs( ['tile_array.lvs.v'] )
+  lvs.extend_inputs( ['tile_array.sram.spi'] )
+  lvs.extend_inputs( ['glb_top.lvs.v'] )
+  lvs.extend_inputs( ['glb_top.sram.spi'] )
+  lvs.extend_inputs( ['global_controller.lvs.v'] )
   lvs.extend_inputs( ['sram.spi'] )
 
   # Add extra input edges to innovus steps that need custom tweaks

--- a/mflowgen/full_chip/glb_top/get_glb_top_outputs.sh
+++ b/mflowgen/full_chip/glb_top/get_glb_top_outputs.sh
@@ -10,5 +10,6 @@ cp -L *cadence-innovus-signoff/outputs/design.lef outputs/glb_top.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/glb_top.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/glb_top.sdf
 cp -L *mentor-calibre-gdsmerge/outputs/design_merged.gds outputs/glb_top.gds
-cp -L *mentor-calibre-lvs/outputs/design.schematic.spi outputs/glb_top.schematic.spi
+cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/glb_top.lvs.v
+cp -L *glb_tile/outputs/sram.spi outputs/glb_top.sram.spi
 

--- a/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
+++ b/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
@@ -10,5 +10,5 @@ cp -L *cadence-innovus-signoff/outputs/design.lef outputs/global_controller.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/global_controller.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/global_controller.sdf
 cp -L *mentor-calibre-gdsmerge/outputs/design_merged.gds outputs/global_controller.gds
-cp -L *mentor-calibre-lvs/outputs/design.schematic.spi outputs/global_controller.schematic.spi
+cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/global_controller.lvs.v
 

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -10,5 +10,6 @@ cp -L *cadence-innovus-signoff/outputs/design.lef outputs/tile_array.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/tile_array.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/tile_array.sdf
 cp -L *mentor-calibre-gdsmerge/outputs/design_merged.gds outputs/tile_array.gds
-cp -L *mentor-calibre-lvs/outputs/design.schematic.spi outputs/tile_array.schematic.spi
+cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/tile_array.lvs.v
+cp -L *Tile_MemCore/outputs/sram.spi outputs/tile_array.sram.spi
 

--- a/mflowgen/glb_top/glb_tile/get_glb_outputs.sh
+++ b/mflowgen/glb_top/glb_tile/get_glb_outputs.sh
@@ -7,7 +7,7 @@ mkdir -p outputs
 cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/glb_tile_tt.lib
 cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/glb_tile.db
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/glb_tile.lef
-cp -L *cadence-innovus-signoff/outputs/design.lvs.v outputs/glb_tile.lvs.v
 cp -L *mentor-calibre-gdsmerge/outputs/design_merged.gds outputs/glb_tile.gds
+cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/glb_tile.lvs.v
 cp -L *gen_sram_macro/outputs/sram.spi outputs/sram.spi
 

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -8,8 +8,8 @@ cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/Tile_MemCore_tt.lib
 cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/Tile_MemCore.db
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/Tile_MemCore.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/Tile_MemCore.vcs.v
-cp -L *cadence-innovus-signoff/outputs/design.lvs.v outputs/Tile_MemCore.lvs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/Tile_MemCore.sdf
 cp -L *mentor-calibre-gdsmerge/outputs/design_merged.gds outputs/Tile_MemCore.gds
+cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/Tile_MemCore.lvs.v
 cp -L *gen_sram_macro/outputs/sram.spi outputs/sram.spi
 

--- a/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
+++ b/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
@@ -8,7 +8,7 @@ cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/Tile_PE_tt.lib
 cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/Tile_PE.db
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/Tile_PE.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/Tile_PE.vcs.v
-cp -L *cadence-innovus-signoff/outputs/design.lvs.v outputs/Tile_PE.lvs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/Tile_PE.sdf
 cp -L *mentor-calibre-gdsmerge/outputs/design_merged.gds outputs/Tile_PE.gds
+cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/Tile_PE.lvs.v
 


### PR DESCRIPTION
- Use verilog instead of spice from blocks to avoid the single-bit bus issues we dealt with before
- Pass the SRAM spice for the blocks up to the top level