### PR TITLE
Buildkite tile array

### DIFF
--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -49,25 +49,18 @@ steps:
 #   continue_on_failure: true
 
 
-# Slowest version does not work (for now) b/c RTL generation is broken.
 # ########################################################################
 # # tile-array slowest version builds rtl from scratch, takes 1.5 hr maybe
+# # DOES NOT WORK (for now) b/c RTL generation is broken
 # - label: 'tile-array init 90m'
 #   agents: { jobsize: "hours" }
 #   commands:
-#   - steps=init
-#   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
-#   # Try a thing
 #   - 'mflowgen/test/test_module.sh full_chip tile_array
 #        --debug
 #        --steps syn,init'
 # 
 # - wait: ~
 #   continue_on_failure: true
-
-
-
-
 
 
 ########################################################################

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,27 +1,32 @@
 steps:
 
 - label: 'Tile_MemCore'
-  command: test=mflowgen/test/test_module.sh
-#   command: mflowgen/test/test_module.sh full_chip tile_array Tile_MemCore --steps synthesis --debug
-  command: $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
   agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
 
 - wait: ~
   continue_on_failure: true
+
+
 
 - label: 'Tile_PE'
-  command: test=mflowgen/test/test_module.sh
-  command: $$test full_chip tile_array Tile_PE --steps synthesis --debug
   agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
 
 - wait: ~
   continue_on_failure: true
 
+
+
 - label: 'tile-array'
+  agents: { jobsize: "hours" }
   commands:
   - test=mflowgen/test/test_module.sh
   - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
-  agents: { jobsize: "hours" }
 
 - wait: ~
   continue_on_failure: true

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -3,8 +3,10 @@ steps:
 - label: 'tile-array'
   agents: { jobsize: "hours" }
   commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test --debug full_chip tile_array --steps copy,init
+  - test="mflowgen/test/test_module.sh --debug"
+  - cached=constraints,rtl,tsmc16,synthesis
+  = steps=init
+  - $$test full_chip tile_array --use_cached $$cached --steps $$steps
   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
 
 - wait: ~

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -5,7 +5,7 @@ steps:
   commands:
   - test="mflowgen/test/test_module.sh --debug"
   - cached=constraints,rtl,tsmc16,synthesis
-  = steps=init
+  - steps=init
   - $$test full_chip tile_array --use_cached $$cached --steps $$steps
   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -7,7 +7,7 @@ steps:
   - echo error foo > mflowgen-run.log
   - echo post-error info
   - if [ "$$FAIL" ]; then echo foo; fi
-  - echo a \
+  >- echo a 
   b c
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,6 +1,26 @@
 steps:
 
 ########################################################################
+# Slowest version builds rtl from scratch, takes 1.5h maybe
+- label: 'tile-array init 90m'
+  agents: { jobsize: "hours" }
+  commands:
+  - steps=init
+  # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
+  # Try a thing
+  - 'mflowgen/test/test_module.sh full_chip tile_array
+       --debug
+       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
+       --steps syn,init'
+
+- wait: ~
+  continue_on_failure: true
+
+
+
+
+
+########################################################################
 # Fastest version uses cached synthesis results, takes ??
 - label: 'tile-array init'
   agents: { jobsize: "hours" }
@@ -32,24 +52,6 @@ steps:
 
 - wait: ~
   continue_on_failure: true
-
-
-########################################################################
-# Slowest version builds rtl from scratch, takes 1.5h maybe
-- label: 'tile-array init 90m'
-  agents: { jobsize: "hours" }
-  commands:
-  - steps=init
-  # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
-  # Try a thing
-  - 'mflowgen/test/test_module.sh full_chip tile_array
-       --debug
-       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
-       --steps rtl,syn,init'
-
-- wait: ~
-  continue_on_failure: true
-
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -3,10 +3,16 @@ steps:
 
 - label: 'tile-array'
   commands:
-  - gold=/sim/buildkite-agent/gold; test=`pwd`/mflowgen/test/test_module.sh
-  - $$test --debug full_chip tile_array --steps none
-  - wdir=mflowgen/test/full_chip/14-tile_array
   - echo pwd=`pwd`
+  - test=`pwd`/mflowgen/test/test_module.sh
+  - $$test --debug full_chip tile_array --steps none
+  - echo pwd=`pwd`
+
+  - wdir=test/full_chip/14-tile_array
+  - echo wdir=$$wdir
+  - ls $$wdir
+
+  - gold=/sim/buildkite-agent/gold
   - echo gold=$$gold
   - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
   - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,16 +1,10 @@
 steps:
 
 ########################################################################
-# Slow version builds rtl from scratch, takes 1.5 hours maybe
-- label: 'tile-array init no-cache'
+# Faster version uses cached rtl but does synthesis, takes an hour maybe
+- label: 'tile-array init no-cache 60m'
   agents: { jobsize: "hours" }
   commands:
-  - test="mflowgen/test/test_module.sh --debug"
-  - cached=MemCore,PE,constraints,rtl,tsmc16,synthesis
-  - steps=init
-  # - $$test full_chip tile_array --use_cached $$cached --steps $$steps
-  # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
-  # Try a thing
   - 'mflowgen/test/test_module.sh full_chip tile_array
        --debug
        --use_cached PE,MemCore,rtl
@@ -18,25 +12,39 @@ steps:
   - pwd
   - gold=/sim/buildkite-agent/gold.tmp
   - test -d $$gold || mkdir $$gold
-  - cp -rp . $gold
+  - cp -rpf . $gold
 
 - wait: ~
   continue_on_failure: true
 
 
+########################################################################
+# Fastest version uses cached synthesis results, takes ??
 # - label: 'tile-array init'
 #   agents: { jobsize: "hours" }
 #   commands:
-#   - test="mflowgen/test/test_module.sh --debug"
-#   - cached=MemCore,PE,constraints,rtl,tsmc16,synthesis
-#   - steps=init
-#   # - $$test full_chip tile_array --use_cached $$cached --steps $$steps
-#   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
-#   # Try a thing
-#   - 'mflowgen/test/test_module.sh
+#   - 'mflowgen/test/test_module.sh full_chip tile_array
 #        --debug
 #        --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
 #        --steps init'
+# 
+# - wait: ~
+#   continue_on_failure: true
+
+
+
+########################################################################
+# Slowest version builds rtl from scratch, takes 1.5h maybe
+# - label: 'tile-array init no-cache 60m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - steps=init
+#   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
+#   # Try a thing
+#   - 'mflowgen/test/test_module.sh full_chip tile_array
+#        --debug
+#        --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
+#        --steps rtl,syn,init'
 # 
 # - wait: ~
 #   continue_on_failure: true
@@ -52,7 +60,7 @@ steps:
 
 
 
-- label: 'MemCore synth'
+- label: 'MemCore synth 17m'
   agents: { jobsize: "hours" }
   commands:
   - test=mflowgen/test/test_module.sh
@@ -62,7 +70,7 @@ steps:
   continue_on_failure: true
 
 
-- label: 'PE synth'
+- label: 'PE synth 23m'
   agents: { jobsize: "hours" }
   commands:
   - test=mflowgen/test/test_module.sh
@@ -135,3 +143,24 @@ steps:
 #   continue_on_failure: true
 # 
 ###########################################################
+
+
+########################################################################
+# OLD way using vars
+# - label: 'tile-array init no-cache 60m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test="mflowgen/test/test_module.sh --debug"
+#   - cached=MemCore,PE,constraints,rtl,tsmc16,synthesis
+#   - steps=init
+#   # - $$test full_chip tile_array --use_cached $$cached --steps $$steps
+#   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
+#   # Try a thing
+#   - 'mflowgen/test/test_module.sh full_chip tile_array
+#        --debug
+#        --use_cached PE,MemCore,rtl
+#        --steps syn,init'
+#   - pwd
+#   - gold=/sim/buildkite-agent/gold.tmp
+#   - test -d $$gold || mkdir $$gold
+#   - cp -rp . $gold

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -2,7 +2,8 @@ steps:
 
 
 - label: 'tile-array'
-  command: echo a b c
+  command: >
+  echo a b c
 
 
 #   - FAIL=true

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -4,6 +4,7 @@ steps:
 - label: 'tile-array'
   command: >
   echo a b c
+  def
 
 
 #   - FAIL=true

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -2,9 +2,9 @@ steps:
 
 
 - label: 'tile-array'
-  command: 'echo a b c
-  d e '
-
+  commands:
+  - 'echo a b c
+d e '
 
 #   - FAIL=true
 #   - echo error foo > mflowgen-run.log

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -8,40 +8,69 @@ steps:
   - $$test --debug full_chip tile_array --steps none
   - echo pwd=`pwd`
 
-  - wdir=mflowgen/test/full_chip/14-tile_array
-  - echo wdir=$$wdir
-  - ls; ls mflowgen; ls mflowgen/test; ls mflowgen/test/full_chip; 
-  - ls $$wdir
+  - cd mflowgen/test/full_chip/14-tile_array
 
   - gold=/sim/buildkite-agent/gold
   - echo gold=$$gold
 
-  - echo cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
-  - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
+  - echo cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore .
+  - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore .
 
