### PR TITLE
Remove skip routing commands on rte* nets

### DIFF
--- a/mflowgen/common/init-fullchip/outputs/io-fillers.tcl
+++ b/mflowgen/common/init-fullchip/outputs/io-fillers.tcl
@@ -39,8 +39,6 @@
     # add_io_fillers -cells "$ioFillerCells" -logic
     addIoFiller -cell "$ioFillerCells" -logic
 
-    set_db [get_db nets rte*] .skip_routing true
-    set_db [get_db nets rte*] .dont_touch true
     set_db [get_db nets esd] .skip_routing true
     set_db [get_db nets esd] .dont_touch true
 


### PR DESCRIPTION
With the latest SoC RTL, for some reason dc uses the net name "rte_0" for the output of the tie cell that connects to the IRTE port of our PCBRTE cells, which drive the RTE rings for all the pads.

```
//rte_0 is output of TIE_LO cell
 TIELBWP16P90 U47 ( .ZN(rte_0) )
 
 //rte_0 connected to PCBRTE pads
 PCBRTE_V IOPAD_bottom_RTE_DIG ( .IRTE(rte_0) );
 PCBRTE_H IOPAD_left_RTE_DIG ( .IRTE(rte_0) );  
 PCBRTE_H IOPAD_right_RTE_DIG ( .IRTE(rte_0) ); 

 // rte_0 connected to all tie lo control signals on pad
 PRWDWUWSWCDGH_H IOPAD_left_TLX_FWD_CLK_0 ( .I(TLX_FWD_CLK_int_0_), .OEN(
      rte_0), .IE(rte_0), .PAD(pad_TLX_FWD_CLK[0]), .RTE(rte_0), .ST(rte_0),
      .PU(rte_0), .DS0(n74), .DS1(n88), .PD(rte_0), .SL(rte_0), .DS2(n101)
       );
```

This wouldn't be a problem, but there was some old code in our init scripts which skipped routing on nets called `rte*`. This left the IRTE inputs, and all of those other pad control signals we tied low floating.

The old code was an attempt to prevent Innovus from routing directly to the RTE rings (which resulted in DRC errors), but that was resolved by instead disconnecting the RTE pins of all the pads during init: https://github.com/StanfordAHA/garnet/blob/cbafc2e51273045166049396d8662ade5c41dfa7/mflowgen/common/init-fullchip/outputs/floorplan.tcl#L38