### PR TITLE
Change interrupt_pulse multicyc path from -from to -through

### DIFF
--- a/mflowgen/full_chip/constraints/cons_scripts/garnet_constraints.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/garnet_constraints.tcl
@@ -15,6 +15,6 @@ set_multicycle_path 9 -hold -to [get_pins -hier *global_controller*/cgra_cfg_rd_
 set_multicycle_path 10 -setup -to [get_pins -hier *global_controller*/sram_cfg_rd_data*]
 set_multicycle_path 9 -hold -to [get_pins -hier *global_controller*/sram_cfg_rd_data*]
 
-set_multicycle_path 5 -setup -from [get_pins -hier *GlobalBuffer*/*interrupt_pulse*]
-set_multicycle_path 4 -hold  -from [get_pins -hier *GlobalBuffer*/*interrupt_pulse*]
+set_multicycle_path 5 -setup -through [get_pins -hier *GlobalBuffer*/*interrupt_pulse*]
+set_multicycle_path 4 -hold  -through [get_pins -hier *GlobalBuffer*/*interrupt_pulse*]
 


### PR DESCRIPTION
This constraint needed -through, since the pin I identified isn't the actual start point