### PR TITLE
Fullchip

### DIFF
--- a/mflowgen/common/custom-power-chip/outputs/power-strategy-dualmesh.tcl
+++ b/mflowgen/common/custom-power-chip/outputs/power-strategy-dualmesh.tcl
@@ -32,7 +32,7 @@ setAddStripeMode -area [list $stripeLlx $stripeLly $stripeUrx $stripeUry]
 
 addStripe \
   -spacing [expr [dbGet top.fPlan.coreSite.size_y] - $M1_width]   \
-  -set_to_set_distance [dbGet top.fPlan.coreSite.size_y]   \
+  -set_to_set_distance [expr 2 * [dbGet top.fPlan.coreSite.size_y]]   \
   -direction horizontal   \
   -layer M1   \
   -width $M1_width \

--- a/mflowgen/full_chip/constraints/cons_scripts/io.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/io.tcl
@@ -8,6 +8,14 @@
 # Date     : May 14, 2020
 #------------------------------------------------------------------------------
 
+# Don't optimize away any of our I/O cells or corner cells
+set_dont_touch [ get_cells ANAIOPAD* ]
+
+set_dont_touch [ get_cells IOPAD* ]
+
+set_dont_touch [ get_cells corner* ]
+
+# I/O Timing constraints
 set master_clk_period     [expr ${soc_master_clk_period} * ${soc_clk_div_factor}]
 
 # ------------------------------------------------------------------------------

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -379,6 +379,8 @@ def construct():
       'main.tcl','quality-of-life.tcl',
       'stylus-compatibility-procs.tcl','floorplan.tcl','io-fillers.tcl',
       'alignment-cells.tcl',
+      'analog-bumps/route-phy-bumps.tcl',
+      'analog-bumps/bump-connect.tcl', 
       'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
       'place-macros.tcl', 'dont-touch.tcl'
     ]}

--- a/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
+++ b/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
@@ -130,8 +130,9 @@ if { ! $::env(soc_only) } {
 }
 # Place SRAMS
 set srams [get_cells -hier -filter {is_memory_cell==true}]
-set sram_width [dbGet [dbGet -p top.insts.name *mem_inst* -i 0].cell.size_x]
-set sram_height [dbGet [dbGet -p top.insts.name *mem_inst* -i 0].cell.size_y]
+set sram_name [get_property [index_collection $srams 0] hierarchical_name]
+set sram_width [dbGet [dbGet -p top.insts.name $sram_name -i 0].cell.size_x]
+set sram_height [dbGet [dbGet -p top.insts.name $sram_name -i 0].cell.size_y]
 
 # SRAM Placement params
 # SRAMs are abutted vertically


### PR DESCRIPTION
Miscellaneous fixes for fullchip flow:

-Dont touch constraints on io cells

-updates to place-macros.tcl to account for new soc rtl

-M1 power stripe fix. the s2s distance was half what it should've been, causing the following warning:

**WARN: (IMPPP-385):    The set width(VDD width+spacing + VSS width specified by -width and -spacing is greater than or is equal to set distance specified by -set_to_set_distance. Tool will not check drc between stripes in different sets so that there may be potential drc issues.                                                                                              