### PR TITLE
Rtl container

### DIFF
--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -13,4 +13,5 @@ parameters:
   soc_only: False
   PWR_AWARE: True
   use_container: True
+  use_local_garnet: True
 

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -12,4 +12,5 @@ parameters:
   interconnect_only: False
   soc_only: False
   PWR_AWARE: True
+  use_container: True
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -37,6 +37,13 @@ else
     # (this will print out the name of the container to attach to)
     container_name=$(aha docker)
     echo "container-name: $container_name"
+
+    if [ $use_local_garnet == True ]; then
+      docker exec $container_name /bin/bash -c "rm -rf /aha/garnet"
+      git clone $GARNET_HOME ./garnet
+      docker cp ./garnet $container_name:/aha/garnet
+    fi
+
     # run garnet.py in container and concat all verilog outputs
     docker exec $container_name /bin/bash -c \
       "source /aha/bin/activate && aha garnet $flags;

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -4,12 +4,8 @@ if [ $soc_only = True ]; then
   touch outputs/design.v
 else
   # Clean out old rtl outputs
-  if [ -d "$GARNET_HOME/genesis_verif/" ]; then
-    rm -rf $GARNET_HOME/genesis_verif
-  fi
-  if [ -f "$GARNET_HOME/garnet.v" ]; then
-    rm $GARNET_HOME/garnet.v
-  fi
+  rm -rf $GARNET_HOME/genesis_verif
+  rm -f $GARNET_HOME/garnet.v
 
   # Build up the flags we want to pass to python garnet.v
   flags="--width $array_width --height $array_height -v --no-sram-stub"
@@ -40,6 +36,7 @@ else
 
     if [ $use_local_garnet == True ]; then
       docker exec $container_name /bin/bash -c "rm -rf /aha/garnet"
+      # Clone local garnet repo to prevent copying untracked files
       git clone $GARNET_HOME ./garnet
       docker cp ./garnet $container_name:/aha/garnet
     fi

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -3,34 +3,55 @@ if [ $soc_only = True ]; then
   echo "soc_only set to true. Garnet not included"
   touch outputs/design.v
 else
-  current_dir=$(pwd)
-  cd $GARNET_HOME
-  if [ -d "genesis_verif/" ]; then
-    rm -rf genesis_verif
-  fi
-  
-  cmd="python garnet.py --width $array_width --height $array_height -v --no-sram-stub"
+  flags="--width $array_width --height $array_height -v --no-sram-stub"
  
   if [ $PWR_AWARE == False ]; then
-   cmd+=" --no-pd"
+   flags+=" --no-pd"
   fi
  
   if [ $interconnect_only == True ]; then
-   cmd+=" --interconnect-only"
+   flags+=" --interconnect-only"
   fi
   
-  eval $cmd
-  
-  # If there are any genesis files, we need to cat those
-  # with the magma generated garnet.v
-  if [ -d "genesis_verif" ]; then
-    cp garnet.v genesis_verif/garnet.sv
-    cat genesis_verif/* >> $current_dir/outputs/design.v
-  # Otherwise, garnet.v contains all rtl
+  if [ $use_container == True ]; then
+    # Clone AHA repo
+    git clone https://github.com/StanfordAHA/aha.git
+    cd aha
+    # install the aha wrapper script
+    pip install -e .
+
+    # pull docker image from docker hub
+    docker pull stanfordaha/garnet:latest
+    
+    # run the container in the background and delete it when it exits
+    # (this will print out the name of the container to attach to)
+    container_name=$(aha docker)
+    echo "container-name: $container_name"
+    docker exec $container_name /bin/bash -c "source /aha/bin/activate && aha garnet $flags"
+    docker cp $container_name:/aha/garnet/garnet.v ../outputs/design.v
+    docker kill $container_name
+    echo "killed docker container $container_name"
+    cd ..
+    
   else
-    cp garnet.v $current_dir/outputs/design.v
-  fi
-  
+    current_dir=$(pwd)
+    cd $GARNET_HOME
+    if [ -d "genesis_verif/" ]; then
+      rm -rf genesis_verif
+    fi
+     
+    eval "python garnet.py $flags"
+    
+    # If there are any genesis files, we need to cat those
+    # with the magma generated garnet.v
+    if [ -d "genesis_verif" ]; then
+      cp garnet.v genesis_verif/garnet.sv
+      cat genesis_verif/* >> $current_dir/outputs/design.v
+    # Otherwise, garnet.v contains all rtl
+    else
+      cp garnet.v $current_dir/outputs/design.v
+    fi
+  fi 
   
   cd $current_dir
 fi


### PR DESCRIPTION
This PR changes the mflowgen rtl node to use the aha docker container to satisfy all of the dependencies needed to generate garnet verilog.

With this change, we hope to greatly improve the reliability of generating garnet RTL by making it easy for everyone to use a consistent snapshot of all garnet dependencies that is already tested and proven to work.

Users who want/need to use their own local python environment can do so by setting the use_container param to false.

Marking this as a draft because I'd still like to be able to capture the local state of the garnet repo and bring that into the docker container, instead of using the pinned version of Garnet. I want to do this because there are many situations in which we make an rtl change in Garnet, and then we need to make accompanying physical design changes. If we can't bring the local state of the garnet repo into the container, then this would be very cumbersome.