### PR TITLE
Linked in ff version (ff,0p88v,125c) of stdcell, stdcell-pm, iocell, …

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -37,6 +37,7 @@ def construct():
     'word_size'           : 32,
     'mux_size'            : 4,
     'corner'              : "tt0p8v25c",
+    'bc_corner'           : "ffg0p88v125c",
     'partial_write'       : False,
     # Utilization target
     'core_density_target' : 0.70,
@@ -108,7 +109,7 @@ def construct():
   sram_steps = \
     [iflow, init, power, place, cts, postcts_hold, route, postroute, postroute_hold, signoff]
   for step in sram_steps:
-    step.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
+    step.extend_inputs( ['sram_tt.lib', 'sram_ff.lib', 'sram.lef'] )
 
   # Need the sram gds to merge into the final layout
 

--- a/mflowgen/common/gen_sram_macro/configure.yml
+++ b/mflowgen/common/gen_sram_macro/configure.yml
@@ -8,6 +8,7 @@ outputs:
   - sram_pwr.v
   - sram.lef
   - sram_tt.lib
+  - sram_ff.lib
   - sram_tt.db
   - sram.gds
   - sram.spi
@@ -17,4 +18,5 @@ parameters:
   word_size: 64
   mux_size: 8
   corner: "tt0p8v25c"
+  bc_corner: "ffg0p88v125c"
   partial_write: False

--- a/mflowgen/common/gen_sram_macro/gen_srams.sh
+++ b/mflowgen/common/gen_sram_macro/gen_srams.sh
@@ -16,6 +16,7 @@ fi
 eval $cmd
 
 ln -s ../$sram_name/NLDM/${sram_name}_${corner}.lib outputs/sram_tt.lib
+ln -s ../$sram_name/NLDM/${sram_name}_${bc_corner}.lib outputs/sram_ff.lib
 ln -s ../$sram_name/GDSII/${sram_name}_m4xdh.gds outputs/sram.gds
 ln -s ../$sram_name/LEF/${sram_name}_m4xdh.lef outputs/sram.lef
 ln -s ../$sram_name/VERILOG/${sram_name}_pwr.v outputs/sram_pwr.v


### PR DESCRIPTION
The innovus foundation flow supports early_case and late_case libs automatically by tagging them with -bc. I just used the ff, 0.88V, 125C corner as the fast corner for the stdcell, stdcell-pm, iocell, and sram libs. You will need the accompanying change to mflowgen to automatically get these files from the globs... https://github.com/cornell-brg/mflowgen/pull/48