### PR TITLE
make block steps in fullchip flow have correct LVS outputs

### DIFF
--- a/mflowgen/full_chip/glb_top/configure.yml
+++ b/mflowgen/full_chip/glb_top/configure.yml
@@ -10,5 +10,6 @@ outputs:
   - glb_top.gds
   - glb_top.vcs.v
   - glb_top.sdf
-  - glb_top.schematic.spi
+  - glb_top.lvs.v
+  - glb_top.sram.spi
 

--- a/mflowgen/full_chip/global_controller/configure.yml
+++ b/mflowgen/full_chip/global_controller/configure.yml
@@ -10,5 +10,5 @@ outputs:
   - global_controller.gds
   - global_controller.vcs.v
   - global_controller.sdf
-  - global_controller.schematic.spi
+  - global_controller.lvs.v
 

--- a/mflowgen/full_chip/tile_array/configure.yml
+++ b/mflowgen/full_chip/tile_array/configure.yml
@@ -10,5 +10,6 @@ outputs:
   - tile_array.gds
   - tile_array.vcs.v
   - tile_array.sdf
-  - tile_array.schematic.spi
+  - tile_array.lvs.v
+  - tile_array.sram.spi
 


### PR DESCRIPTION
Some last changes to make fullchip LVS work... seems like this was missing from #532 

The files needed for LVS for the block steps in the full chip flow (glb_top, tile_array, global_controller) were being copied to the outputs directory, but since the configure.yml for these steps didn't have the files in it, they weren't being connected to the LVS node.