### PR TITLE
Add global controller generated clock constraint

### DIFF
--- a/mflowgen/full_chip/constraints/cons_scripts/clocks_4_cgra.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/clocks_4_cgra.tcl
@@ -34,3 +34,9 @@ create_generated_clock -name cgra_gclk \
     -divide_by 1 \
     -master_clock cgra_by_${cgra_clk_div_factor}_clk \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_cgra_gclk/Q]
+
+## CGRA Clock from global controller
+create_generated_clock -name global_controller_clk \
+    -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_cgra_gclk/Q]
+    -divide_by 1 \
+    [get_pins core/u_aha_garnet/u_garnet/GlobalController_cfg_32_32_axi_13_32_inst0_global_controller_inst0/clk_out]

--- a/mflowgen/full_chip/constraints/cons_scripts/clocks_4_cgra.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/clocks_4_cgra.tcl
@@ -37,6 +37,6 @@ create_generated_clock -name cgra_gclk \
 
 ## CGRA Clock from global controller
 create_generated_clock -name global_controller_clk \
-    -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_cgra_gclk/Q]
+    -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_cgra_gclk/Q] \
     -divide_by 1 \
-    [get_pins core/u_aha_garnet/u_garnet/GlobalController_cfg_32_32_axi_13_32_inst0_global_controller_inst0/clk_out]
+    [get_pins -hier *global_controller_inst0/clk_out]


### PR DESCRIPTION
Gets rid of unconstrained paths between tile array, GLB, GLC