### PR TITLE
RTL changes in global buffer to meet timing.

### DIFF
--- a/global_buffer/rtl/glb_bank.sv
+++ b/global_buffer/rtl/glb_bank.sv
@@ -10,7 +10,6 @@ import global_buffer_param::*;
 
 module glb_bank (
     input  logic                        clk,
-    input  logic                        clk_en,
     input  logic                        reset,
 
     input  wr_packet_t                  wr_packet,

--- a/global_buffer/rtl/glb_bank_ctrl.sv
+++ b/global_buffer/rtl/glb_bank_ctrl.sv
@@ -43,31 +43,29 @@ module glb_bank_ctrl  (
 //===========================================================================//
 // packet
 logic                       packet_rd_en_d1, packet_rd_en_d2;
-logic                       packet_wr_en_d1, packet_wr_en_d2;
 // packet_sel_t                packet_rdrq_packet_sel_d1, packet_rdrq_packet_sel_d2;
 logic [BANK_DATA_WIDTH-1:0] packet_rd_data_d1;
 
 // sram cfg
 logic                       cfg_rd_en_d1, cfg_rd_en_d2;
-logic                       cfg_wr_en_d1, cfg_wr_en_d2;
 logic                       cfg_sram_rd_addr_mux_d1, cfg_sram_rd_addr_mux_d2;
 logic [BANK_DATA_WIDTH-1:0] cfg_sram_rd_data, cfg_sram_rd_data_d1;
 
 // internal mem
 logic                       internal_mem_rd_en, internal_mem_rd_en_d1, internal_mem_rd_en_d2;
-logic                       internal_mem_wr_en, internal_mem_wr_en_d1;
-logic [BANK_ADDR_WIDTH-1:0] internal_mem_addr, internal_mem_addr_d1;
-logic [BANK_DATA_WIDTH-1:0] internal_mem_data_in, internal_mem_data_in_d1;
-logic [BANK_DATA_WIDTH-1:0] internal_mem_data_in_bit_sel, internal_mem_data_in_bit_sel_d1;
+logic                       internal_mem_wr_en;
+logic [BANK_ADDR_WIDTH-1:0] internal_mem_addr;
+logic [BANK_DATA_WIDTH-1:0] internal_mem_data_in;
+logic [BANK_DATA_WIDTH-1:0] internal_mem_data_in_bit_sel;
 
 //===========================================================================//
 // output assignment
 //===========================================================================//
-assign mem_wr_en = internal_mem_wr_en_d1;
-assign mem_rd_en = internal_mem_rd_en_d1;
-assign mem_data_in_bit_sel = internal_mem_data_in_bit_sel_d1;
-assign mem_data_in = internal_mem_data_in_d1;
-assign mem_addr = internal_mem_addr_d1;
+assign mem_wr_en = internal_mem_wr_en;
+assign mem_rd_en = internal_mem_rd_en;
+assign mem_data_in_bit_sel = internal_mem_data_in_bit_sel;
+assign mem_data_in = internal_mem_data_in;
+assign mem_addr = internal_mem_addr;
 
 //===========================================================================//
 // Set mem_wr_en and mem_data_in output
@@ -119,51 +117,26 @@ always_comb begin
     end
 end
 
-//===========================================================================//
-// pipeline register
-//===========================================================================//
-always_ff @(posedge clk or posedge reset) begin
-    if (reset) begin
-        internal_mem_wr_en_d1 <= 0;
-        internal_mem_data_in_bit_sel_d1 <= '0;
-        internal_mem_rd_en_d1 <= 0;
-        internal_mem_data_in_d1 <= '0;
-        internal_mem_addr_d1 <= '0;
-    end
-    else begin
-        internal_mem_wr_en_d1 <= internal_mem_wr_en;
-        internal_mem_data_in_bit_sel_d1 <= internal_mem_data_in_bit_sel;
-        internal_mem_rd_en_d1 <= internal_mem_rd_en;
-        internal_mem_data_in_d1 <= internal_mem_data_in;
-        internal_mem_addr_d1 <= internal_mem_addr;
-    end
-end
 
 //===========================================================================//
 // packet assignment
 //===========================================================================//
 always_ff @(posedge clk or posedge reset) begin
     if (reset) begin
+        internal_mem_rd_en_d1 <= 0;
         internal_mem_rd_en_d2 <= 0;
         cfg_rd_en_d1 <= 0;
         cfg_rd_en_d2 <= 0;
-        cfg_wr_en_d1 <= 0;
-        cfg_wr_en_d2 <= 0;
-        packet_wr_en_d1 <= 0;
-        packet_wr_en_d2 <= 0;
         packet_rd_en_d1 <= 0;
         packet_rd_en_d2 <= 0;
         // packet_rdrq_packet_sel_d1 <= '0;
         // packet_rdrq_packet_sel_d2 <= '0;
     end
     else begin
+        internal_mem_rd_en_d1 <= internal_mem_rd_en;
         internal_mem_rd_en_d2 <= internal_mem_rd_en_d1;
         cfg_rd_en_d1 <= if_sram_cfg.rd_en;
         cfg_rd_en_d2 <= cfg_rd_en_d1;
-        cfg_wr_en_d1 <= if_sram_cfg.wr_en;
-        cfg_wr_en_d2 <= cfg_wr_en_d1;
-        packet_wr_en_d1 <= packet_wr_en;
-        packet_wr_en_d2 <= packet_wr_en_d1;
         packet_rd_en_d1 <= packet_rd_en;
         packet_rd_en_d2 <= packet_rd_en_d1;
         // packet_rdrq_packet_sel_d1 <= packet_rdrq_packet_sel;
@@ -181,7 +154,6 @@ always_ff @(posedge clk or posedge reset) begin
     end
 end
 
-// assign packet_rd_data = (internal_mem_rd_en_d2 & packet_rd_en_d2 & ~cfg_wr_en_d2 & ~cfg_rd_en_d2 & ~packet_wr_en_d2) ? mem_data_out : packet_rd_data_d1;
 // just assumes proc/cfg/packet do not write at the same time
 assign packet_rd_data = packet_rd_en_d2 ? mem_data_out : packet_rd_data_d1;
 assign packet_rd_data_valid = packet_rd_en_d2;

--- a/global_buffer/rtl/glb_bank_memory.sv
+++ b/global_buffer/rtl/glb_bank_memory.sv
@@ -31,6 +31,7 @@ logic [BANK_DATA_WIDTH-1:0]                     sram_data_in;
 logic [BANK_DATA_WIDTH-1:0]                     sram_bit_sel;
 logic [BANK_DATA_WIDTH-1:0]                     sram_data_out;
 logic                                           sram_ren_d1;
+logic                                           sram_ren_d2;
 logic [BANK_DATA_WIDTH-1:0]                     data_out_d1;
 
 //===========================================================================//
@@ -67,13 +68,15 @@ end
 always_ff @(posedge clk or posedge reset) begin
     if (reset) begin
         sram_ren_d1 <= 0;
+        sram_ren_d2 <= 0;
         data_out_d1 <= 0;
     end
     else begin
         sram_ren_d1 <= sram_ren;
+        sram_ren_d2 <= sram_ren_d1;
         data_out_d1 <= data_out;
     end
 end
-assign data_out = sram_ren_d1 ? sram_data_out : data_out_d1;
+assign data_out = sram_ren_d2 ? sram_data_out : data_out_d1;
 
 endmodule

--- a/global_buffer/rtl/glb_bank_sram_gen.sv
+++ b/global_buffer/rtl/glb_bank_sram_gen.sv
@@ -53,15 +53,34 @@ always_ff @ (posedge CLK) begin
     end
 end
 
+// pipeline registers
+// always_ff @(posedge CLK) begin
+//     D_d1 <= D;
+// end
+// 
+// always_ff @(posedge CLK) begin
+//     WEB_array_d1 <= WEB_array;
+// end
+// 
+// always_ff @(posedge CLK) begin
+//     A_to_mem_d1 <= A_to_mem;
+// end
+// 
+// always_ff @(posedge CLK) begin
+//     CEB_d1 <= CEB;
+// end
+// 
+// always_ff @(posedge CLK) begin
+//     BWEB_d1 <= BWEB;
+// end
+
 //Use parameters to decide which width of memory to instantiate and how many
 genvar i;
 generate
     for (i = 0; i < NUM_INST; i = i + 1) begin
         logic [63:0] Q_temp;
-        logic [63:0] D_stretch;
         TS1N16FFCLLSBLVTC2048X64M8SW
-        sram_array (.CLK(CLK), .A(A_to_mem), .BWEB(BWEB), .CEB(CEB), .WEB(WEB_array[i]), .D(D_stretch), .Q(Q_temp), .RTSEL(2'b01), .WTSEL(2'b00));
-        assign D_stretch = D;
+        sram_array (.CLK(CLK), .A(A_to_mem), .BWEB(BWEB), .CEB(CEB), .WEB(WEB_array[i]), .D(D), .Q(Q_temp), .RTSEL(2'b01), .WTSEL(2'b00));
         assign Q_array[i] = Q_temp[DATA_WIDTH-1:0];
     end
 endgenerate

--- a/global_buffer/rtl/glb_bank_sram_gen.sv
+++ b/global_buffer/rtl/glb_bank_sram_gen.sv
@@ -45,34 +45,52 @@ assign WEB_array = (~WEB) ? ~(1 << mem_select) : ~0;
 assign Q = data_out;
 assign data_out = Q_array[output_select];
 
+// pipeline registers
+logic                   CEB_d1;
+logic                   WEB_d1;
+logic [DATA_WIDTH-1:0]  BWEB_d1;
+logic [DATA_WIDTH-1:0]  D_d1;
+logic [NUM_INST-1:0]    WEB_array_d1;
+logic [ADDR_WIDTH-PER_MEM_ADDR_WIDTH-1:0] mem_select_d1;
+logic [PER_MEM_ADDR_WIDTH-1:0] A_to_mem_d1;
+
+
+always_ff @(posedge CLK) begin
+    WEB_d1 <= WEB;
+end
+
 always_ff @ (posedge CLK) begin
-    if (CEB == 0) begin
-        if (WEB == 1) begin
-            output_select <= mem_select;
+    if (CEB_d1 == 0) begin
+        if (WEB_d1 == 1) begin
+            output_select <= mem_select_d1;
         end
     end
 end
 
+always_ff @(posedge CLK) begin
+    mem_select_d1 <= mem_select;
+end
+
 // pipeline registers
-// always_ff @(posedge CLK) begin
-//     D_d1 <= D;
-// end
-// 
-// always_ff @(posedge CLK) begin
-//     WEB_array_d1 <= WEB_array;
-// end
-// 
-// always_ff @(posedge CLK) begin
-//     A_to_mem_d1 <= A_to_mem;
-// end
-// 
-// always_ff @(posedge CLK) begin
-//     CEB_d1 <= CEB;
-// end
-// 
-// always_ff @(posedge CLK) begin
-//     BWEB_d1 <= BWEB;
-// end
+always_ff @(posedge CLK) begin
+    D_d1 <= D;
+end
+
+always_ff @(posedge CLK) begin
+    WEB_array_d1 <= WEB_array;
+end
+
+always_ff @(posedge CLK) begin
+    A_to_mem_d1 <= A_to_mem;
+end
+
+always_ff @(posedge CLK) begin
+    CEB_d1 <= CEB;
+end
+
+always_ff @(posedge CLK) begin
+    BWEB_d1 <= BWEB;
+end
 
 //Use parameters to decide which width of memory to instantiate and how many
 genvar i;
@@ -80,7 +98,7 @@ generate
     for (i = 0; i < NUM_INST; i = i + 1) begin
         logic [63:0] Q_temp;
         TS1N16FFCLLSBLVTC2048X64M8SW
-        sram_array (.CLK(CLK), .A(A_to_mem), .BWEB(BWEB), .CEB(CEB), .WEB(WEB_array[i]), .D(D), .Q(Q_temp), .RTSEL(2'b01), .WTSEL(2'b00));
+        sram_array (.CLK(CLK), .A(A_to_mem_d1), .BWEB(BWEB_d1), .CEB(CEB_d1), .WEB(WEB_array_d1[i]), .D(D_d1), .Q(Q_temp), .RTSEL(2'b01), .WTSEL(2'b00));
         assign Q_array[i] = Q_temp[DATA_WIDTH-1:0];
     end
 endgenerate

--- a/global_buffer/rtl/glb_core_load_dma.sv
+++ b/global_buffer/rtl/glb_core_load_dma.sv
@@ -269,7 +269,12 @@ always_comb begin
             strm_active_next = 1;
         end
         else if (num_inactive_words_internal == '0) begin
-            strm_active_next = 1;
+            if (last_strm) begin
+                strm_active_next = 0;
+            end
+            else begin
+                strm_active_next = 1;
+            end
         end
         else begin
             if (strm_active) begin
@@ -365,7 +370,6 @@ always_comb begin
     for (int i=0; i<LOOP_LEVEL; i=i+1) begin
         last_strm = last_strm & ((iter_internal[i].range == 0) | (itr[i] == iter_internal[i].range - 1));
     end
-    last_strm = last_strm & (strm_inactive_cnt == '0);
 end
 
 // done pulse internal

--- a/global_buffer/rtl/glb_core_pc_dma.sv
+++ b/global_buffer/rtl/glb_core_pc_dma.sv
@@ -60,7 +60,7 @@ logic rd_data_valid_next, rd_data_valid_internal;
 always_comb begin
     pc_done_pulse = 0;
     for (int i=0; i < INTERRUPT_PULSE; i=i+1) begin
-        pc_done_pulse = pc_done_pulse | done_pulse_internal_d_arr[FIXED_LATENCY+3*cfg_pc_latency+i];
+        pc_done_pulse = pc_done_pulse | done_pulse_internal_d_arr[FIXED_LATENCY +cfg_pc_latency+i + NUM_GLB_TILES];
     end
 end
 assign rdrq_packet.rd_en = rd_en_internal;

--- a/global_buffer/rtl/glb_core_pc_dma.sv
+++ b/global_buffer/rtl/glb_core_pc_dma.sv
@@ -38,13 +38,14 @@ module glb_core_pc_dma (
 //============================================================================//
 localparam int BANK_DATA_BYTE = ((BANK_DATA_WIDTH + 8 - 1)/8); //8
 localparam int FIXED_LATENCY = 7;
+localparam int INTERRUPT_PULSE = 4;
 
 //============================================================================//
 // Internal logic
 //============================================================================//
 logic start_pulse_next, start_pulse_internal;
 logic done_pulse_next, done_pulse_internal;
-logic done_pulse_internal_d_arr [3*NUM_GLB_TILES + FIXED_LATENCY];
+logic done_pulse_internal_d_arr [3*NUM_GLB_TILES + FIXED_LATENCY + INTERRUPT_PULSE];
 logic pc_run_next, pc_run;
 logic [MAX_NUM_CFGS_WIDTH-1:0] cfg_cnt_next, cfg_cnt_internal;
 logic [GLB_ADDR_WIDTH-1:0] addr_next, addr_internal;
@@ -56,7 +57,12 @@ logic rd_data_valid_next, rd_data_valid_internal;
 //============================================================================//
 // assigns
 //============================================================================//
-assign pc_done_pulse = done_pulse_internal_d_arr[3*cfg_pc_latency + FIXED_LATENCY];
+always_comb begin
+    pc_done_pulse = 0;
+    for (int i=0; i < INTERRUPT_PULSE; i=i+1) begin
+        pc_done_pulse = pc_done_pulse | done_pulse_internal_d_arr[FIXED_LATENCY+3*cfg_pc_latency+i];
+    end
+end
 assign rdrq_packet.rd_en = rd_en_internal;
 assign rdrq_packet.rd_addr = rd_addr_internal;
 // assign rdrq_packet.packet_sel.packet_type = PSEL_PCFG;
@@ -195,7 +201,7 @@ end
 
 // done pulse pipeline
 // parallel configuration is not stalled
-glb_shift #(.DATA_WIDTH(1), .DEPTH(3*NUM_GLB_TILES+FIXED_LATENCY)
+glb_shift #(.DATA_WIDTH(1), .DEPTH(3*NUM_GLB_TILES+FIXED_LATENCY+INTERRUPT_PULSE)
 ) glb_shift_done_pulse (
     .data_in(done_pulse_internal),
     .data_out(done_pulse_internal_d_arr),

--- a/global_buffer/rtl/glb_core_proc_router.sv
+++ b/global_buffer/rtl/glb_core_proc_router.sv
@@ -70,15 +70,21 @@ end
 //============================================================================//
 // request packet
 //============================================================================//
-assign packet_w2e_esto.wr = (is_even == 1'b1)
-                          ? packet_w2e_wsti_d1.wr : packet_w2e_wsti.wr;
-assign packet_e2w_wsto.wr = (is_even == 1'b0) 
-                          ? packet_e2w_esti_d1.wr : packet_e2w_esti.wr;
+// assign packet_w2e_esto.wr = (is_even == 1'b1)
+//                           ? packet_w2e_wsti_d1.wr : packet_w2e_wsti.wr;
+// assign packet_e2w_wsto.wr = (is_even == 1'b0) 
+//                           ? packet_e2w_esti_d1.wr : packet_e2w_esti.wr;
+// 
+// assign packet_w2e_esto.rdrq = (is_even == 1'b1)
+//                             ? packet_w2e_wsti_d1.rdrq : packet_w2e_wsti.rdrq;
+// assign packet_e2w_wsto.rdrq = (is_even == 1'b0)
+//                             ? packet_e2w_esti_d1.rdrq : packet_e2w_esti.rdrq;
 
-assign packet_w2e_esto.rdrq = (is_even == 1'b1)
-                            ? packet_w2e_wsti_d1.rdrq : packet_w2e_wsti.rdrq;
-assign packet_e2w_wsto.rdrq = (is_even == 1'b0)
-                            ? packet_e2w_esti_d1.rdrq : packet_e2w_esti.rdrq;
+assign packet_w2e_esto.wr = packet_w2e_wsti_d1.wr;
+assign packet_e2w_wsto.wr = packet_e2w_esti_d1.wr;
+
+assign packet_w2e_esto.rdrq = packet_w2e_wsti_d1.rdrq;
+assign packet_e2w_wsto.rdrq = packet_e2w_esti_d1.rdrq;
 
 // packet router to core
 assign wr_packet_pr2sw = (is_even == 1'b1)
@@ -90,20 +96,25 @@ assign rdrq_packet_pr2sw = (is_even == 1'b1)
 // response packet
 //============================================================================//
 // packet core to router switch
+// assign packet_w2e_esto.rdrs = (is_even == 1'b1)
+//                         ? (rdrs_packet_sw2pr_d1.rd_data_valid == 1) 
+//                         ? rdrs_packet_sw2pr_d1 : packet_w2e_wsti_d1.rdrs
+//                         : packet_w2e_wsti.rdrs;
+// 
+// assign packet_e2w_wsto.rdrs = (is_even == 1'b0)
+//                         ? (rdrs_packet_sw2pr_d1.rd_data_valid == 1) 
+//                         ? rdrs_packet_sw2pr_d1 : packet_e2w_esti_d1.rdrs
+//                         : packet_e2w_esti.rdrs;
+
+
 assign packet_w2e_esto.rdrs = (is_even == 1'b1)
                         ? (rdrs_packet_sw2pr_d1.rd_data_valid == 1) 
                         ? rdrs_packet_sw2pr_d1 : packet_w2e_wsti_d1.rdrs
-                        : packet_w2e_wsti.rdrs;
+                        : packet_w2e_wsti_d1.rdrs;
 
 assign packet_e2w_wsto.rdrs = (is_even == 1'b0)
                         ? (rdrs_packet_sw2pr_d1.rd_data_valid == 1) 
                         ? rdrs_packet_sw2pr_d1 : packet_e2w_esti_d1.rdrs
-                        : packet_e2w_esti.rdrs;
-
-// assign packet_w2e_esto.rdrs = (rdrs_packet_sw2pr_d1.rd_data_valid == 1) 
-//                             ? rdrs_packet_sw2pr_d1 : packet_w2e_wsti_d1.rdrs;
-// 
-// assign packet_e2w_wsto.rdrs = (rdrs_packet_sw2pr_d1.rd_data_valid == 1) 
-//                             ? rdrs_packet_sw2pr_d1 : packet_e2w_esti_d1.rdrs;
+                        : packet_e2w_esti_d1.rdrs;
 
 endmodule

--- a/global_buffer/rtl/glb_core_store_dma.sv
+++ b/global_buffer/rtl/glb_core_store_dma.sv
@@ -58,8 +58,6 @@ logic [BANK_DATA_WIDTH-1:0]     cache_data, next_cache_data;
 logic [BANK_DATA_WIDTH/8-1:0]   cache_strb, next_cache_strb;
 
 // working dma header register
-logic [GLB_ADDR_WIDTH-1:0]      start_addr;
-logic [MAX_NUM_WORDS_WIDTH-1:0] num_words;
 logic [$clog2(QUEUE_DEPTH)-1:0] q_sel_cnt_r, q_sel_cnt;
 
 // dma control logic

--- a/global_buffer/rtl/glb_tile.sv
+++ b/global_buffer/rtl/glb_tile.sv
@@ -10,7 +10,7 @@ import global_buffer_param::*;
 
 module glb_tile (
     input  logic                                                clk,
-    input  logic                                                stall,
+    input  logic                                                clk_en,
     input  logic                                                cgra_stall_in,
     input  logic                                                reset,
     input  logic [TILE_SEL_ADDR_WIDTH-1:0]                      glb_tile_id,

--- a/global_buffer/rtl/glb_tile.sv
+++ b/global_buffer/rtl/glb_tile.sv
@@ -11,7 +11,6 @@ import global_buffer_param::*;
 module glb_tile (
     input  logic                                                clk,
     input  logic                                                clk_en,
-    input  logic                                                cgra_stall_in,
     input  logic                                                reset,
     input  logic [TILE_SEL_ADDR_WIDTH-1:0]                      glb_tile_id,
 
@@ -230,8 +229,6 @@ module glb_tile (
 
     // soft reset
     input  logic                                                cgra_soft_reset,
-
-    output logic [CGRA_PER_GLB-1:0]                             cgra_stall,
 
     // trigger
     input  logic                                                strm_start_pulse,

--- a/global_buffer/rtl/glb_tile_cfg_ctrl.sv
+++ b/global_buffer/rtl/glb_tile_cfg_ctrl.sv
@@ -121,23 +121,23 @@ always_ff @(posedge clk or posedge reset) begin
         if_cfg_est_m.wr_data <= '0;
     end
     // optional
-    else if (if_cfg_wst_s.wr_clk_en)  begin
-        if (if_cfg_wst_s.wr_en == 1'b1 && !wr_tile_id_match) begin
-            if_cfg_est_m.wr_en <= if_cfg_wst_s.wr_en;
-            if_cfg_est_m.wr_addr <= if_cfg_wst_s.wr_addr;
-            if_cfg_est_m.wr_data <= if_cfg_wst_s.wr_data;
-        end
-        else begin
-            if_cfg_est_m.wr_en <= 0;
-            if_cfg_est_m.wr_addr <= '0;
-            if_cfg_est_m.wr_data <= '0;
-        end
+    // else if (if_cfg_wst_s.wr_clk_en)  begin
+    if (if_cfg_wst_s.wr_en == 1'b1 && !wr_tile_id_match) begin
+        if_cfg_est_m.wr_en <= if_cfg_wst_s.wr_en;
+        if_cfg_est_m.wr_addr <= if_cfg_wst_s.wr_addr;
+        if_cfg_est_m.wr_data <= if_cfg_wst_s.wr_data;
     end
     else begin
         if_cfg_est_m.wr_en <= 0;
         if_cfg_est_m.wr_addr <= '0;
         if_cfg_est_m.wr_data <= '0;
     end
+    // end
+    // else begin
+    //     if_cfg_est_m.wr_en <= 0;
+    //     if_cfg_est_m.wr_addr <= '0;
+    //     if_cfg_est_m.wr_data <= '0;
+    // end
 end
 always_ff @(negedge clk or posedge reset) begin
     if (reset) begin
@@ -155,20 +155,20 @@ always_ff @(posedge clk or posedge reset) begin
         if_cfg_est_m.rd_addr <= '0;
     end
     // optional
-    else if (if_cfg_wst_s.rd_clk_en)  begin
-        if (if_cfg_wst_s.rd_en == 1'b1 && !rd_tile_id_match) begin
-            if_cfg_est_m.rd_en <= if_cfg_wst_s.rd_en;
-            if_cfg_est_m.rd_addr <= if_cfg_wst_s.rd_addr;
-        end
-        else begin
-            if_cfg_est_m.rd_en <= 0;
-            if_cfg_est_m.rd_addr <= '0;
-        end
+    // else if (if_cfg_wst_s.rd_clk_en)  begin
+    if (if_cfg_wst_s.rd_en == 1'b1 && !rd_tile_id_match) begin
+        if_cfg_est_m.rd_en <= if_cfg_wst_s.rd_en;
+        if_cfg_est_m.rd_addr <= if_cfg_wst_s.rd_addr;
     end
     else begin
         if_cfg_est_m.rd_en <= 0;
         if_cfg_est_m.rd_addr <= '0;
     end
+    // end
+    // else begin
+    //     if_cfg_est_m.rd_en <= 0;
+    //     if_cfg_est_m.rd_addr <= '0;
+    // end
 end
 
 always_ff @(negedge clk or posedge reset) begin

--- a/global_buffer/rtl/glb_tile_int.sv
+++ b/global_buffer/rtl/glb_tile_int.sv
@@ -10,7 +10,7 @@ import global_buffer_param::*;
 
 module glb_tile_int (
     input  logic                            clk,
-    input  logic                            stall,
+    input  logic                            clk_en,
     input  logic                            cgra_stall_in,
     input  logic                            reset,
     input  logic [TILE_SEL_ADDR_WIDTH-1:0]  glb_tile_id,
@@ -121,19 +121,8 @@ assign cfg_pc_tile_connected_esto = cfg_pc_tile_connected_next;
 assign cfg_pc_tile_connected_prev = cfg_pc_tile_connected_wsti;
 
 //============================================================================//
-// pipeline registers for stall
+// pipeline registers for cgra stall
 //============================================================================//
-logic stall_d1, clk_en;
-always_ff @(posedge clk or posedge reset) begin
-    if (reset) begin
-        stall_d1 <= 0;
-    end
-    else begin
-        stall_d1 <= stall;
-    end
-end
-assign clk_en = !stall_d1;
-
 logic [CGRA_PER_GLB-1:0] cgra_stall_d1;
 always_ff @(posedge clk or posedge reset) begin
     if (reset) begin

--- a/global_buffer/rtl/glb_tile_int.sv
+++ b/global_buffer/rtl/glb_tile_int.sv
@@ -11,7 +11,6 @@ import global_buffer_param::*;
 module glb_tile_int (
     input  logic                            clk,
     input  logic                            clk_en,
-    input  logic                            cgra_stall_in,
     input  logic                            reset,
     input  logic [TILE_SEL_ADDR_WIDTH-1:0]  glb_tile_id,
 
@@ -32,9 +31,6 @@ module glb_tile_int (
     output rd_packet_t                      pc_packet_e2w_wsto,
     input  rd_packet_t                      pc_packet_e2w_esti,
     output rd_packet_t                      pc_packet_w2e_esto,
-
-    // cgra stall
-    output logic [CGRA_PER_GLB-1:0]         cgra_stall,
 
     // stream data
     input  logic [CGRA_DATA_WIDTH-1:0]      stream_data_f2g [CGRA_PER_GLB],
@@ -119,22 +115,6 @@ assign cfg_tile_connected_esto = cfg_tile_connected_next;
 assign cfg_tile_connected_prev = cfg_tile_connected_wsti;
 assign cfg_pc_tile_connected_esto = cfg_pc_tile_connected_next;
 assign cfg_pc_tile_connected_prev = cfg_pc_tile_connected_wsti;
-
-//============================================================================//
-// pipeline registers for cgra stall
-//============================================================================//
-logic [CGRA_PER_GLB-1:0] cgra_stall_d1;
-always_ff @(posedge clk or posedge reset) begin
-    if (reset) begin
-        cgra_stall_d1 <= '0;
-    end
-    else begin
-        for (int i=0; i<CGRA_PER_GLB; i=i+1) begin
-            cgra_stall_d1[i] <= cgra_stall_in;
-        end
-    end
-end
-assign cgra_stall = cgra_stall_d1;
 
 //============================================================================//
 // pipeline registers for start_pulse

--- a/global_buffer/rtl/global_buffer.sv
+++ b/global_buffer/rtl/global_buffer.sv
@@ -178,7 +178,7 @@ always_ff @(posedge reset or posedge clk) begin
         cgra_cfg_g2f_cfg_addr <= '0;
         cgra_cfg_g2f_cfg_data <= '0;
     end
-    else if (clk_en) begin
+    else begin
         cgra_cfg_g2f_cfg_wr_en <= cgra_cfg_g2f_cfg_wr_en_int;
         cgra_cfg_g2f_cfg_rd_en <= cgra_cfg_g2f_cfg_rd_en_int;
         cgra_cfg_g2f_cfg_addr <= cgra_cfg_g2f_cfg_addr_int;

--- a/global_buffer/rtl/global_buffer.sv
+++ b/global_buffer/rtl/global_buffer.sv
@@ -193,7 +193,7 @@ always_ff @(posedge reset or posedge clk) begin
         stream_data_f2g_int <= '0;
         stream_data_valid_f2g_int <= '0;
     end
-    else if (clk_en) begin
+    else begin
         stream_data_f2g_int <= stream_data_f2g;
         stream_data_valid_f2g_int <= stream_data_valid_f2g;
     end
@@ -204,7 +204,7 @@ always_ff @(posedge reset or posedge clk) begin
         stream_data_g2f <= '0;
         stream_data_valid_g2f <= '0;
     end
-    else if (clk_en) begin
+    else begin
         stream_data_g2f <= stream_data_g2f_int;
         stream_data_valid_g2f <= stream_data_valid_g2f_int;
     end

--- a/global_buffer/testbench/glb_test.sv
+++ b/global_buffer/testbench/glb_test.sv
@@ -211,7 +211,7 @@ program automatic glb_test (
                 s_ifc[0].cbd.strm_start_pulse <= 1;
                 @(posedge clk);
                 s_ifc[0].cbd.strm_start_pulse <= 0;
-                repeat(13) @(posedge clk);
+                repeat(14) @(posedge clk);
 
                 data_expected = 0;
 
@@ -266,7 +266,7 @@ program automatic glb_test (
                 s_ifc[0].cbd.strm_start_pulse <= 1;
                 @(posedge clk);
                 s_ifc[0].cbd.strm_start_pulse <= 0;
-                repeat(15) @(posedge clk);
+                repeat(16) @(posedge clk);
                 data_expected = 0;
 
                 for(int i=0; i<128; i++) begin

--- a/global_buffer/testbench/glb_test.sv
+++ b/global_buffer/testbench/glb_test.sv
@@ -159,7 +159,7 @@ program automatic glb_test (
                 env.run();
             end
             begin
-                repeat(253) @(posedge clk);
+                repeat(269) @(posedge clk);
                 for (int i=0; i<128; i++) begin
                     data_expected = ((4*i+3) << 48) + ((4*i+2) << 32) + ((4*i+1) << 16) + (4*i);
                     assert(p_ifc.rd_data_valid == 1) else $error("rd_data_valid is not asserted");
@@ -195,7 +195,7 @@ program automatic glb_test (
                 env.run();
             end
             begin
-                repeat(253) @(posedge clk);
+                repeat(653) @(posedge clk);
                 for (int i=0; i<512; i++) begin
                     data_expected = ((4*i+3) << 48) + ((4*i+2) << 32) + ((4*i+1) << 16) + (4*i);
                     assert(p_ifc.rd_data_valid == 1) else $error("rd_data_valid is not asserted");
@@ -383,7 +383,7 @@ program automatic glb_test (
                 env.run();
             end
             begin
-                repeat(140) @(posedge clk);
+                repeat(156) @(posedge clk);
                 for (int i=0; i<128; i++) begin
                     data_expected = ((4*i+3) << 48) + ((4*i+2) << 32) + ((4*i+1) << 16) + (4*i);
                     assert(p_ifc.rd_data_valid == 1) else $error("rd_data_valid is not asserted");

--- a/global_buffer/testbench/glb_test.sv
+++ b/global_buffer/testbench/glb_test.sv
@@ -281,10 +281,11 @@ program automatic glb_test (
         
         my_trans_c[0] = new(0, 'h00, 'h55);
         my_trans_c[1] = new(0, 'h3c, (2**(BANK_ADDR_WIDTH+1))-128);
-        my_trans_c[2] = new(0, 'h44, 'h200400);
-        my_trans_c[3] = new(0, 'h48, 'h0);
-        my_trans_c[4] = new(0, 'h38, 'h1);
-        my_trans_c[5] = new(0, 'h04, 'h2);
+        my_trans_c[2] = new(0, 'h40, 'h0);
+        my_trans_c[3] = new(0, 'h44, 'h200400);
+        my_trans_c[4] = new(0, 'h48, 'h0);
+        my_trans_c[5] = new(0, 'h38, 'h1);
+        my_trans_c[6] = new(0, 'h04, 'h2);
 
         foreach(my_trans_p[i])
             seq.add(my_trans_p[i]);
@@ -306,18 +307,14 @@ program automatic glb_test (
                 data_expected = 0;
 
                 for(int i=0; i<128; i++) begin
-                    for (int j=0; j<10; j++) begin
-                        if (j%10 < 8) begin
-                            assert(s_ifc[0].data_valid_g2f == 1);
-                            assert(s_ifc[0].data_g2f == data_expected) else $error("data_expected: 0x%h, real_data: 0x%h", data_expected, s_ifc[0].data_g2f);
-                            data_expected++;
-                        end
-                        else begin
-                            assert(s_ifc[0].data_valid_g2f == 0);
-                        end
+                    for (int j=0; j<8; j++) begin
+                        assert(s_ifc[0].data_valid_g2f == 1);
+                        assert(s_ifc[0].data_g2f == data_expected) else $error("data_expected: 0x%h, real_data: 0x%h", data_expected, s_ifc[0].data_g2f);
+                        data_expected++;
                         @(posedge clk);
                     end
                 end
+                assert(s_ifc[0].data_valid_g2f == 0);
                 repeat(2000) @(posedge clk);
 
             end

--- a/global_buffer/testbench/glb_test.sv
+++ b/global_buffer/testbench/glb_test.sv
@@ -436,7 +436,7 @@ program automatic glb_test (
                 top.cgra_cfg_jtag_gc2glb_rd_en <= 1;
                 top.cgra_cfg_jtag_gc2glb_addr <= 'h1234;
                 top.cgra_cfg_jtag_gc2glb_data <= 'h5678;
-                repeat(2) @(posedge clk);
+                repeat(3) @(posedge clk);
                 assert(c_ifc[0].cgra_cfg_addr == 'h0000123400001234);
                 assert(c_ifc[0].cgra_cfg_rd_en == 2'b11);
                 assert(c_ifc[0].cgra_cfg_wr_en == 0);
@@ -446,7 +446,7 @@ program automatic glb_test (
                 top.cgra_cfg_jtag_gc2glb_rd_en <= 0;
                 top.cgra_cfg_jtag_gc2glb_addr <= 0;
                 top.cgra_cfg_jtag_gc2glb_data <= 0;
-                repeat(2) @(posedge clk);
+                repeat(3) @(posedge clk);
                 assert(c_ifc[0].cgra_cfg_addr == 0);
                 assert(c_ifc[0].cgra_cfg_rd_en == 0);
                 assert(c_ifc[0].cgra_cfg_wr_en == 0);
@@ -457,7 +457,7 @@ program automatic glb_test (
                 @(posedge clk);
                 c_ifc[0].pcfg_start_pulse <= 0;
 
-                repeat(59) @(posedge clk);
+                repeat(60) @(posedge clk);
                 for (int i=0; i<128; i++) begin
                     top.cgra_stall_in <= 0;
                     data_expected = ((4*i+1) << 48) + ((4*i+0) << 32) + ((4*i+1) << 16) + (4*i);

--- a/mflowgen/glb_tile/constraints/constraints.tcl
+++ b/mflowgen/glb_tile/constraints/constraints.tcl
@@ -82,11 +82,11 @@ set_multicycle_path -setup 4 -to [get_ports if_sram_cfg*wr* -filter "direction==
 set_multicycle_path -setup 4 -through [get_cells -hier if_sram_cfg*wr*]
 set_multicycle_path -setup 4 -to [get_cells -hier if_sram_cfg*wr*]
 set_multicycle_path -setup 4 -from [get_cells -hier if_sram_cfg*wr*]
-set_multicycle_path -hold 2 -from [get_ports if_sram_cfg*wr* -filter "direction==in"]
-set_multicycle_path -hold 2 -to [get_ports if_sram_cfg*wr* -filter "direction==out"]
-set_multicycle_path -hold 2 -through [get_cells -hier if_sram_cfg*wr*]
-set_multicycle_path -hold 2 -to [get_cells -hier if_sram_cfg*wr*]
-set_multicycle_path -hold 2 -from [get_cells -hier if_sram_cfg*wr*]
+set_multicycle_path -hold 3 -from [get_ports if_sram_cfg*wr* -filter "direction==in"]
+set_multicycle_path -hold 3 -to [get_ports if_sram_cfg*wr* -filter "direction==out"]
+set_multicycle_path -hold 3 -through [get_cells -hier if_sram_cfg*wr*]
+set_multicycle_path -hold 3 -to [get_cells -hier if_sram_cfg*wr*]
+set_multicycle_path -hold 3 -from [get_cells -hier if_sram_cfg*wr*]
 
 # Make all signals limit their fanout
 # loose fanout number to reduce the number of buffer and meet timing

--- a/mflowgen/glb_tile/constraints/constraints.tcl
+++ b/mflowgen/glb_tile/constraints/constraints.tcl
@@ -47,6 +47,8 @@ set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if
 set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_cfg_wst* -filter "direction==in"]
 set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_sram_cfg_est* -filter "direction==in"]
 set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_sram_cfg_wst* -filter "direction==in"]
+# ignore timing when rd_en is 1
+set_case_analysis 0 cgra_cfg_jtag_wsti_rd_en
 
 # tile id is constant
 set_input_delay -clock ${clock_name} 0 glb_tile_id

--- a/mflowgen/glb_tile/constraints/constraints.tcl
+++ b/mflowgen/glb_tile/constraints/constraints.tcl
@@ -40,11 +40,13 @@ set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.2] [all_inputs]
 # cfg_clk_en is negative edge triggered
 set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.2] -clock_fall [get_ports *_clk_en -filter "direction==in"]
 
-# all est<->wst connections are now registered so do not need high4delay =>commented out
-# set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.4] [get_ports *_esti*]
-# set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.4] [get_ports *_wsti*]
-# set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.4] [get_ports if_cfg_est* -filter "direction==in"]
-# set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.4] [get_ports if_cfg_wst* -filter "direction==in"]
+# all est<->wst connections
+set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports *_esti*]
+set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports *_wsti*]
+set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_cfg_est* -filter "direction==in"]
+set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_cfg_wst* -filter "direction==in"]
+set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_sram_cfg_est* -filter "direction==in"]
+set_input_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_sram_cfg_wst* -filter "direction==in"]
 
 # tile id is constant
 set_input_delay -clock ${clock_name} 0 glb_tile_id
@@ -57,11 +59,13 @@ set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.2] [all_outputs
 # cfg_clk_en is negative edge triggered
 set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.2] -clock_fall [get_ports *_clk_en -filter "direction==out"]
 
-# all est<->wst connections are now registered so do not need high delay =>commented out
-# set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.4] [get_ports *_esto* -filter "direction==out"]
-# set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.4] [get_ports *_wsto* -filter "direction==out"]
-# set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.4] [get_ports if_cfg_est* -filter "direction==out"]
-# set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.4] [get_ports if_cfg_wst* -filter "direction==out"]
+# all est<->wst connections
+set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports *_esto* -filter "direction==out"]
+set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports *_wsto* -filter "direction==out"]
+set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_cfg_est* -filter "direction==out"]
+set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_cfg_wst* -filter "direction==out"]
+set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_sram_cfg_est* -filter "direction==out"]
+set_output_delay -clock ${clock_name} [expr ${dc_clock_period}*0.5] [get_ports if_sram_cfg_wst* -filter "direction==out"]
 
 
 # set false path

--- a/mflowgen/glb_top/constraints/constraints.tcl
+++ b/mflowgen/glb_top/constraints/constraints.tcl
@@ -51,7 +51,7 @@ set_false_path -to [get_ports if_sram_cfg*rd* -filter "direction==out"]
 
 # jtag write
 set_multicycle_path -setup 4 -from [get_ports if_sram_cfg*wr* -filter "direction==in"]
-set_multicycle_path -hold 2 -from [get_ports if_sram_cfg*wr* -filter "direction==in"]
+set_multicycle_path -hold 3 -from [get_ports if_sram_cfg*wr* -filter "direction==in"]
 
 # set_output_delay constraints for output ports
 

--- a/mflowgen/glb_top/constraints/constraints.tcl
+++ b/mflowgen/glb_top/constraints/constraints.tcl
@@ -72,16 +72,23 @@ set_false_path -from [get_ports cgra_cfg_jtag_gc2glb_rd_en]
 # jtag bypass mode is false path
 set_false_path -from [get_ports cgra_cfg_jtag_gc2glb_addr] 
 set_false_path -from [get_ports cgra_cfg_jtag_gc2glb_data] 
+set_false_path -through [get_pins glb_tile_gen[*].glb_tile/*jtag*]
 
 # jtag sram read
 set_multicycle_path -setup 10 -from [get_ports if_sram_cfg*rd* -filter "direction==in"]
-set_multicycle_path -setup 10 -to [get_ports if_sram_cfg*rd* -filter "direction==out"]
 set_multicycle_path -hold 9 -from [get_ports if_sram_cfg*rd* -filter "direction==in"]
+set_multicycle_path -setup 10 -to [get_ports if_sram_cfg*rd* -filter "direction==out"]
 set_multicycle_path -hold 9 -to [get_ports if_sram_cfg*rd* -filter "direction==out"]
+set_multicycle_path -setup 10 -through [get_pins glb_tile_gen[*].glb_tile/if_sram*rd*]
+set_multicycle_path -hold 9 -through [get_pins glb_tile_gen[*].glb_tile/if_sram*rd*]
 
 # jtag write
 set_multicycle_path -setup 4 -from [get_ports if_sram_cfg*wr* -filter "direction==in"]
 set_multicycle_path -hold 3 -from [get_ports if_sram_cfg*wr* -filter "direction==in"]
+set_multicycle_path -setup 4 -to [get_ports if_sram_cfg*wr* -filter "direction==out"]
+set_multicycle_path -hold 3 -to [get_ports if_sram_cfg*wr* -filter "direction==out"]
+set_multicycle_path -setup 4 -through [get_pins glb_tile_gen[*].glb_tile/if_sram*wr*]
+set_multicycle_path -hold 3 -through [get_pins glb_tile_gen[*].glb_tile/if_sram*wr*]
 
 # interrupt is asserted for 4 cycles 
 set_multicycle_path -setup 4 -to [get_ports *interrupt_pulse -filter "direction==out"]

--- a/mflowgen/glb_top/constraints/constraints.tcl
+++ b/mflowgen/glb_top/constraints/constraints.tcl
@@ -85,8 +85,6 @@ set_multicycle_path -hold 9 -through [get_pins glb_tile_gen[*].glb_tile/if_sram*
 # jtag write
 set_multicycle_path -setup 4 -from [get_ports if_sram_cfg*wr* -filter "direction==in"]
 set_multicycle_path -hold 3 -from [get_ports if_sram_cfg*wr* -filter "direction==in"]
-set_multicycle_path -setup 4 -to [get_ports if_sram_cfg*wr* -filter "direction==out"]
-set_multicycle_path -hold 3 -to [get_ports if_sram_cfg*wr* -filter "direction==out"]
 set_multicycle_path -setup 4 -through [get_pins glb_tile_gen[*].glb_tile/if_sram*wr*]
 set_multicycle_path -hold 3 -through [get_pins glb_tile_gen[*].glb_tile/if_sram*wr*]
 

--- a/mflowgen/glb_top/constraints/constraints.tcl
+++ b/mflowgen/glb_top/constraints/constraints.tcl
@@ -70,8 +70,8 @@ set_multicycle_path -hold 9 -from [get_ports reset]
 # glc reading configuration registers is false path
 set_false_path -from [get_ports cgra_cfg_jtag_gc2glb_rd_en]
 # jtag bypass mode is false path
-set_false_path -from [get_ports cgra_cfg_jtag_gc2glb_addr] -to [get_ports cgra_cfg_g2f_cfg_addr]
-set_false_path -from [get_ports cgra_cfg_jtag_gc2glb_data] -to [get_ports cgra_cfg_g2f_cfg_data]
+set_false_path -from [get_ports cgra_cfg_jtag_gc2glb_addr] 
+set_false_path -from [get_ports cgra_cfg_jtag_gc2glb_data] 
 
 # jtag sram read
 set_multicycle_path -setup 10 -from [get_ports if_sram_cfg*rd* -filter "direction==in"]


### PR DESCRIPTION
This PR includes update in `constraint` file and RTL to meet timing.

1. There was a timing issue hard to fix regarding SRAM macro. Basically, `sram_gen_array` generates a giant mux of sram macros, which makes it hard to meet timing. I basically added a register right before `sram` instead of `sram_gen_array`.

2. Increase delay to assert interrupt pulse due to increased latency.

3. Increase the number of cycles interrupt pulse is asserted to 4 to meet timing.

4. Add constraints.