-  - echo cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
-  - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
+  - echo cp -rp $$gold/full_chip/*tile_array/1-Tile_PE .
+  - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE .
 
-  - echo wdir=$$wdir
-  - ls; ls mflowgen; ls mflowgen/test; ls mflowgen/test/full_chip; 
-  - ls $$wdir
+  - make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
 
-
-
-  - cd $$wdir; make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
-  - cd $$wdir; make rtl |& tee make-rtl.log | awk -f $test/rtl-filter1.awk || set FAIL
+  - make rtl |& tee make-rtl.log | awk -f $test/rtl-filter1.awk || set FAIL
   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
         echo "Looks like we failed, here are some errors maybe:";
         echo grep -i error mflowgen-run.log;
         grep -i error mflowgen-run.log; echo exit 13;
     fi'
-  - cd $$wdir; make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
+  - make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
         echo "Looks like we failed, here are some errors maybe:";
         echo grep -i error mflowgen-run.log;
         grep -i error mflowgen-run.log; echo exit 13;
     fi'
-  - cd $$wdir; make cadence-innovus-init  |& tee make-init.log || set FAIL
+  - make cadence-innovus-init  |& tee make-init.log || set FAIL
+
+
+
+
+#   - wdir=mflowgen/test/full_chip/14-tile_array
+#   - echo wdir=$$wdir
+#   - ls; ls mflowgen; ls mflowgen/test; ls mflowgen/test/full_chip; 
+#   - ls $$wdir
+# 
+#   - gold=/sim/buildkite-agent/gold
+#   - echo gold=$$gold
+# 
+#   - echo cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
+#   - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
+# 
+#   - echo cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
+#   - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
+# 
+#   - echo wdir=$$wdir
+#   - ls; ls mflowgen; ls mflowgen/test; ls mflowgen/test/full_chip; 
+#   - ls $$wdir
+# 
+#   - cd $$wdir; make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
+# 
+#   - cd $$wdir; make rtl |& tee make-rtl.log | awk -f $test/rtl-filter1.awk || set FAIL
+#   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
+#         echo "Looks like we failed, here are some errors maybe:";
+#         echo grep -i error mflowgen-run.log;
+#         grep -i error mflowgen-run.log; echo exit 13;
+#     fi'
+#   - cd $$wdir; make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
+#   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
+#         echo "Looks like we failed, here are some errors maybe:";
+#         echo grep -i error mflowgen-run.log;
+#         grep -i error mflowgen-run.log; echo exit 13;
+#     fi'
+#   - cd $$wdir; make cadence-innovus-init  |& tee make-init.log || set FAIL
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -3,37 +3,42 @@ steps:
 
 - label: 'tile-array'
   commands:
-  - FAIL=true
-  - echo error foo > mflowgen-run.log
-  - echo post-error info
-  - 'echo a b c
-d e '
-  - if [ "$$FAIL" ]; then echo foo; fi
-  - 'if [ "$FAIL" ]; then 
-        echo foo; fi'
-  - 'if [ "$$FAIL" ]; then
-        echo "+++ FAIL";
+  - gold=/sim/buildkite-agent/gold; test=`pwd`/mflowgen/test/test_module.sh
+  - $$test --debug full_chip tile_array --steps none
+  - wdir=mflowgen/test/full_chip/14-tile_array
+  - echo pwd=`pwd`
+  - echo gold=$$gold
+  - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
+  - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
+  - cd $$wdir; make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
+  - cd $$wdir; make rtl |& tee make-rtl.log | awk -f $test/rtl-filter1.awk || set FAIL
+  - 'if [ "$FAIL" ]; then echo "+++ FAIL";
         echo "Looks like we failed, here are some errors maybe:";
         echo grep -i error mflowgen-run.log;
-        grep -i error mflowgen-run.log;
-        exit 13;
+        grep -i error mflowgen-run.log; echo exit 13;
     fi'
+  - cd $$wdir; make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
+  - 'if [ "$FAIL" ]; then echo "+++ FAIL";
+        echo "Looks like we failed, here are some errors maybe:";
+        echo grep -i error mflowgen-run.log;
+        grep -i error mflowgen-run.log; echo exit 13;
+    fi'
+  - cd $$wdir; make cadence-innovus-init  |& tee make-init.log || set FAIL
 
 
 
-
-#   - gold=/sim/buildkite-agent/gold; test=`pwd`/mflowgen/test/test_module.sh
-#   - $$test --debug full_chip tile_array --steps none
-#   - wdir=mflowgen/test/full_chip/14-tile_array
-#   - echo pwd=`pwd`
-#   - echo gold=$$gold
-#   - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
-#   - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
-#   - cd $$wdir; make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
-#   - cd $$wdir; make rtl |& tee make-rtl.log | awk -f $test/rtl-filter1.awk || set FAIL
-#   - cd $$wdir; make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
-#   - cd $$wdir; make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
-
+#   - FAIL=true
+#   - echo error foo > mflowgen-run.log
+#   - echo post-error info
+#   - 'if [ "$FAIL" ]; then 
+#         echo foo; fi'
+#   - 'if [ "$FAIL" ]; then
+#         echo "+++ FAIL";
+#         echo "Looks like we failed, here are some errors maybe:";
+#         echo grep -i error mflowgen-run.log;
+#         grep -i error mflowgen-run.log;
+#         exit 13;
+#     fi'
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,7 +1,9 @@
 steps:
 
 - label: 'Tile_MemCore'
-  command: mflowgen/test/test_module.sh full_chip tile_array Tile_MemCore --steps synthesis --debug
+  command: test=mflowgen/test/test_module.sh
+#   command: mflowgen/test/test_module.sh full_chip tile_array Tile_MemCore --steps synthesis --debug
+  command: $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
   agents: { jobsize: "hours" }
 
 - wait: ~

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -3,14 +3,32 @@ steps:
 
 - label: 'tile-array'
   commands:
-  - gold=/sim/buildkite-agent/gold; test=`pwd`/mflowgen/test/test_module.sh
-  - $$test --debug full_chip tile_array --steps none
-  - wdir=mflowgen/test/full_chip/14-tile_array
-  - echo pwd=`pwd`
-  - echo gold=$$gold
-  - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
-  - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
-  - cd $$wdir; make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
+  - FAIL=true
+  - echo error foo > mflowgen-run.log
+  - if [ "$$FAIL" ]; then \
+        echo '+++ FAIL'; \
+        echo 'Looks like we failed, here are some errors maybe:'; \
+        echo grep -i error mflowgen-run.log; \
+        grep -i error mflowgen-run.log; \
+        exit 13; \
+    fi
+  - echo post-error info
+
+
+
+
+
+#   - gold=/sim/buildkite-agent/gold; test=`pwd`/mflowgen/test/test_module.sh
+#   - $$test --debug full_chip tile_array --steps none
+#   - wdir=mflowgen/test/full_chip/14-tile_array
+#   - echo pwd=`pwd`
+#   - echo gold=$$gold
+#   - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
+#   - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
+#   - cd $$wdir; make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
+#   - cd $$wdir; make rtl |& tee make-rtl.log | awk -f $test/rtl-filter1.awk || set FAIL
+#   - cd $$wdir; make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
+#   - cd $$wdir; make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -23,7 +23,7 @@ steps:
 
 ########################################################################
 # tile-array, fastest version, uses cached synthesis results, takes 5 min
-- label: 'tile-array init 5m'
+- label: 'array init only 5m'
   agents: { jobsize: "hours" }
   commands:
   - 'mflowgen/test/test_module.sh full_chip tile_array
@@ -35,24 +35,23 @@ steps:
   continue_on_failure: true
 
 
-
-########################################################################
-# Middle version uses cached rtl but does synthesis, takes 22 minutes
-- label: 'tile-array init 22m'
-  agents: { jobsize: "hours" }
-  commands:
-  - 'mflowgen/test/test_module.sh full_chip tile_array
-       --debug
-       --use_cached PE,MemCore,rtl
-       --steps syn,init'
-
-- wait: ~
-  continue_on_failure: true
+# ########################################################################
+# # tile-array middle version uses cached rtl but does synthesis, takes 22 minutes
+# - label: 'array syn+init 22m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - 'mflowgen/test/test_module.sh full_chip tile_array
+#        --debug
+#        --use_cached PE,MemCore,rtl
+#        --steps syn,init'
+# 
+# - wait: ~
+#   continue_on_failure: true
 
 
 # Slowest version does not work (for now) b/c RTL generation is broken.
 # ########################################################################
-# # Slowest version builds rtl from scratch, takes 1.5 hr maybe
+# # tile-array slowest version builds rtl from scratch, takes 1.5 hr maybe
 # - label: 'tile-array init 90m'
 #   agents: { jobsize: "hours" }
 #   commands:

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -19,7 +19,6 @@ steps:
 
 
 
-
 ########################################################################
 # Fastest version uses cached synthesis results, takes ??
 - label: 'tile-array init'

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -11,17 +11,14 @@ d e '
   - if [ "$$FAIL" ]; then echo foo; fi
   - 'if [ "$FAIL" ]; then 
         echo foo; fi'
+  - 'if [ "$$FAIL" ]; then
+        echo "+++ FAIL";
+        echo "Looks like we failed, here are some errors maybe:";
+        echo grep -i error mflowgen-run.log;
+        grep -i error mflowgen-run.log;
+        exit 13;
+    fi'
 
-
-
-#   - if [ "$$FAIL" ]; then \
-#         echo '+++ FAIL'; \
-#         echo 'Looks like we failed, here are some errors maybe:'; \
-#         echo grep -i error mflowgen-run.log; \
-#         grep -i error mflowgen-run.log; \
-#         exit 13; \
-#     fi
-# 
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -8,8 +8,9 @@ steps:
   - $$test --debug full_chip tile_array --steps none
   - echo pwd=`pwd`
 
-  - wdir=test/full_chip/14-tile_array
+  - wdir=mflowgen/test/full_chip/14-tile_array
   - echo wdir=$$wdir
+  - ls; ls mflowgen; ls mflowgen/test; ls mflowgen/test/full_chip; 
   - ls $$wdir
 
   - gold=/sim/buildkite-agent/gold

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -7,12 +7,8 @@ steps:
   - echo error foo > mflowgen-run.log
   - echo post-error info
   - if [ "$$FAIL" ]; then echo foo; fi
-  - echo a
+  - echo a \
   b c
-  - if [ "x" ]; then
-      echo a
-    fi
-  
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -2,8 +2,8 @@ steps:
 
 
 - label: 'tile-array'
-  command: echo a b c \\
-  d e
+  command: { echo a b c
+  d e }
 
 
 #   - FAIL=true

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -21,13 +21,13 @@ steps:
 
   - make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
 
-  - make rtl |& tee make-rtl.log | awk -f $test/rtl-filter1.awk || set FAIL
+  - make rtl |& tee make-rtl.log | awk -f $$test/rtl-filter1.awk || set FAIL
   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
         echo "Looks like we failed, here are some errors maybe:";
         echo grep -i error mflowgen-run.log;
         grep -i error mflowgen-run.log; echo exit 13;
     fi'
-  - make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
+  - make synopsys-dc-synthesis |& tee make-syn.log | awk -f $$test/post-rtl-filter1.awk || set FAIL
   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
         echo "Looks like we failed, here are some errors maybe:";
         echo grep -i error mflowgen-run.log;

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -5,11 +5,12 @@ steps:
   commands:
   - gold=/sim/buildkite-agent/gold; test=`pwd`/mflowgen/test/test_module.sh
   - $$test --debug full_chip tile_array --steps none
+  - wdir=mflowgen/test/full_chip/14-tile_array
   - echo pwd=`pwd`
   - echo gold=$$gold
-  - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore .
-  - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE .
-  - make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
+  - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
+  - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
+  - cd $$wdir; make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -9,6 +9,10 @@ steps:
   - if [ "$$FAIL" ]; then echo foo; fi
   - echo a
   b c
+  - if [ "x" ]; then
+      echo a
+    fi
+  
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -7,8 +7,7 @@ steps:
   - echo error foo > mflowgen-run.log
   - echo post-error info
   - if [ "$$FAIL" ]; then echo foo; fi
-  - echo a \
-  b
+  - echo a
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -15,8 +15,19 @@ steps:
 
   - gold=/sim/buildkite-agent/gold
   - echo gold=$$gold
+
+  - echo cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
   - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
+
+  - echo cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
   - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
+
+  - echo wdir=$$wdir
+  - ls; ls mflowgen; ls mflowgen/test; ls mflowgen/test/full_chip; 
+  - ls $$wdir
+
+
+
   - cd $$wdir; make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
   - cd $$wdir; make rtl |& tee make-rtl.log | awk -f $test/rtl-filter1.awk || set FAIL
   - 'if [ "$FAIL" ]; then echo "+++ FAIL";

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -2,8 +2,8 @@ steps:
 
 
 - label: 'tile-array'
-  command: { echo a b c
-  d e }
+  command: 'echo a b c
+  d e '
 
 
 #   - FAIL=true

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -5,16 +5,22 @@ steps:
   commands:
   - FAIL=true
   - echo error foo > mflowgen-run.log
-  - if [ "$$FAIL" ]; then \
-        echo '+++ FAIL'; \
-        echo 'Looks like we failed, here are some errors maybe:'; \
-        echo grep -i error mflowgen-run.log; \
-        grep -i error mflowgen-run.log; \
-        exit 13; \
-    fi
   - echo post-error info
+  - if [ "$$FAIL" ]; then echo foo; fi
+  - echo a \
+  b
 
 
+
+
+#   - if [ "$$FAIL" ]; then \
+#         echo '+++ FAIL'; \
+#         echo 'Looks like we failed, here are some errors maybe:'; \
+#         echo grep -i error mflowgen-run.log; \
+#         grep -i error mflowgen-run.log; \
+#         exit 13; \
+#     fi
+# 
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,22 +1,24 @@
 steps:
 
-- label: 'tile-array'
+- label: 'tile-array init'
   agents: { jobsize: "hours" }
   commands:
   - test="mflowgen/test/test_module.sh --debug"
   - cached=MemCore,PE,constraints,rtl,tsmc16,synthesis
   - steps=init
-  - $$test full_chip tile_array --use_cached $$cached --steps $$steps
+  # - $$test full_chip tile_array --use_cached $$cached --steps $$steps
   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
+  # Try a thing
+  - 'mflowgen/test/test_module.sh
+       --debug
+       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
+       --steps init'
 
 - wait: ~
   continue_on_failure: true
 
 
-
-
-
-- label: 'Tile_MemCore'
+- label: 'MemCore synth'
   agents: { jobsize: "hours" }
   commands:
   - test=mflowgen/test/test_module.sh
@@ -26,8 +28,7 @@ steps:
   continue_on_failure: true
 
 
-
-- label: 'Tile_PE'
+- label: 'PE synth'
   agents: { jobsize: "hours" }
   commands:
   - test=mflowgen/test/test_module.sh

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -6,12 +6,12 @@ steps:
   - FAIL=true
   - echo error foo > mflowgen-run.log
   - echo post-error info
-  - if [ "$$FAIL" ]; then echo foo; fi
   >- echo a 
   b c
 
 
 
+#   - if [ "$$FAIL" ]; then echo foo; fi
 
 #   - if [ "$$FAIL" ]; then \
 #         echo '+++ FAIL'; \

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -11,7 +11,7 @@ steps:
   # - $$test full_chip tile_array --use_cached $$cached --steps $$steps
   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
   # Try a thing
-  - 'mflowgen/test/test_module.sh
+  - 'mflowgen/test/test_module.sh full_chip tile_array
        --debug
        --use_cached PE,MemCore,rtl
        --steps syn,init'

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,133 +1,30 @@
 steps:
 
+- label: 'Tile_MemCore'
+  command: mflowgen/test/test_module.sh full_chip tile_array Tile_MemCore --steps synthesis --debug
+  agents: { jobsize: "hours" }
+
+- wait: ~
+  continue_on_failure: true
+
+- label: 'Tile_PE'
+  command: test=mflowgen/test/test_module.sh
+  command: $$test full_chip tile_array Tile_PE --steps synthesis --debug
+  agents: { jobsize: "hours" }
+
+- wait: ~
+  continue_on_failure: true
 
 - label: 'tile-array'
   commands:
   - test=mflowgen/test/test_module.sh
   - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
+  agents: { jobsize: "hours" }
+
+- wait: ~
+  continue_on_failure: true
 
 
-
-#   - echo pwd=`pwd`
-#   - test=`pwd`/mflowgen/test/test_module.sh
-#   - $$test --debug full_chip tile_array --steps none
-# 
-#   - echo pwd=`pwd`
-# 
-#   - cd mflowgen/test/full_chip/14-tile_array
-# 
-#   - gold=/sim/buildkite-agent/gold
-#   - echo gold=$$gold
-# 
-#   - echo cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore .
-#   - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore .
-# 
-#   - echo cp -rp $$gold/full_chip/*tile_array/1-Tile_PE .
-#   - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE .
-# 
-#   - make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
-# 
-#   - make rtl |& tee make-rtl.log | awk -f $$test/rtl-filter1.awk || set FAIL
-#   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
-#         echo "Looks like we failed, here are some errors maybe:";
-#         echo grep -i error mflowgen-run.log;
-#         grep -i error mflowgen-run.log; echo exit 13;
-#     fi'
-#   - make synopsys-dc-synthesis |& tee make-syn.log | awk -f $$test/post-rtl-filter1.awk || set FAIL
-#   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
-#         echo "Looks like we failed, here are some errors maybe:";
-#         echo grep -i error mflowgen-run.log;
-#         grep -i error mflowgen-run.log; echo exit 13;
-#     fi'
-#   - make cadence-innovus-init  |& tee make-init.log || set FAIL
-
-
-
-
-#   - wdir=mflowgen/test/full_chip/14-tile_array
-#   - echo wdir=$$wdir
-#   - ls; ls mflowgen; ls mflowgen/test; ls mflowgen/test/full_chip; 
-#   - ls $$wdir
-# 
-#   - gold=/sim/buildkite-agent/gold
-#   - echo gold=$$gold
-# 
-#   - echo cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
-#   - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore $$wdir
-# 
-#   - echo cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
-#   - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE $$wdir
-# 
-#   - echo wdir=$$wdir
-#   - ls; ls mflowgen; ls mflowgen/test; ls mflowgen/test/full_chip; 
-#   - ls $$wdir
-# 
-#   - cd $$wdir; make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
-# 
-#   - cd $$wdir; make rtl |& tee make-rtl.log | awk -f $test/rtl-filter1.awk || set FAIL
-#   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
-#         echo "Looks like we failed, here are some errors maybe:";
-#         echo grep -i error mflowgen-run.log;
-#         grep -i error mflowgen-run.log; echo exit 13;
-#     fi'
-#   - cd $$wdir; make synopsys-dc-synthesis |& tee make-syn.log | awk -f $test/post-rtl-filter1.awk || set FAIL
-#   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
-#         echo "Looks like we failed, here are some errors maybe:";
-#         echo grep -i error mflowgen-run.log;
-#         grep -i error mflowgen-run.log; echo exit 13;
-#     fi'
-#   - cd $$wdir; make cadence-innovus-init  |& tee make-init.log || set FAIL
-
-
-
-#   - FAIL=true
-#   - echo error foo > mflowgen-run.log
-#   - echo post-error info
-#   - 'if [ "$FAIL" ]; then 
-#         echo foo; fi'
-#   - 'if [ "$FAIL" ]; then
-#         echo "+++ FAIL";
-#         echo "Looks like we failed, here are some errors maybe:";
-#         echo grep -i error mflowgen-run.log;
-#         grep -i error mflowgen-run.log;
-#         exit 13;
-#     fi'
-
-
-
-
-# ###########################################################
-# 
-# - label: 'tile-array'
-#   command: mflowgen/test/test_module.sh full_chip tile_array --debug \
-#            --steps rtl,syn,init
-#   agents: { jobsize: "hours" }
-# 
-# - wait: ~
-#   continue_on_failure: true
-
-
-
-
-
-
-
-# Temporarily disabled while we try and get tile-array working
-###########################################################
-# - label: 'Tile_PE'
-#   command: mflowgen/test/test_module.sh full_chip tile_array Tile_PE --steps synopsys-dc-synthesis --debug
-#   agents: { jobsize: "hours" }
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# - label: 'Tile_MemCore'
-#   command: mflowgen/test/test_module.sh full_chip tile_array Tile_MemCore --steps synopsys-dc-synthesis --debug
-#   agents: { jobsize: "hours" }
-# 
-# - wait: ~
-#   continue_on_failure: true
-###########################################################
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -52,24 +52,24 @@ steps:
 
 
 
-# - label: 'MemCore synth'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - test=mflowgen/test/test_module.sh
-#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# 
-# - label: 'PE synth'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - test=mflowgen/test/test_module.sh
-#   - $$test full_chip tile_array Tile_PE --steps synthesis --debug
-# 
-# - wait: ~
-#   continue_on_failure: true
+- label: 'MemCore synth'
+  agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+
+- wait: ~
+  continue_on_failure: true
+
+
+- label: 'PE synth'
+  agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
+
+- wait: ~
+  continue_on_failure: true
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -3,37 +3,43 @@ steps:
 
 - label: 'tile-array'
   commands:
-  - echo pwd=`pwd`
-  - test=`pwd`/mflowgen/test/test_module.sh
-  - $$test --debug full_chip tile_array --steps none
-  - echo pwd=`pwd`
+  - test=mflowgen/test/test_module.sh
+  - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
 
-  - cd mflowgen/test/full_chip/14-tile_array
 
-  - gold=/sim/buildkite-agent/gold
-  - echo gold=$$gold
 
-  - echo cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore .
-  - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore .
-
-  - echo cp -rp $$gold/full_chip/*tile_array/1-Tile_PE .
-  - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE .
-
-  - make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
-
-  - make rtl |& tee make-rtl.log | awk -f $$test/rtl-filter1.awk || set FAIL
-  - 'if [ "$FAIL" ]; then echo "+++ FAIL";
-        echo "Looks like we failed, here are some errors maybe:";
-        echo grep -i error mflowgen-run.log;
-        grep -i error mflowgen-run.log; echo exit 13;
-    fi'
-  - make synopsys-dc-synthesis |& tee make-syn.log | awk -f $$test/post-rtl-filter1.awk || set FAIL
-  - 'if [ "$FAIL" ]; then echo "+++ FAIL";
-        echo "Looks like we failed, here are some errors maybe:";
-        echo grep -i error mflowgen-run.log;
-        grep -i error mflowgen-run.log; echo exit 13;
-    fi'
-  - make cadence-innovus-init  |& tee make-init.log || set FAIL
+#   - echo pwd=`pwd`
+#   - test=`pwd`/mflowgen/test/test_module.sh
+#   - $$test --debug full_chip tile_array --steps none
+# 
+#   - echo pwd=`pwd`
+# 
+#   - cd mflowgen/test/full_chip/14-tile_array
+# 
+#   - gold=/sim/buildkite-agent/gold
+#   - echo gold=$$gold
+# 
+#   - echo cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore .
+#   - cp -rp $$gold/full_chip/*tile_array/0-Tile_MemCore .
+# 
+#   - echo cp -rp $$gold/full_chip/*tile_array/1-Tile_PE .
+#   - cp -rp $$gold/full_chip/*tile_array/1-Tile_PE .
+# 
+#   - make -n rtl | grep 'mkdir.*output' | sed 's/.output.*//'
+# 
+#   - make rtl |& tee make-rtl.log | awk -f $$test/rtl-filter1.awk || set FAIL
+#   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
+#         echo "Looks like we failed, here are some errors maybe:";
+#         echo grep -i error mflowgen-run.log;
+#         grep -i error mflowgen-run.log; echo exit 13;
+#     fi'
+#   - make synopsys-dc-synthesis |& tee make-syn.log | awk -f $$test/post-rtl-filter1.awk || set FAIL
+#   - 'if [ "$FAIL" ]; then echo "+++ FAIL";
+#         echo "Looks like we failed, here are some errors maybe:";
+#         echo grep -i error mflowgen-run.log;
+#         grep -i error mflowgen-run.log; echo exit 13;
+#     fi'
+#   - make cadence-innovus-init  |& tee make-init.log || set FAIL
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -2,13 +2,15 @@ steps:
 
 
 - label: 'tile-array'
