### PR TITLE
rtl-reuse

### DIFF
--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -2,7 +2,8 @@
 # Hierarchical flows can accept RTL as an input from parent graph
 if [ -f ../inputs/design.v ]; then
   echo "Using RTL from parent graph"
-  ln -s ../../inputs/design.v outputs/design.v
+  mkdir outputs
+  (cd outputs; ln -s ../../inputs/design.v)
 else
   if [ $soc_only = True ]; then
     echo "soc_only set to true. Garnet not included"

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -1,80 +1,86 @@
 #!/bin/bash
-if [ $soc_only = True ]; then
-  echo "soc_only set to true. Garnet not included"
-  touch outputs/design.v
+# Hierarchical flows can accept RTL as an input from parent graph
+if [ -f ../inputs/design.v ]; then
+  echo "Using RTL from parent graph"
+  ln -s ../../inputs/design.v outputs/design.v
 else
-  # Clean out old rtl outputs
-  rm -rf $GARNET_HOME/genesis_verif
-  rm -f $GARNET_HOME/garnet.v
-
-  # Build up the flags we want to pass to python garnet.v
-  flags="--width $array_width --height $array_height -v --no-sram-stub"
- 
-  if [ $PWR_AWARE == False ]; then
-   flags+=" --no-pd"
-  fi
- 
-  if [ $interconnect_only == True ]; then
-   flags+=" --interconnect-only"
-  fi
- 
-  # Use aha docker container for all dependencies 
-  if [ $use_container == True ]; then
-    # Clone AHA repo
-    git clone https://github.com/StanfordAHA/aha.git
-    cd aha
-    # install the aha wrapper script
-    pip install -e .
-
-    # pull docker image from docker hub
-    docker pull stanfordaha/garnet:latest
-    
-    # run the container in the background and delete it when it exits
-    # (this will print out the name of the container to attach to)
-    container_name=$(aha docker)
-    echo "container-name: $container_name"
-
-    if [ $use_local_garnet == True ]; then
-      docker exec $container_name /bin/bash -c "rm -rf /aha/garnet"
-      # Clone local garnet repo to prevent copying untracked files
-      git clone $GARNET_HOME ./garnet
-      docker cp ./garnet $container_name:/aha/garnet
-    fi
-
-    # run garnet.py in container and concat all verilog outputs
-    docker exec $container_name /bin/bash -c \
-      "source /aha/bin/activate && aha garnet $flags;
-       cd garnet
-       if [ -d "genesis_verif" ]; then
-         cp garnet.v genesis_verif/garnet.v
-         cat genesis_verif/* >> design.v
-       else
-         cp garnet.v design.v
-       fi"
-    # Copy the concatenated design.v output out of the container
-    docker cp $container_name:/aha/garnet/design.v ../outputs/design.v
-    # Kill the container
-    docker kill $container_name
-    echo "killed docker container $container_name"
-    cd ..
-  
-  # Else we want to use local python env to generate rtl 
+  if [ $soc_only = True ]; then
+    echo "soc_only set to true. Garnet not included"
+    touch outputs/design.v
   else
-    current_dir=$(pwd)
-    cd $GARNET_HOME
-     
-    eval "python garnet.py $flags"
-    
-    # If there are any genesis files, we need to cat those
-    # with the magma generated garnet.v
-    if [ -d "genesis_verif" ]; then
-      cp garnet.v genesis_verif/garnet.sv
-      cat genesis_verif/* >> $current_dir/outputs/design.v
-    # Otherwise, garnet.v contains all rtl
-    else
-      cp garnet.v $current_dir/outputs/design.v
-    fi
-  fi 
+    # Clean out old rtl outputs
+    rm -rf $GARNET_HOME/genesis_verif
+    rm -f $GARNET_HOME/garnet.v
   
-  cd $current_dir
+    # Build up the flags we want to pass to python garnet.v
+    flags="--width $array_width --height $array_height -v --no-sram-stub"
+   
+    if [ $PWR_AWARE == False ]; then
+     flags+=" --no-pd"
+    fi
+   
+    if [ $interconnect_only == True ]; then
+     flags+=" --interconnect-only"
+    fi
+   
+    # Use aha docker container for all dependencies 
+    if [ $use_container == True ]; then
+      # Clone AHA repo
+      git clone https://github.com/StanfordAHA/aha.git
+      cd aha
+      # install the aha wrapper script
+      pip install -e .
+  
+      # pull docker image from docker hub
+      docker pull stanfordaha/garnet:latest
+      
+      # run the container in the background and delete it when it exits
+      # (this will print out the name of the container to attach to)
+      container_name=$(aha docker)
+      echo "container-name: $container_name"
+  
+      if [ $use_local_garnet == True ]; then
+        docker exec $container_name /bin/bash -c "rm -rf /aha/garnet"
+        # Clone local garnet repo to prevent copying untracked files
+        git clone $GARNET_HOME ./garnet
+        docker cp ./garnet $container_name:/aha/garnet
+      fi
+  
+      # run garnet.py in container and concat all verilog outputs
+      docker exec $container_name /bin/bash -c \
+        "source /aha/bin/activate && aha garnet $flags;
+         cd garnet
+         if [ -d "genesis_verif" ]; then
+           cp garnet.v genesis_verif/garnet.v
+           cat genesis_verif/* >> design.v
+         else
+           cp garnet.v design.v
+         fi"
+      # Copy the concatenated design.v output out of the container
+      docker cp $container_name:/aha/garnet/design.v ../outputs/design.v
+      # Kill the container
+      docker kill $container_name
+      echo "killed docker container $container_name"
+      cd ..
+    
+    # Else we want to use local python env to generate rtl 
+    else
+      current_dir=$(pwd)
+      cd $GARNET_HOME
+       
+      eval "python garnet.py $flags"
+      
+      # If there are any genesis files, we need to cat those
+      # with the magma generated garnet.v
+      if [ -d "genesis_verif" ]; then
+        cp garnet.v genesis_verif/garnet.sv
+        cat genesis_verif/* >> $current_dir/outputs/design.v
+      # Otherwise, garnet.v contains all rtl
+      else
+        cp garnet.v $current_dir/outputs/design.v
+      fi
+    fi 
+    
+    cd $current_dir
+  fi
 fi

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -35,6 +35,8 @@ def construct():
     'array_width'       : 32,
     'array_height'      : 16,
     'interconnect_only' : False,
+    # Power Domains
+    'PWR_AWARE'         : True
     # Include Garnet?
     'soc_only'          : False,
     # Include SoC core? (use 0 for false, 1 for true)

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -36,7 +36,7 @@ def construct():
     'array_height'      : 16,
     'interconnect_only' : False,
     # Power Domains
-    'PWR_AWARE'         : True
+    'PWR_AWARE'         : True,
     # Include Garnet?
     'soc_only'          : False,
     # Include SoC core? (use 0 for false, 1 for true)

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -296,6 +296,8 @@ def construct():
           g.connect_by_name( block, power_gdsmerge )
           g.connect_by_name( block, drc            )
           g.connect_by_name( block, lvs            )
+      # Tile_array can use rtl from rtl node
+      g.connect_by_name( rtl, tile_array )
 
   g.connect_by_name( rtl,         dc        )
   g.connect_by_name( soc_rtl,     dc        )

--- a/mflowgen/full_chip/tile_array/configure.yml
+++ b/mflowgen/full_chip/tile_array/configure.yml
@@ -3,6 +3,9 @@ name: tile_array
 commands:
   - bash get_tile_array_outputs.sh
 
+inputs:
+  - design.v
+
 outputs:
   - tile_array_tt.lib
   - tile_array.lef

--- a/mflowgen/tile_array/Tile_MemCore/configure.yml
+++ b/mflowgen/tile_array/Tile_MemCore/configure.yml
@@ -3,6 +3,9 @@ name: Tile_MemCore
 commands:
   - bash get_Tile_MemCore_outputs.sh
 
+inputs:
+  - design.v
+
 outputs:
   - Tile_MemCore_tt.lib
   - Tile_MemCore.lef

--- a/mflowgen/tile_array/Tile_PE/configure.yml
+++ b/mflowgen/tile_array/Tile_PE/configure.yml
@@ -3,6 +3,9 @@ name: Tile_PE
 commands:
   - bash get_Tile_PE_outputs.sh
 
+inputs:
+  - design.v
+
 outputs:
   - Tile_PE_tt.lib
   - Tile_PE.lef

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -191,6 +191,9 @@ def construct():
   # memory tiles. If this is the case, we don't need to run the
   # memory tile flow.
   if parameters['array_width'] > 3:
+      # inputs to Tile_MemCore
+      g.connect_by_name( rtl, Tile_MemCore )
+      # outputs from Tile_MemCore
       g.connect_by_name( Tile_MemCore,      dc           )
       g.connect_by_name( Tile_MemCore,      iflow        )
       g.connect_by_name( Tile_MemCore,      init         )
@@ -211,6 +214,10 @@ def construct():
       g.connect_by_name( custom_lvs,        lvs          )
       g.connect_by_name( Tile_MemCore,      vcs_sim      )
 
+  
+  # inputs to Tile_PE
+  g.connect_by_name( rtl, Tile_PE )
+  # outputs from Tile_PE
   g.connect_by_name( Tile_PE,      dc           )
   g.connect_by_name( Tile_PE,      iflow        )
   g.connect_by_name( Tile_PE,      init         )

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -35,6 +35,8 @@ def construct():
     'array_width'       : 32,
     'array_height'      : 16,
     'interconnect_only' : False,
+    # Power Domains
+    'PWR_AWARE'         : True
     # Useful Skew (CTS)
     'useful_skew'       : False,
     # Testing

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -36,7 +36,7 @@ def construct():
     'array_height'      : 16,
     'interconnect_only' : False,
     # Power Domains
-    'PWR_AWARE'         : True
+    'PWR_AWARE'         : True,
     # Useful Skew (CTS)
     'useful_skew'       : False,
     # Testing


### PR DESCRIPTION
This PR makes it possible for hierarchical blocks to re-use the rtl from the parent graph, rather than regenerating it.

This approach has 3 main advantages:
- Avoids wasted time generating RTL that we’ve already generated in multiple places within full chip graph (can be significant savings for RTL of full size tile array)
- Avoids hacking in stashed rtl to nodes within fullchip graph (or within tile array graph). Instead we generate the RTL at the topmost graph, and feed it in as an input to the nodes that need it within.
- By only generating 1 version of the RTL, we ensure that there can never be any inconsistencies between the rtl that different nodes are using.
