### PR TITLE
Pin to old pytest since the new one turns syntax warning into error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - docker run -d -it --name garnet keyiz/garnet-flow bash
     - docker cp ../garnet garnet:/
     - docker exec -i garnet bash -c "pip install -r /garnet/requirements.txt" 
-    - docker exec -i garnet bash -c "pip install pytest python-coveralls"
+    - docker exec -i garnet bash -c "pip install pytest==5.4.3 python-coveralls"
     - docker exec -i garnet bash -c "pip install pytest-cov pytest-codestyle z3-solver" 
       #- docker exec -i garnet bash -c "wget https://web.stanford.edu/~makaim/files/yosys-static -O ./bin/yosys"
       #- docker exec -i garnet bash -c "chmod +x ./bin/yosys"


### PR DESCRIPTION
There are some deprecation warnings in one of the libraries used by garnet. The latest pytest added a braking changes that turns all syntax warnings into error, see [here](https://docs.pytest.org/en/stable/changelog.html#pytest-6-0-0-2020-07-28). This PR pinned pytest to the old version before the dependent library is fixed.