-  commands:
-  - FAIL=true
-  - echo error foo > mflowgen-run.log
-  - echo post-error info
-  command: >-
-  echo a 
-  b c
+  command: echo a b c
+
+
+#   - FAIL=true
+#   - echo error foo > mflowgen-run.log
+#   - echo post-error info
+#   command: >-
+#   echo a 
+#   b c
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -6,7 +6,8 @@ steps:
   - FAIL=true
   - echo error foo > mflowgen-run.log
   - echo post-error info
-  >- echo a 
+  command: >-
+  echo a 
   b c
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -6,8 +6,8 @@ steps:
   - FAIL=true
   - echo error foo > mflowgen-run.log
   - echo post-error info
-  - 'echo a b c
-d e '
+  - 'echo a b c'\
+'d e '
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -8,6 +8,7 @@ steps:
   - echo post-error info
   - if [ "$$FAIL" ]; then echo foo; fi
   - echo a
+  b c
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,27 +1,29 @@
 steps:
 
 ########################################################################
-# Slowest version builds rtl from scratch, takes 1.5h maybe
-- label: 'tile-array init 90m'
+- label: 'MemCore synth 17m'
   agents: { jobsize: "hours" }
   commands:
-  - steps=init
-  # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
-  # Try a thing
-  - 'mflowgen/test/test_module.sh full_chip tile_array
-       --debug
-       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
-       --steps syn,init'
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
 
 - wait: ~
   continue_on_failure: true
 
 
