### PR TITLE
various flow fixes for dragonphy

### DIFF
--- a/mflowgen/common/fc-netlist-fixing/outputs/netlist-fixing.tcl
+++ b/mflowgen/common/fc-netlist-fixing/outputs/netlist-fixing.tcl
@@ -7,6 +7,12 @@ addNet ESD_3 -ground -physical
 addNet POC_0 -ground -physical
 addNet POC_1 -ground -physical
 
+addModulePort - AVSS bidi
+addModulePort - AVDD bidi
+addModulePort - CVSS bidi
+addModulePort - CVDD bidi
+addModulePort - ext_Vcal bidi
+
 addNet AVDD -power -physical
 addNet AVSS -ground -physical
 addNet CVDD -power -physical

--- a/mflowgen/full_chip/custom-lvs-rules/outputs/rules.svrf
+++ b/mflowgen/full_chip/custom-lvs-rules/outputs/rules.svrf
@@ -1,1 +1,2 @@
 LVS BOX "*TS1N*"
+LVS BOX "dragonphy_top"


### PR DESCRIPTION
Depends on https://github.com/cornell-brg/mflowgen/pull/55

Alex, do you mind testing the new netlist fixing script on the train_5_24_ANALOG_750MHz design? You can just source the script in the final pre-signoff step and then write out an LVS verilog. I can take a look at the verilog to see if it looks right.

You can write the LVS verilog with the following:

```
foreach x $ADK_LVS_EXCLUDE_CELL_LIST {
  append lvs_exclude_list [dbGet -u -e top.insts.cell.name $x] " "
}

saveNetlist -excludeLeafCell                   \
            -phys                              \
            -excludeCellInst $lvs_exclude_list \
            <path>.lvs.v
```