### PR TITLE
unplace any std cells placed during init

### DIFF
--- a/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
+++ b/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
@@ -198,3 +198,6 @@ foreach_in_collection sram $srams {
   }
 }
 
+# Unplace any standard cells that got placed during init. Not sure why they're
+# being placed, but they make power stripe generation take forever.
+dbSet [dbGet top.insts.cell.baseClass core -p2].pStatus unplaced


### PR DESCRIPTION
For some reason, there were some illegally placed standard cells in the bottom left corner of the fullchip floorplan after init. They made M1 power stripe generation take forever (presumably  because of DRC checking), so I added a line at the end of init to unplace all standard cells.

<img width="451" alt="Screen Shot 2020-05-18 at 1 45 56 PM" src="https://user-images.githubusercontent.com/4943164/82250705-f319ae00-9919-11ea-934a-8a2a39b88037.png">