+########################################################################
+- label: 'PE synth 23m'
+  agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
 
+- wait: ~
+  continue_on_failure: true
 
 ########################################################################
-# Fastest version uses cached synthesis results, takes ??
-- label: 'tile-array init'
+# tile-array, fastest version, uses cached synthesis results, takes 5 min
+- label: 'tile-array init 5m'
   agents: { jobsize: "hours" }
   commands:
   - 'mflowgen/test/test_module.sh full_chip tile_array
@@ -35,8 +37,8 @@ steps:
 
 
 ########################################################################
-# Middle version uses cached rtl but does synthesis, takes an hour maybe
-- label: 'tile-array init 60m'
+# Middle version uses cached rtl but does synthesis, takes 22 minutes
+- label: 'tile-array init 22m'
   agents: { jobsize: "hours" }
   commands:
   - 'mflowgen/test/test_module.sh full_chip tile_array
@@ -44,52 +46,35 @@ steps:
        --use_cached PE,MemCore,rtl
        --steps syn,init'
 
-#   - pwd
-#   - gold=/sim/buildkite-agent/gold.tmp
-#   - test -d $$gold || mkdir $$gold
-#   - cp -rpf . $$gold
-
 - wait: ~
   continue_on_failure: true
 
 
+# Slowest version does not work (for now) b/c RTL generation is broken.
+# ########################################################################
+# # Slowest version builds rtl from scratch, takes 1.5 hr maybe
+# - label: 'tile-array init 90m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - steps=init
+#   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
+#   # Try a thing
+#   - 'mflowgen/test/test_module.sh full_chip tile_array
+#        --debug
+#        --steps syn,init'
+# 
+# - wait: ~
+#   continue_on_failure: true
 
 
 
 
 
 
-
-
-
-- label: 'MemCore synth 17m'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
-
-- wait: ~
-  continue_on_failure: true
-
-
-- label: 'PE synth 23m'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
-
-- wait: ~
-  continue_on_failure: true
-
-
-
-
-
-
-
-
-
-
+########################################################################
+########################################################################
+########################################################################
+# Rest, from here down, is TBD
 
 ###########################################################
 # Non-hierarchical version

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,7 +1,22 @@
 steps:
 
 ########################################################################
-# Faster version uses cached rtl but does synthesis, takes an hour maybe
+# Fastest version uses cached synthesis results, takes ??
+- label: 'tile-array init'
+  agents: { jobsize: "hours" }
+  commands:
+  - 'mflowgen/test/test_module.sh full_chip tile_array
+       --debug
+       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
+       --steps init'
+
+- wait: ~
+  continue_on_failure: true
+
+
+
+########################################################################
+# Middle version uses cached rtl but does synthesis, takes an hour maybe
 - label: 'tile-array init 60m'
   agents: { jobsize: "hours" }
   commands:
@@ -9,45 +24,31 @@ steps:
        --debug
        --use_cached PE,MemCore,rtl
        --steps syn,init'
-  - pwd
-  - gold=/sim/buildkite-agent/gold.tmp
-  - test -d $$gold || mkdir $$gold
-  - cp -rpf . $$gold
+
+#   - pwd
+#   - gold=/sim/buildkite-agent/gold.tmp
+#   - test -d $$gold || mkdir $$gold
+#   - cp -rpf . $$gold
 
 - wait: ~
   continue_on_failure: true
 
 
 ########################################################################
-# Fastest version uses cached synthesis results, takes ??
-# - label: 'tile-array init'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - 'mflowgen/test/test_module.sh full_chip tile_array
-#        --debug
-#        --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
-#        --steps init'
-# 
-# - wait: ~
-#   continue_on_failure: true
-
-
-
-########################################################################
 # Slowest version builds rtl from scratch, takes 1.5h maybe
-# - label: 'tile-array init 90m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - steps=init
-#   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
-#   # Try a thing
-#   - 'mflowgen/test/test_module.sh full_chip tile_array
-#        --debug
-#        --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
-#        --steps rtl,syn,init'
-# 
-# - wait: ~
-#   continue_on_failure: true
+- label: 'tile-array init 90m'
+  agents: { jobsize: "hours" }
+  commands:
+  - steps=init
+  # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
+  # Try a thing
+  - 'mflowgen/test/test_module.sh full_chip tile_array
+       --debug
+       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
+       --steps rtl,syn,init'
+
+- wait: ~
+  continue_on_failure: true
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -143,3 +143,4 @@ steps:
 #   - gold=/sim/buildkite-agent/gold.tmp
 #   - test -d $$gold || mkdir $$gold
 #   - cp -rp . $gold
