### PR TITLE
[pe/mem] add custom timing assertions for clk passthroughs

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -65,6 +65,7 @@ def construct():
   custom_init          = Step( this_dir + '/custom-init'                           )
   custom_lvs           = Step( this_dir + '/custom-lvs-rules'                      )
   custom_power         = Step( this_dir + '/../common/custom-power-leaf'           )
+  custom_timing_assert = Step( this_dir + '/../common/custom-timing-assert'        )
 
   # Power aware setup
   if pwr_aware:
@@ -90,6 +91,12 @@ def construct():
   drc          = Step( 'mentor-calibre-drc',            default=True )
   lvs          = Step( 'mentor-calibre-lvs',            default=True )
   debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
+
+  # Add custom timing scripts
+
+  custom_timing_steps = [ dc, postcts_hold, signoff ] # connects to these
+  for c_step in custom_timing_steps:
+    c_step.extend_inputs( custom_timing_assert.all_outputs() )
 
   # Add sram macro inputs to downstream nodes
 
@@ -143,6 +150,7 @@ def construct():
   g.add_step( gen_sram             )
   g.add_step( constraints          )
   g.add_step( dc                   )
+  g.add_step( custom_timing_assert )
   g.add_step( iflow                )
   g.add_step( init                 )
   g.add_step( custom_init          )
@@ -206,6 +214,9 @@ def construct():
 
   g.connect_by_name( rtl,         dc        )
   g.connect_by_name( constraints, dc        )
+
+  for c_step in custom_timing_steps:
+    g.connect_by_name( custom_timing_assert, c_step )
 
   g.connect_by_name( dc,       iflow        )
   g.connect_by_name( dc,       init         )
@@ -271,6 +282,14 @@ def construct():
   #-----------------------------------------------------------------------
 
   g.update_params( parameters )
+
+  # Add custom timing scripts
+
+  for c_step in custom_timing_steps:
+    order = c_step.get_param( 'order' )
+    order.append( 'report-special-timing.tcl' )
+    c_step.set_param( 'order', order )
+    c_step.extend_postconditions( [{ 'pytest': 'inputs/test_timing.py' }] )
 
   # Update PWR_AWARE variable
   dc.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )

--- a/mflowgen/common/custom-timing-assert/configure.yml
+++ b/mflowgen/common/custom-timing-assert/configure.yml
@@ -1,0 +1,16 @@
+#=========================================================================
+# Custom Scripts -- timing assertions
+#=========================================================================
+# This node adds a timing reporting script and a pytest suite to check
+# the timing of those reports.
+
+name: custom-timing-assert
+
+#-------------------------------------------------------------------------
+# Inputs and Outputs
+#-------------------------------------------------------------------------
+
+outputs:
+  - report-special-timing.tcl  # special timing reports
+  - test_timing.py             # pytest assertions on the reports
+

--- a/mflowgen/common/custom-timing-assert/outputs/report-special-timing.tcl
+++ b/mflowgen/common/custom-timing-assert/outputs/report-special-timing.tcl
@@ -1,0 +1,13 @@
+#=========================================================================
+# report-special-timing.py
+#=========================================================================
+# Additional timing reports for special paths (e.g., feedthroughs) that we
+# want to parse using mflowgen assertions.
+#
+
+# Clock passthrough
+
+report_timing -from clk_pass_through \
+              -to   clk_pass_through_out \
+              > reports/time-clock-passthrough.rpt
+

--- a/mflowgen/common/custom-timing-assert/outputs/test_timing.py
+++ b/mflowgen/common/custom-timing-assert/outputs/test_timing.py
@@ -1,0 +1,96 @@
+#=========================================================================
+# test_timing.py
+#=========================================================================
+# Additional timing assertions for special paths (e.g., feedthroughs)
+#
+
+#-------------------------------------------------------------------------
+# tests
+#-------------------------------------------------------------------------
+
+def test_clk_pass_through_arrival():
+  rpt = 'reports/time-clock-passthrough.rpt'
+  assert arrival( rpt ) >= 0.030 # clock must pass through >= 0.030 ns
+  assert arrival( rpt ) <= 0.052 # clock must pass through <= 0.052 ns
+
+
+
+#-------------------------------------------------------------------------
+# slack
+#-------------------------------------------------------------------------
+# Reads a timing report (dc or innovus) and returns the slack (for the
+# first path) as a float.
+#
+
+def slack( rpt ):
+
+  # Read the timing report
+
+  with open( rpt ) as f:
+    lines = [ l for l in f.readlines() if 'slack' in l.lower() ]
+
+  # Extract the slack
+  #
+  # Get the first line with a slack number, which looks like this for DC:
+  #
+  #     slack (MET)              0.0195
+  #
+  # It looks like this for Innovus:
+  #
+  #     = Slack Time                    0.020
+  #
+
+  output = float( lines[0].split()[-1] )
+
+  return output
+
+#-------------------------------------------------------------------------
+# arrival
+#-------------------------------------------------------------------------
+# Reads a timing report and returns the arrival time (for the first path)
+# as a float.
+#
+
+def arrival( rpt ):
+
+  # Read the timing report
+
+  with open( rpt ) as f:
+    lines = [ l for l in f.readlines() if 'arrival time' in l.lower() ]
+
+  # To allow us to use this function to extract the arrival times in both
+  # DC/Innovus timing reports, we filter out certain kinds of lines from
+  # the Innovus timing report, which would normally look like this:
+  #
+  #     Other End Arrival Time          0.000
+  #     = Beginpoint Arrival Time       10.009
+  #
+
+  lines = [ l for l in lines if 'Other End'  not in l ]
+  lines = [ l for l in lines if 'Beginpoint' not in l ]
+
+  # Extract the arrival time
+  #
+  # Get the first line with an arrival time, which looks like this for
+  # DC:
+  #
+  #     data arrival time        0.0305
+  #
+  #     > Note that there is usually another "negative" version of this
+  #     number just below, where the report shows its math:
+  #
+  #         data required time       0.0500
+  #         data arrival time       -0.0305
+  #
+  #     > We want the first number, not this one.
+  #
+  # It looks like this for Innovus:
+  #
+  #     - Arrival Time                  0.031
+  #
+
+  output = float( lines[0].split()[-1] )
+
+  return output
+
+


### PR DESCRIPTION
This pull request adds the "custom-timing-assert" node and attaches it to the PE/MEM flows.

This node allows any DC or Innovus node to dump some specific timing report (e.g., clock pass through) and assert a condition on it (e.g., clk pass through must be greater than 30ps and less than 50ps). Right now, this node only checks for the clk pass through, but more reports and checks can be added.

The PE/MEM flows have this node attached to:

1. dc synth
2. innovus postcts_hold
3. innovus signoff

So all three of those steps will dump `reports/time-clock-passthrough.rpt` and have a pytest postcondition that asserts that the arrival time is in bounds.

**NOTE: This change will pass on Alex's latest final build with all updated tile constraints, but garnet/master currently does not have all those updated tile constraints (so this change will cause buildkite to fail).**
