### PR TITLE
Ensure that glb_top rtl is generated in glb_top flow, rather than rel…

### DIFF
--- a/bin/requirements_check.sh
+++ b/bin/requirements_check.sh
@@ -128,21 +128,22 @@ avail=`df $tmpdir --output=avail | tail -1`
 avail_human=`df -H $tmpdir --output=avail | tail -1`
 avail_human=`echo $avail_human` ; # Eliminate whitespace?
 echo ""
-echo "Looks like /tmp has $avail_human available space"
+echo "Looks like $tmpdir has $avail_human available space"
 echo "-- Note need more than 3G for postroute of full chip"
 echo "-- 60G has been enough in the past"
 echo "-- Not sure about space < 60G and > 3G"
 echo ""
-G=$(( 1024 * 1024 * 1024 ))
-if [[ $avail < $(( 3 * $G )) ]]; then
+# G=$(( 1024 * 1024 * 1024 ))
+G=$(( 1024 * 1024 )) ; # As reported by df in 1024-byte blocks!
+if [[ $avail -lt $(( 3 * $G )) ]]; then
     ERROR "less than 3G definitely NOT ENOUGH for full chip postroute"
     echo "Recommend you do something like 'export TMPDIR=/sim/tmp'"
     exit 13
-elif [[ $avail < $(( 20 * $G )) ]]; then
+elif [[ $avail -lt $(( 20 * $G )) ]]; then
     ERROR "less than 20G probably NOT ENOUGH for full chip postroute"
     echo "Recommend you do something like 'export TMPDIR=/sim/tmp'"
     exit 13
-elif [[ $avail < $(( 60 * $G )) ]]; then
+elif [[ $avail -lt $(( 60 * $G )) ]]; then
     echo "***WARNING less than 60G not (yet) proven to be enough"
     echo "           Recommend you do something like 'export TMPDIR=/sim/tmp'"
     echo ""

--- a/mflowgen/glb_top/rtl/gen_rtl.sh
+++ b/mflowgen/glb_top/rtl/gen_rtl.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# SystemRDL run
+make -C $GARNET_HOME/global_buffer rtl
+
 cat $GARNET_HOME/global_buffer/rtl/global_buffer_param.svh >> outputs/design.v
 cat $GARNET_HOME/global_buffer/rtl/global_buffer_pkg.svh >> outputs/design.v
 cat $GARNET_HOME/global_buffer/rtl/axil_ifc.sv >> outputs/design.v


### PR DESCRIPTION
This PR updates the glb_top rtl node to always run the make command necessary to generate glb rtl. With this change, it's not a problem for the glb_top rtl node to be run before the glb_tile node within the glb_top graph.