+

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -2,7 +2,7 @@ steps:
 
 ########################################################################
 # Faster version uses cached rtl but does synthesis, takes an hour maybe
-- label: 'tile-array init no-cache 60m'
+- label: 'tile-array init 60m'
   agents: { jobsize: "hours" }
   commands:
   - 'mflowgen/test/test_module.sh full_chip tile_array
@@ -35,7 +35,7 @@ steps:
 
 ########################################################################
 # Slowest version builds rtl from scratch, takes 1.5h maybe
-# - label: 'tile-array init no-cache 60m'
+# - label: 'tile-array init 90m'
 #   agents: { jobsize: "hours" }
 #   commands:
 #   - steps=init

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,5 +1,19 @@
 steps:
 
+- label: 'tile-array'
+  agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test --debug full_chip tile_array --steps copy,init
+  # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
+
+- wait: ~
+  continue_on_failure: true
+
+
+
+
+
 - label: 'Tile_MemCore'
   agents: { jobsize: "hours" }
   commands:
@@ -22,14 +36,6 @@ steps:
 
 
 
-- label: 'tile-array'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
-
-- wait: ~
-  continue_on_failure: true
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -4,7 +4,7 @@ steps:
   agents: { jobsize: "hours" }
   commands:
   - test="mflowgen/test/test_module.sh --debug"
-  - cached=constraints,rtl,tsmc16,synthesis
+  - cached=MemCore,PE,constraints,rtl,tsmc16,synthesis
   - steps=init
   - $$test full_chip tile_array --use_cached $$cached --steps $$steps
   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -12,7 +12,7 @@ steps:
   - pwd
   - gold=/sim/buildkite-agent/gold.tmp
   - test -d $$gold || mkdir $$gold
-  - cp -rpf . $gold
+  - cp -rpf . $$gold
 
 - wait: ~
   continue_on_failure: true

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -3,15 +3,11 @@ steps:
 
 - label: 'tile-array'
   commands:
+  - FAIL=true
+  - echo error foo > mflowgen-run.log
+  - echo post-error info
   - 'echo a b c
 d e '
-
-#   - FAIL=true
-#   - echo error foo > mflowgen-run.log
-#   - echo post-error info
-#   command: >-
-#   echo a 
-#   b c
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -2,9 +2,8 @@ steps:
 
 
 - label: 'tile-array'
-  command: >
-  echo a b c
-  def
+  command: echo a b c \\
+  d e
 
 
 #   - FAIL=true

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -6,12 +6,13 @@ steps:
   - FAIL=true
   - echo error foo > mflowgen-run.log
   - echo post-error info
-  - 'echo a b c'\
-'d e '
+  - 'echo a b c
+d e '
+  - if [ "$$FAIL" ]; then echo foo; fi
+  - 'if [ "$FAIL" ]; then 
+        echo foo; fi'
 
 
-
-#   - if [ "$$FAIL" ]; then echo foo; fi
 
 #   - if [ "$$FAIL" ]; then \
 #         echo '+++ FAIL'; \

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,6 +1,8 @@
 steps:
 
-- label: 'tile-array init'
+########################################################################
+# Slow version builds rtl from scratch, takes 1.5 hours maybe
+- label: 'tile-array init no-cache'
   agents: { jobsize: "hours" }
   commands:
   - test="mflowgen/test/test_module.sh --debug"
@@ -11,31 +13,63 @@ steps:
   # Try a thing
   - 'mflowgen/test/test_module.sh
        --debug
-       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
-       --steps init'
+       --use_cached PE,MemCore,rtl
+       --steps syn,init'
+  - pwd
+  - gold=/sim/buildkite-agent/gold.tmp
+  - test -d $$gold || mkdir $$gold
+  - cp -rp . $gold
 
 - wait: ~
   continue_on_failure: true
 
 
-- label: 'MemCore synth'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+# - label: 'tile-array init'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test="mflowgen/test/test_module.sh --debug"
+#   - cached=MemCore,PE,constraints,rtl,tsmc16,synthesis
+#   - steps=init
+#   # - $$test full_chip tile_array --use_cached $$cached --steps $$steps
+#   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
+#   # Try a thing
+#   - 'mflowgen/test/test_module.sh
+#        --debug
+#        --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
+#        --steps init'
+# 
+# - wait: ~
+#   continue_on_failure: true
 
-- wait: ~
-  continue_on_failure: true
 
 
-- label: 'PE synth'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
 
-- wait: ~
-  continue_on_failure: true
+
+
+
+
+
+
+
+
+# - label: 'MemCore synth'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test=mflowgen/test/test_module.sh
+#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+# 
+# - wait: ~
+#   continue_on_failure: true
+# 
+# 
+# - label: 'PE synth'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test=mflowgen/test/test_module.sh
+#   - $$test full_chip tile_array Tile_PE --steps synthesis --debug
+# 
+# - wait: ~
+#   continue_on_failure: true
 
 
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -384,12 +384,26 @@ done
 
 
 # TEMPORARY DELETEME SOON!!!
+
+# $mflowgen is e.g. "/sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test/mflowgen"
+# But we want:
+# ls -ld /sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test/mflowgen/adks
+# ls -ld /sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test/full_chip
+# And we think that
+# build=/sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test
+
 set -x
 echo '+++ TEMPORARY hack to save results in gold cache'
 if [ "$final_module" == "tile_array" ]; then
   gold=/sim/buildkite-agent/gold.$$
   test -d $gold || mkdir $gold
-  cp -rpf . $mflowgen $gold
+  test -d $gold/mflowgen || mkdir $gold/mflowgen
+
+  a=$build/mflowgen/adks; ls -ld $a
+  fc=$build/full_chip;    ls -ld $fc
+
+  cp -rpf $build/mflowgen/adks $gold/mflowgen
+  cp -rpf $build/full_chip $gold
 fi
 
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -345,18 +345,26 @@ for step in ${build_sequence[@]}; do
         # If stop copying here, still takes an hour
         # What if we copy more stuff?
 
+#             2-constraints \
+#             3-custom-cts-overrides \
+#             4-custom-init \
+#             5-custom-lvs-rules \
+#             9-rtl \
+#             11-tsmc16 \
+#             12-synopsys-dc-synthesis \
+# 
+
         for f in \
             2-constraints \
-            3-custom-cts-overrides \
-            4-custom-init \
-            5-custom-lvs-rules \
             9-rtl \
             11-tsmc16 \
+            12-synopsys-dc-synthesis \
         ; do
             echo cp -rpf $gold/full_chip/*tile_array/$f .
             cp -rpf $gold/full_chip/*tile_array/1-Tile_PE .
         done
-
+        echo "+++ ......TODO list (`date +'%a %H:%M'`)"
+        make -n cadence-innovus-init | grep 'mkdir.*output' | sed 's/.output.*//'
         continue
     fi
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -364,6 +364,7 @@ set -x
 
 
 
+function PASS { return 0; }
 touch .stamp; # Breaks if don't do this before final step; I forget why...? Chris knows...
 for step in ${build_sequence[@]}; do
 
@@ -374,7 +375,8 @@ for step in ${build_sequence[@]}; do
     # [ "$DEBUG" ] && echo "    $step_orig -> $step"
 
     echo "+++ ......TODO list for step $step (`date +'%a %H:%M'`)"
-    make -n $step | grep 'mkdir.*output' | sed 's/.output.*//' | sed 's/mkdir -p/  make/'
+    make -n $step || PASS
+    make -n $step | grep 'mkdir.*output' | sed 's/.output.*//' | sed 's/mkdir -p/  make/' || PASS
 
     echo "--- ......MAKE $step (`date +'%a %H:%M'`)"
     # echo "make $step"

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -333,7 +333,7 @@ for step in ${build_sequence[@]}; do
     fi
 
     if [ "$step" == "copy" ]; then 
-        echo '--- ......SETUP context from gold cache'
+        echo "--- ......SETUP context from gold cache (`date +'%a %H:%M'`)"
         gold=/sim/buildkite-agent/gold
 
         echo cp -rpf $gold/full_chip/*tile_array/0-Tile_MemCore .
@@ -363,7 +363,7 @@ for step in ${build_sequence[@]}; do
     
 
 
-    echo "--- ......MAKE $step"
+    echo "--- ......MAKE $step (`date +'%a %H:%M'`)"
 #     if [ "$step" == "synthesis" ]; then step=synopsys-dc-synthesis; fi
     echo "make $step"
     make $step |& tee make.log || set FAIL

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -311,11 +311,27 @@ done
 touch .stamp; # Breaks if don't do this before final step; I forget why...? Chris knows...
 set +x
 for step in ${build_sequence[@]}; do
+
     if [ "$step" == "none" ]; then 
         echo '--- DONE (for now)'
         echo pre-exit pwd=`pwd`
         exit
     fi
+
+    if [ "$step" == "copy" ]; then 
+        echo '--- ......SETUP context from gold cache'
+        gold=/sim/buildkite-agent/gold; echo gold=$gold
+
+        echo cp -rp $gold/full_chip/*tile_array/0-Tile_MemCore .
+        cp -rp $gold/full_chip/*tile_array/0-Tile_MemCore .
+        
+        echo cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
+        cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
+        
+    fi
+
+    
+
 
     echo "--- ......MAKE $step"
 #     if [ "$step" == "synthesis" ]; then step=synopsys-dc-synthesis; fi

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -77,12 +77,12 @@ function step_alias {
     esac
 }
 
-for step in ${build_sequence[@]}; do
-    echo -n "    $step -> "
-    step=`step_alias $step`
-    echo $step
-done
-exit
+# for step in ${build_sequence[@]}; do
+#     echo -n "    $step -> "
+#     step=`step_alias $step`
+#     echo $step
+# done
+# exit
 
 
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -367,7 +367,7 @@ if [ "$copy_list" ]; then
         fi
         gold=`cd $gold/*${m}; pwd`
     done
-    [ "$DEBUG" ] && echo "Found gold cache directory '$gold'"
+    [ "$DEBUG" ] && echo "  Found gold cache directory '$gold'"
 fi
 
 # # TEST AREA LEAVE HEADLIGHTS ON
@@ -413,10 +413,10 @@ set +x
 for step in ${build_sequence[@]}; do
 
     # Expand aliases e.g. "syn" -> "synopsys-dc-synthesis"
+    step_orig=$step; step=`step_alias $step`
     echo "================================================================"
-    echo -n "    Ready to do step $step -> "
-    step=`step_alias $step`
-    echo $step
+    echo "    Ready to do step $step_orig -> $step"
+    # [ "$DEBUG" ] && echo "    $step_orig -> $step"
 
 # None? There's no none.
 #     if [ "$step" == "none" ]; then 
@@ -469,7 +469,7 @@ for step in ${build_sequence[@]}; do
 
     
     echo "+++ ......TODO list for step $step (`date +'%a %H:%M'`)"
-    make -n $step | grep 'mkdir.*output' | sed 's/.output.*//'
+    make -n $step | grep 'mkdir.*output' | sed 's/.output.*//' | sed 's/^/  /'
 
     echo "--- ......MAKE $step (`date +'%a %H:%M'`)"
 #     if [ "$step" == "synthesis" ]; then step=synopsys-dc-synthesis; fi

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -342,6 +342,21 @@ for step in ${build_sequence[@]}; do
         echo cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
         cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
         
