### PR TITLE
set false path on read_config_data paths

### DIFF
--- a/mflowgen/full_chip/constraints/cons_scripts/garnet_constraints.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/garnet_constraints.tcl
@@ -8,6 +8,11 @@
 # Date     : May 18, 2020
 #------------------------------------------------------------------------------
 
-set_multicycle_path 5 -setup -to [get_pins -hier *global_controller*/cgra_cfg_rd_data*]
-set_multicycle_path 4 -hold -to [get_pins -hier *global_controller*/cgra_cfg_rd_data*]
+#set_multicycle_path 5 -setup -to [get_pins -hier *global_controller*/cgra_cfg_rd_data*]
+#set_multicycle_path 4 -hold -to [get_pins -hier *global_controller*/cgra_cfg_rd_data*]
+
+# Setting this to be a false path instead because the tile array.lib file
+# we generate for some reason reports this path to have huge negative delay,
+# which causes major hold time issues
+set_false_path -to [get_pins -hier *global_controller*/cgra_cfg_rd_data*]
 


### PR DESCRIPTION
Changing this to be a false path instead of a multicycle path because of issues with tile_array .lib file