### PR TITLE
add -p to mkdir command in rtl node

### DIFF
--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -15,3 +15,5 @@ parameters:
   use_container: True
   use_local_garnet: True
 
+postconditions:
+  - assert File( 'outputs/design.v' )        # must exist

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -2,7 +2,7 @@
 # Hierarchical flows can accept RTL as an input from parent graph
 if [ -f ../inputs/design.v ]; then
   echo "Using RTL from parent graph"
-  mkdir outputs
+  mkdir -p outputs
   (cd outputs; ln -s ../../inputs/design.v)
 else
   if [ $soc_only = True ]; then


### PR DESCRIPTION
Tiny fix to prevent mkdir error in rtl node.