+        # If stop copying here, still takes an hour
+        # What if we copy more stuff?
+
+        for f in \
+            2-constraints \
+            3-custom-cts-overrides \
+            4-custom-init \
+            5-custom-lvs-rules \
+            9-rtl \
+            11-tsmc16 \
+        ; do
+            echo cp -rp $gold/full_chip/*tile_array/$f .
+            cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
+        done
+
         continue
     fi
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -310,7 +310,7 @@ done
 # Copy pre-built steps from (gold) cache
 if [ "$copy_list" ]; then 
     echo "+++ ......SETUP context from gold cache (`date +'%a %H:%M'`)"
-
+    set -x
     # Build the path to the gold cache
     gold=/sim/buildkite-agent/gold
     for m in ${modlist[@]}; do 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -139,8 +139,7 @@ export TMPDIR=/sim/tmp
 
 # Colons is stupids, define "PASS" to use instead
 PASS=:
-alias PASS=:
-
+function PASS { return 0; }
 
 ########################################################################
 # Find GARNET_HOME
@@ -385,10 +384,11 @@ done
 
 
 # TEMPORARY DELETEME SOON!!!
+set -x
 echo '+++ TEMPORARY hack to save results in gold cache'
 if [ "$final_module" == "tile_array" ]; then
   gold=/sim/buildkite-agent/gold.$$
-  test -d $$gold || mkdir $$gold
+  test -d $gold || mkdir $gold
   cp -rpf . $mflowgen $gold
 fi
 
@@ -401,7 +401,7 @@ fi
 
 echo '+++ PASS/FAIL info maybe, to make you feel good'
 set -x
-alias PASS=:
+function PASS { return 0; }
 grep -i error make.log | tail || PASS
 echo "-----"
 grep FAIL make.log | tail || PASS

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -355,7 +355,15 @@ fi
 
 ########################################################################
 # Run the makefiles for each step
+
+
+
 set +x
+set -x
+
+
+
+
 touch .stamp; # Breaks if don't do this before final step; I forget why...? Chris knows...
 for step in ${build_sequence[@]}; do
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -328,6 +328,7 @@ for step in ${build_sequence[@]}; do
         echo cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
         cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
         
+        continue
     fi
 
     

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -56,12 +56,12 @@ done
 # Turn build sequence into an array e.g. 'lvs,gls' => 'lvs gls'
 build_sequence=`echo $build_sequence | tr ',' ' '`
 
-step_synthesis=synopsys-dc-synthesis
-
-# build_sequence=(a b synthesis)
-for step in ${build_sequence[@]}; do
-    if [ "$step_$step" ] ; then echo $step = $step_$step; fi
-done
+# step_synthesis=synopsys-dc-synthesis
+# 
+# # build_sequence=(a b synthesis)
+# for step in ${build_sequence[@]}; do
+#     if [ "$step_$step" ] ; then echo $step = $step_$step; fi
+# done
 
 # E.g. 'step_alias syn' returns 'synopsys-dc-synthesis'
 function step_alias {
@@ -76,6 +76,15 @@ function step_alias {
         *)             echo "$1" ;;
     esac
 }
+
+for step in ${build_sequence[@]}; do
+    echo -n "    $step -> "
+    step=`step_alias $step`
+    echo $step
+done
+exit
+
+
 
 # firstmod=${modlist[0]}; modlist=(${modlist[@]:1})
 
@@ -312,6 +321,11 @@ touch .stamp; # Breaks if don't do this before final step; I forget why...? Chri
 set +x
 for step in ${build_sequence[@]}; do
 
+    # Expand aliases e.g. "syn" -> "synopsys-dc-synthesis"
+    echo -n "    $step -> "
+    step=`step_alias $step`
+    echo $step
+
     if [ "$step" == "none" ]; then 
         echo '--- DONE (for now)'
         echo pre-exit pwd=`pwd`
@@ -320,7 +334,7 @@ for step in ${build_sequence[@]}; do
 
     if [ "$step" == "copy" ]; then 
         echo '--- ......SETUP context from gold cache'
-        gold=/sim/buildkite-agent/gold; echo gold=$gold
+        gold=/sim/buildkite-agent/gold
 
         echo cp -rp $gold/full_chip/*tile_array/0-Tile_MemCore .
         cp -rp $gold/full_chip/*tile_array/0-Tile_MemCore .

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -281,7 +281,8 @@ function build_module {
     [ "$MFLOWGEN_PATH" ] || echo "WARNING MFLOWGEN_PATH var not set."
 
     if ! test -f Makefile; then 
-        echo "--- ...BUILD MODULE '$modname'"
+        dirname="$modname"
+        echo "--- ...BUILD MODULE '$dirname'"
     else
         # Find appropriate directory name for subgraph e.g. "14-tile_array"
         # Looking for a "make list" line that matches modname e.g.

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -361,10 +361,16 @@ for step in ${build_sequence[@]}; do
             12-synopsys-dc-synthesis \
         ; do
             echo cp -rpf $gold/full_chip/*tile_array/$f .
-            cp -rpf $gold/full_chip/*tile_array/1-Tile_PE .
+            cp -rpf $gold/full_chip/*tile_array/$f .
         done
         echo "+++ ......TODO list (`date +'%a %H:%M'`)"
         make -n cadence-innovus-init | grep 'mkdir.*output' | sed 's/.output.*//'
+
+        # Maybe do this again?
+        touch .stamp; # Breaks if don't do this before final step; I forget why...? Chris knows...
+        make -n cadence-innovus-init | grep 'mkdir.*output' | sed 's/.output.*//'
+
+
         continue
     fi
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -383,28 +383,28 @@ done
 
 
 
-# TEMPORARY DELETEME SOON!!!
-
-# $mflowgen is e.g. "/sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test/mflowgen"
-# But we want:
-# ls -ld /sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test/mflowgen/adks
-# ls -ld /sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test/full_chip
-# And we think that
-# build=/sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test
-
-set -x
-echo '+++ TEMPORARY hack to save results in gold cache'
-if [ "$final_module" == "tile_array" ]; then
-  gold=/sim/buildkite-agent/gold.$$
-  test -d $gold || mkdir $gold
-  test -d $gold/mflowgen || mkdir $gold/mflowgen
-
-  a=$build/mflowgen/adks; ls -ld $a
-  fc=$build/full_chip;    ls -ld $fc
-
-  cp -rpf $build/mflowgen/adks $gold/mflowgen
-  cp -rpf $build/full_chip $gold
-fi
+# # TEMPORARY DELETEME SOON!!!
+# 
+# # $mflowgen is e.g. "/sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test/mflowgen"
+# # But we want:
+# # ls -ld /sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test/mflowgen/adks
+# # ls -ld /sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test/full_chip
+# # And we think that
+# # build=/sim/buildkite-agent/builds/bigjobs-1/tapeout-aha/mflowgen/mflowgen/test
+# 
+# set -x
+# echo '+++ TEMPORARY hack to save results in gold cache'
+# if [ "$final_module" == "tile_array" ]; then
+#   gold=/sim/buildkite-agent/gold.$$
+#   test -d $gold || mkdir $gold
+#   test -d $gold/mflowgen || mkdir $gold/mflowgen
+# 
+#   a=$build/mflowgen/adks; ls -ld $a
+#   fc=$build/full_chip;    ls -ld $fc
+# 
+#   cp -rpf $build/mflowgen/adks $gold/mflowgen
+#   cp -rpf $build/full_chip $gold
+# fi
 
 
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -308,20 +308,18 @@ done
 
 ##############################################################################
 # Copy pre-built steps from (gold) cache
-# Build the path to the gold cache
 if [ "$copy_list" ]; then 
     echo "+++ ......SETUP context from gold cache (`date +'%a %H:%M'`)"
-    gold=/sim/buildkite-agent/gold
-    [ "$DEBUG" ] && echo "  Found gold cache directory '$gold'"
 
