### PR TITLE
add back default_threshold_voltage_group to glb_tile constraints

### DIFF
--- a/mflowgen/glb_tile/constraints/constraints.tcl
+++ b/mflowgen/glb_tile/constraints/constraints.tcl
@@ -18,6 +18,11 @@ create_clock -name ${clock_name} \
              -period ${dc_clock_period} \
              [get_ports ${clock_net}]
 
+# Set voltage groups
+set_attribute [get_lib *90tt0p8v25c] default_threshold_voltage_group SVT
+set_attribute [get_lib *lvt*] default_threshold_voltage_group LVT
+set_attribute [get_lib *ulvt*] default_threshold_voltage_group ULVT
+
 # This constraint sets the load capacitance in picofarads of the
 # output pins of your design.
 


### PR DESCRIPTION
Realized we should keep these constraints in, since this is more complicated than I thought.