-    # NOT NECESSARY we'll find out soon enough
-    #     for m in ${modlist[@]}; do 
-    #         ls $gold/*${m} >& /dev/null || echo FAIL
-    #         if [ "$FAIL" == "true" ]; then
-    #             echo "***ERROR could not find cache dir '$gold'"; exit 13
-    #         fi
-    #         gold=`cd $gold/*${m}; pwd`
-    #     done
+    # Build the path to the gold cache
+    gold=/sim/buildkite-agent/gold
+    for m in ${modlist[@]}; do 
+        ls $gold/*${m} >& /dev/null || echo FAIL
+        if [ "$FAIL" == "true" ]; then
+            echo "***ERROR could not find cache dir '$gold'"; exit 13; fi
+        gold=`cd $gold/*${m}; pwd`
+    done
+    [ "$DEBUG" ] && echo "  Found gold cache directory '$gold'"
 
     # Copy desired info from gold cache
     for step in ${copy_list[@]}; do

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -385,16 +385,16 @@ fi
 for step in ${copy_list[@]}; do
 
     # Expand aliases e.g. "syn" -> "synopsys-dc-synthesis"
-    echo -n "    $step -> "
+    # echo -n "    $step -> "
     step=`step_alias $step`
-    echo $step
+    # echo $step
 
     cache=`cd $gold/*${step}; pwd` || FAIL=true
     if [ "$FAIL" == "true" ]; then
         echo "***ERROR could not find cache dir '$gold'"; exit 13
     fi
 
-    echo cp -rpf $cache .
+    echo "    cp -rpf $cache ."
     cp -rpf $cache .
 
 #     # Maybe do this again?
@@ -413,7 +413,8 @@ set +x
 for step in ${build_sequence[@]}; do
 
     # Expand aliases e.g. "syn" -> "synopsys-dc-synthesis"
-    echo -n "    $step -> "
+    echo "================================================================"
+    echo -n "    Ready to do step $step -> "
     step=`step_alias $step`
     echo $step
 
@@ -456,7 +457,7 @@ for step in ${build_sequence[@]}; do
 #             cp -rpf $gold/full_chip/*tile_array/$f .
 #         done
 #         echo "+++ ......TODO list (`date +'%a %H:%M'`)"
-#         make -n cadence-innovus-init | grep 'mkdir.*output' | sed 's/.output.*//'
+#         make -n cadence-innovus-init | grep 'mkdir.*output' | sed 's/.output.*//' | sed 's/^/  /'
 # 
 #         # Maybe do this again?
 #         touch .stamp; # Breaks if don't do this before final step; I forget why...? Chris knows...

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -336,11 +336,11 @@ for step in ${build_sequence[@]}; do
         echo '--- ......SETUP context from gold cache'
         gold=/sim/buildkite-agent/gold
 
-        echo cp -rp $gold/full_chip/*tile_array/0-Tile_MemCore .
-        cp -rp $gold/full_chip/*tile_array/0-Tile_MemCore .
+        echo cp -rpf $gold/full_chip/*tile_array/0-Tile_MemCore .
+        cp -rpf $gold/full_chip/*tile_array/0-Tile_MemCore .
         
-        echo cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
-        cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
+        echo cp -rpf $gold/full_chip/*tile_array/1-Tile_PE .
+        cp -rpf $gold/full_chip/*tile_array/1-Tile_PE .
         
         # If stop copying here, still takes an hour
         # What if we copy more stuff?
@@ -353,8 +353,8 @@ for step in ${build_sequence[@]}; do
             9-rtl \
             11-tsmc16 \
         ; do
-            echo cp -rp $gold/full_chip/*tile_array/$f .
-            cp -rp $gold/full_chip/*tile_array/1-Tile_PE .
+            echo cp -rpf $gold/full_chip/*tile_array/$f .
+            cp -rpf $gold/full_chip/*tile_array/1-Tile_PE .
         done
 
         continue

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -121,9 +121,14 @@ done
 
 
 
-
-
-
+# gold=/sim/buildkite-agent/gold
+# m=full_chippp
+# g=`cd $gold/*${m}; pwd`; ls $gold >& /dev/null || echo FAIL=true
+# `cd $gold/*${m}` || echo FAIL
+# ls $g || echo FAIL
+# echo $g
+# 
+# 
 
 
 
@@ -356,25 +361,25 @@ if [ "$copy_list" ]; then
     echo "+++ ......SETUP context from gold cache (`date +'%a %H:%M'`)"
     gold=/sim/buildkite-agent/gold
     for m in ${modlist[@]}; do 
-        # build_module $m; 
-        gold=`cd $gold/${m}*; pwd` || FAIL=true
+        ls $gold/*${m} >& /dev/null || echo FAIL
         if [ "$FAIL" == "true" ]; then
             echo "***ERROR could not find cache dir '$gold'"; exit 13
         fi
+        gold=`cd $gold/*${m}; pwd`
     done
     [ "$DEBUG" ] && echo "Found gold cache directory '$gold'"
 fi
 
-# TEST AREA LEAVE HEADLIGHTS ON
-set +x
-modlist=(full_chip tile_array Tile_PE)
-modlist=(full_chip tile_array)
-gold=/sim/buildkite-agent/gold
-for m in ${modlist[@]}; do 
-    # build_module $m; 
-    gold=`cd $gold/*${m}; pwd` || echo oops FIAL
-    echo GOLD=$gold
-done
+# # TEST AREA LEAVE HEADLIGHTS ON
+# set +x
+# modlist=(full_chip tile_array Tile_PE)
+# modlist=(full_chip tile_array)
+# gold=/sim/buildkite-agent/gold
+# for m in ${modlist[@]}; do 
+#     # build_module $m; 
+#     gold=`cd $gold/*${m}; pwd` || echo oops FIAL
+#     echo GOLD=$gold
+# done
 
 # Copy desired info from gold cache
 for step in ${copy_list[@]}; do

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -380,11 +380,12 @@ for step in ${build_sequence[@]}; do
 done
 
 echo '+++ PASS/FAIL info maybe, to make you feel good'
-grep -i error make.log | tail
+set -x
+grep -i error make.log | tail || PASS
 echo "-----"
-grep FAIL make.log | tail
+grep FAIL make.log | tail || PASS
 echo "-----"
-grep -i passed make.log | tail
+grep -i passed make.log | tail || PASS
 echo ""
 
 echo '+++ RUNTIMES'; make runtimes

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -139,6 +139,8 @@ export TMPDIR=/sim/tmp
 
 # Colons is stupids, define "PASS" to use instead
 PASS=:
+alias PASS=:
+
 
 ########################################################################
 # Find GARNET_HOME
@@ -327,6 +329,7 @@ if [ "$copy_list" ]; then
         # Ugh stupid special case TODO/FIXME need a '--use_stash' arg now I guess
         if [ "$step" == "rtl" ]; then
             if [ "$final_module" == "tile_array" ]; then
+                # alex hack for fixing/preventing bad rtl
                 set -x
                 mflowgen stash link --path /home/ajcars/tile-array-rtl-stash/2020-0724-mflowgen-stash-75007d
                 mflowgen stash pull --hash 2fbc7a
@@ -379,8 +382,26 @@ for step in ${build_sequence[@]}; do
     fi
 done
 
+
+
+# TEMPORARY DELETEME SOON!!!
+echo '+++ TEMPORARY hack to save results in gold cache'
+if [ "$final_module" == "tile_array" ]; then
+  gold=/sim/buildkite-agent/gold.$$
+  test -d $$gold || mkdir $$gold
+  cp -rp . $mflowgen $gold
+fi
+
+
+
+
+
+
+
+
 echo '+++ PASS/FAIL info maybe, to make you feel good'
 set -x
+alias PASS=:
 grep -i error make.log | tail || PASS
 echo "-----"
 grep FAIL make.log | tail || PASS

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -57,6 +57,25 @@ while [ $# -gt 0 ] ; do
     shift
 done
         
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 DEBUG=true
 if [ "$DEBUG"=="true" ]; then
     echo VERBOSE=$VERBOSE
@@ -92,7 +111,22 @@ if [ "$DEBUG"=="true" ]; then
 fi
 
 # Turn copy list into an array e.g. 'Tile_PE,rtl' => 'Tile_PE,rtl'
-copy_steps=`echo $use_cached | tr ',' ' '`
+copy_list=`echo $use_cached | tr ',' ' '`
+
+
+if [ "$copy_list" ]; then echo YES FOUND COPY LIST; fi
+for step in ${copy_list[@]}; do
+    echo $step
+done
+
+
+
+
+
+
+
+
+
 
 
 if [ "$branch_filter" ]; then

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -375,7 +375,7 @@ for step in ${build_sequence[@]}; do
     # [ "$DEBUG" ] && echo "    $step_orig -> $step"
 
     echo "+++ ......TODO list for step $step (`date +'%a %H:%M'`)"
-    make -n $step || PASS
+    make -n $step > /dev/null || PASS ; # Get error messages, if any, maybe.
     make -n $step | grep 'mkdir.*output' | sed 's/.output.*//' | sed 's/mkdir -p/  make/' || PASS
 
     echo "--- ......MAKE $step (`date +'%a %H:%M'`)"

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -389,7 +389,7 @@ echo '+++ TEMPORARY hack to save results in gold cache'
 if [ "$final_module" == "tile_array" ]; then
   gold=/sim/buildkite-agent/gold.$$
   test -d $$gold || mkdir $$gold
-  cp -rp . $mflowgen $gold
+  cp -rpf . $mflowgen $gold
 fi
 
 

--- a/mflowgen/tile_array/custom-init/outputs/floorplan.tcl
+++ b/mflowgen/tile_array/custom-init/outputs/floorplan.tcl
@@ -178,33 +178,50 @@ for {set row $min_row} {$row <= $max_row} {incr row} {
       # Here, we find whcih hi/lo pin is supposed to drive this tile_id input pin
       # We're going to draw a shape to connect these two pins
 
-      # OLD - no good b/c $id_net no longer unique for a given id pin :(
-      # E.g. recently every 'zero' pin has the same net name 'const_0_1_out_0_'
-      set tie_pin [get_pins -of_objects $id_net -filter "hierarchical_name!~*id*"] 
-
-#       ################################################################
-#       # BEGIN new code for finding hi/lo pin "tie_pin"
-#       #
-#       # Find hi/lo pins nearest targeted tile_id pin, e.g.
-#       #   - id pin 0 is between lo[0] and hi[0]
-#       #   - id pin 1 is between hi[0] and lo[1]
-#       set lo_index [expr int(floor($index/2.0))]; # E.g. index=1 => lo_index=0
-#       set hi_index [expr int( ceil($index/2.0))]; # E.g. index=1 => hi_index=1
-#       set lo_pin "$tile_name/lo[$lo_index]"     ; # "Tile_X00_Y01/lo[0]"
-#       set hi_pin "$tile_name/hi[$hi_index]"     ; # "Tile_X00_Y01/hi[1]"
-#       #
-#       # Decide which pin to connect, 'hi' or 'lo'
-#       # Note new algorithm depends on the following assumptions:
-#       #   * all zero-targeted id pins are part of net 'const_0_1_out_0_'
-#       #   * all id pins whose net name is not 'const_0_1_out_0_' are one-targeted pins
-#       if { $id_net_name == "const_0_1_out_0_" } then {
-#           set tie_pin [get_pins -filter "hierarchical_name==$lo_pin"]
-#       } else {
-#           set tie_pin [get_pins -filter "hierarchical_name==$hi_pin"]
-#       }
-#         # set tie_pin_name [get_property $tie_pin hierarchical_name]
-#       # END new code for finding hi/lo pin "tie_pin"
-#       ################################################################
+      # Find the nearest hi/lo pin to which we can connect the id pin
+      if {1 > 0} {
+          # Original code broke when magma implemented some optimizations.
+          # It was no good b/c $id_net was no longer unique for a given id pin :(
+          # E.g. every 'zero' pin had the same net name 'const_0_1_out_0_'
+          # So we wrote and used the new code in the else clause below.
+          #
+          # Original code was reinstated after we implemented a hack
+          # that pulls old un-optimized RTL code before tile_array
+          # step; also I guess maybe we want this to break when/if
+          # per-pin net names not unique b/c we think it will break
+          # LVS LVS, tiehi/tielo assignments later...maybe...?
+          set tie_pin [get_pins -of_objects $id_net -filter "hierarchical_name!~*id*"] 
+          
+      } else {
+          # Alternative method for finding tie_pin, works with latest magma "optimization."
+          # Does not depend on per-pin unique net names,
+          # but makes other dumb assumptions, see below for details.
+          # I.e. works when all "0" level pins are connected to same net "const_0..."
+          
+          ################################################################
+          # BEGIN new code for finding hi/lo pin "tie_pin"
+          #
+          # Find hi/lo pins nearest targeted tile_id pin, e.g.
+          #   - id pin 0 is between lo[0] and hi[0]
+          #   - id pin 1 is between hi[0] and lo[1]
+          set lo_index [expr int(floor($index/2.0))]; # E.g. index=1 => lo_index=0
+          set hi_index [expr int( ceil($index/2.0))]; # E.g. index=1 => hi_index=1
+          set lo_pin "$tile_name/lo[$lo_index]"     ; # "Tile_X00_Y01/lo[0]"
+          set hi_pin "$tile_name/hi[$hi_index]"     ; # "Tile_X00_Y01/hi[1]"
+          #
+          # Decide which pin to connect, 'hi' or 'lo'
+          # Note new algorithm depends on the following assumptions:
+          #   * all zero-targeted id pins are part of net 'const_0_1_out_0_'
+          #   * all id pins whose net name is not 'const_0_1_out_0_' are one-targeted pins
+          if { $id_net_name == "const_0_1_out_0_" } then {
+              set tie_pin [get_pins -filter "hierarchical_name==$lo_pin"]
+          } else {
+              set tie_pin [get_pins -filter "hierarchical_name==$hi_pin"]
+          }
+          # set tie_pin_name [get_property $tie_pin hierarchical_name]
+          # END new code for finding hi/lo pin "tie_pin"
+          ################################################################
+      } 
 
       # Build the shape that connects id pin to hi/lo pin
       set tie_pin_y [get_property $tie_pin y_coordinate]

--- a/mflowgen/tile_array/custom-init/outputs/floorplan.tcl
+++ b/mflowgen/tile_array/custom-init/outputs/floorplan.tcl
@@ -180,31 +180,31 @@ for {set row $min_row} {$row <= $max_row} {incr row} {
 
       # OLD - no good b/c $id_net no longer unique for a given id pin :(
       # E.g. recently every 'zero' pin has the same net name 'const_0_1_out_0_'
-      # set tie_pin [get_pins -of_objects $id_net -filter "hierarchical_name!~*id*"] 
+      set tie_pin [get_pins -of_objects $id_net -filter "hierarchical_name!~*id*"] 
 
-      ################################################################
-      # BEGIN new code for finding hi/lo pin "tie_pin"
-      #
-      # Find hi/lo pins nearest targeted tile_id pin, e.g.
-      #   - id pin 0 is between lo[0] and hi[0]
-      #   - id pin 1 is between hi[0] and lo[1]
-      set lo_index [expr int(floor($index/2.0))]; # E.g. index=1 => lo_index=0
-      set hi_index [expr int( ceil($index/2.0))]; # E.g. index=1 => hi_index=1
-      set lo_pin "$tile_name/lo[$lo_index]"     ; # "Tile_X00_Y01/lo[0]"
-      set hi_pin "$tile_name/hi[$hi_index]"     ; # "Tile_X00_Y01/hi[1]"
-      #
-      # Decide which pin to connect, 'hi' or 'lo'
-      # Note new algorithm depends on the following assumptions:
-      #   * all zero-targeted id pins are part of net 'const_0_1_out_0_'
-      #   * all id pins whose net name is not 'const_0_1_out_0_' are one-targeted pins
-      if { $id_net_name == "const_0_1_out_0_" } then {
-          set tie_pin [get_pins -filter "hierarchical_name==$lo_pin"]
-      } else {
-          set tie_pin [get_pins -filter "hierarchical_name==$hi_pin"]
-      }
-        # set tie_pin_name [get_property $tie_pin hierarchical_name]
-      # END new code for finding hi/lo pin "tie_pin"
-      ################################################################
+#       ################################################################
+#       # BEGIN new code for finding hi/lo pin "tie_pin"
+#       #
+#       # Find hi/lo pins nearest targeted tile_id pin, e.g.
+#       #   - id pin 0 is between lo[0] and hi[0]
+#       #   - id pin 1 is between hi[0] and lo[1]
+#       set lo_index [expr int(floor($index/2.0))]; # E.g. index=1 => lo_index=0
+#       set hi_index [expr int( ceil($index/2.0))]; # E.g. index=1 => hi_index=1
+#       set lo_pin "$tile_name/lo[$lo_index]"     ; # "Tile_X00_Y01/lo[0]"
+#       set hi_pin "$tile_name/hi[$hi_index]"     ; # "Tile_X00_Y01/hi[1]"
+#       #
+#       # Decide which pin to connect, 'hi' or 'lo'
+#       # Note new algorithm depends on the following assumptions:
+#       #   * all zero-targeted id pins are part of net 'const_0_1_out_0_'
+#       #   * all id pins whose net name is not 'const_0_1_out_0_' are one-targeted pins
+#       if { $id_net_name == "const_0_1_out_0_" } then {
+#           set tie_pin [get_pins -filter "hierarchical_name==$lo_pin"]
+#       } else {
+#           set tie_pin [get_pins -filter "hierarchical_name==$hi_pin"]
+#       }
+#         # set tie_pin_name [get_property $tie_pin hierarchical_name]
+#       # END new code for finding hi/lo pin "tie_pin"
+#       ################################################################
 
       # Build the shape that connects id pin to hi/lo pin
       set tie_pin_y [get_property $tie_pin y_coordinate]


### PR DESCRIPTION
Implements a quick 5-minute tile_array test that uses pre-built synthesized RTL to verify cadence-innovus-init scripts. With this addition, we now have a 35-minute test suite of three buildkite checks: PE tile synthesis, mem tile synthesis, and this new tile_array test.

Also available in pipeline.yml, but turned off by default:
* a 60-minute tile_array check that start from pre-built RTL, then synthesizes it.
* a 90-minute tile_array check that starts from scratch and runs through the init stage.

This latest version of test_module has greatly expanded capabilities, including a "--use_cache" option to bring in pre-built steps from a gold cache etc.
```
./test_module.sh --help

Usage: ./test_module.sh [OPTION] <module>,<subgraph>,<subsubgraph>... --steps <step1>,<step2>...

Options:
  --branch <b>  only run test if in git branch <b>
  -v, --verbose VERBOSE mode
  -q, --quiet   QUIET mode
  -h, --help    help and examples
  --debug       DEBUG mode
  --steps       step(s) to run in the indicated (sub)graph. default = 'lvs,drc'
  --use_cache   list of steps to copy from cache

Examples:
    ./test_module.sh Tile_PE
    ./test_module.sh Tile_MemCore
    ./test_module.sh Tile_PE --branch 'devtile*'
    ./test_module.sh --verbose Tile_PE --steps synthesis
    ./test_module.sh full_chip tile_array Tile_PE --steps synthesis
    ./test_module.sh full_chip tile_array Tile_PE --steps synthesis --use_cache Tile_PE,Tile_MemCore
```

So e.g. the existing tests in pipeline.yml look something like this:
```
- label: 'MemCore synth 17m'
  commands:
  - test_module.sh full_chip tile_array Tile_MemCore --steps synthesis --debug

- label: 'PE synth 23m'
  commands:
  - test_module.sh full_chip tile_array Tile_PE --steps synthesis --debug

# tile-array, fastest version, uses cached synthesis results, takes 5 min
- label: 'array init only 5m'
  commands:
  - 'mflowgen/test/test_module.sh full_chip tile_array
       --debug
       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
       --steps init'
```

...and the two tile_array tests that are currently commented-out look like this:

```
# tile-array middle version uses cached rtl but does synthesis, takes 22 minutes
# - label: 'array syn+init 22m'
#   commands:
#   - 'mflowgen/test/test_module.sh full_chip tile_array
#        --debug
#        --use_cached PE,MemCore,rtl
#        --steps syn,init'

# tile-array slowest version builds rtl from scratch, takes 1.5 hr maybe
# - label: 'tile-array init 90m'
#   commands:
#   - 'mflowgen/test/test_module.sh full_chip tile_array
#        --debug
#        --steps syn,init'
```
