### PR TITLE
Bktest updates

### DIFF
--- a/.buildkite/pipeline_fullchip.yml
+++ b/.buildkite/pipeline_fullchip.yml
@@ -1,24 +1,22 @@
 steps:
 
-# - label: 'full_chip 36h'
-#   agents: { queue: "papers" }
-#   commands:
-#   - steps=rtl,tile_array,glb_top,global_controller,tile_array
-#   - steps=$${steps},dragonphy,soc-rtl,synthesis
-#   - steps=$${steps},place,route,postroute_hold,lvs
-#   - 'mflowgen/test/test_module.sh full_chip
-#        --debug
-#        --update_cache /sim/buildkite-agent/gold.latest
-#        --steps $$steps'
-
-
-- label: 'glb-top synthesis'
+- label: 'full_chip 36h'
   agents: { queue: "papers" }
   commands:
-  - 'mflowgen/test/test_module.sh full_chip glb_top
+  - steps=rtl,tile_array,glb_top,global_controller,tile_array
+  - steps=$${steps},dragonphy,soc-rtl,synthesis
+  - steps=$${steps},place,route,postroute_hold,lvs
+  - 'mflowgen/test/test_module.sh full_chip
        --debug
-       --update_cache /sim/buildkite-agent/gold.$$BUILDKITE_BUILD_NUMBER
-       --steps syn'
+       --update_cache /sim/buildkite-agent/gold.latest
+       --steps $$steps'
+
+# - label: 'glb-top synthesis'
+#   agents: { queue: "papers" }
+#   commands:
+#   - 'mflowgen/test/test_module.sh full_chip glb_top
+#        --debug
+#        --steps syn'
 
 
 ##############################################################################

--- a/.buildkite/pipeline_fullchip.yml
+++ b/.buildkite/pipeline_fullchip.yml
@@ -5,19 +5,11 @@ steps:
   commands:
   - steps=rtl,tile_array,glb_top,global_controller,tile_array
   - steps=$${steps},dragonphy,soc-rtl,synthesis
-  - steps=$${steps},place,route,postroute_hold,lvs
+  - steps=$${steps},place,route,postroute_hold,lvs,drc
   - 'mflowgen/test/test_module.sh full_chip
        --debug
-       --update_cache /sim/buildkite-agent/gold.latest
+       --update_cache /sim/buildkite-agent/gold.$$BUILDKITE_BUILD_NUMBER
        --steps $$steps'
-
-# - label: 'glb-top synthesis'
-#   agents: { queue: "papers" }
-#   commands:
-#   - 'mflowgen/test/test_module.sh full_chip glb_top
-#        --debug
-#        --steps syn'
-
 
 ##############################################################################
 # FULL CHIP RUNS

--- a/.buildkite/pipeline_fullchip.yml
+++ b/.buildkite/pipeline_fullchip.yml
@@ -21,6 +21,21 @@ steps:
        --steps syn'
 
 
+##############################################################################
+# FULL CHIP RUNS
+# 
+# To build the full chip through LVS, starting from scratch:
+#   (Note if you do it all at one go like this, it doesn't save anything
+#   til the very end, and then only if nothing failed along the way! :(
+# 
+# - label: 'full_chip 36h'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - 'mflowgen/test/test_module.sh full_chip
+#        --debug
+#        --update_cache /sim/buildkite-agent/gold.$$BUILDKITE_BUILD_NUMBER
+#        --steps lvs'
+# 
 # To build the full chip through LVS, starting from scratch, with discrete checkpoints
 # - label: 'full_chip 36h'
 #   agents: { jobsize: "hours" }

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -3,22 +3,22 @@ steps:
 ##############################################################################
 # FULL CHIP RUNS - see pipeline_fullchip.yml
 
-##############################################################################
-# INDIVIDUAL TILE RUNS
-
-- label: 'MemCore synth 17m'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
-
-- label: 'PE synth 23m'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
+# ##############################################################################
+# # INDIVIDUAL TILE RUNS
+# 
+# - label: 'MemCore synth 17m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test=mflowgen/test/test_module.sh
+#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+# - wait: { continue_on_failure: true } # One step at a time + continue on failure
+# 
+# - label: 'PE synth 23m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test=mflowgen/test/test_module.sh
+#   - $$test full_chip tile_array Tile_PE --steps synthesis --debug
+# - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 
 
@@ -32,8 +32,14 @@ steps:
   - 'mflowgen/test/test_module.sh full_chip tile_array
        --debug
        --use_cached constraints,MemCore,PE,rtl,synthesis
+       --update_cache /sim/buildkite-agent/cache.$$BUILDKITE_BUILD_NUMBER.deleteme
        --steps init'
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
+
+
+# To build a cache:
+# --update_cache /sim/buildkite-agent/gold.$$BUILDKITE_BUILD_NUMBER
+
 
 
 ########################################################################

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -3,22 +3,22 @@ steps:
 ##############################################################################
 # FULL CHIP RUNS - see pipeline_fullchip.yml
 
-##############################################################################
-# INDIVIDUAL TILE RUNS
-
-- label: 'MemCore synth 17m'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
-
-- label: 'PE synth 23m'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
+# ##############################################################################
+# # INDIVIDUAL TILE RUNS
+# 
+# - label: 'MemCore synth 17m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test=mflowgen/test/test_module.sh
+#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+# - wait: { continue_on_failure: true } # One step at a time + continue on failure
+# 
+# - label: 'PE synth 23m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test=mflowgen/test/test_module.sh
+#   - $$test full_chip tile_array Tile_PE --steps synthesis --debug
+# - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,28 +1,32 @@
 steps:
 
-# ########################################################################
-# - label: 'MemCore synth 17m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - test=mflowgen/test/test_module.sh
-#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# 
-# ########################################################################
-# - label: 'PE synth 23m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - test=mflowgen/test/test_module.sh
-#   - $$test full_chip tile_array Tile_PE --steps synthesis --debug
-# 
-# - wait: ~
-#   continue_on_failure: true
-
 ##############################################################################
 # FULL CHIP RUNS - see pipeline_fullchip.yml
+
+##############################################################################
+# INDIVIDUAL TILE RUNS
+
+########################################################################
+- label: 'MemCore synth 17m'
+  agents: { jobsize: "hours" }
+  commands:
+  - echo PASS
+#   - test=mflowgen/test/test_module.sh
+#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+
+- wait: ~, continue_on_failure: true # Serialize the steps
+
+COMMENT:
+########################################################################
+- label: 'PE synth 23m'
+  agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
+
+# Serialize the steps
+- wait: ~
+  continue_on_failure: true
 
 ##############################################################################
 # TILE_ARRAY RUNS

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,150 +1,70 @@
 steps:
 
-########################################################################
-- label: 'MemCore synth 17m'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
-
-- wait: ~
-  continue_on_failure: true
-
-
-########################################################################
-- label: 'PE synth 23m'
-  agents: { jobsize: "hours" }
-  commands:
-  - test=mflowgen/test/test_module.sh
-  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
-
-- wait: ~
-  continue_on_failure: true
-
+# ########################################################################
+# - label: 'MemCore synth 17m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test=mflowgen/test/test_module.sh
+#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+# 
+# - wait: ~
+#   continue_on_failure: true
+# 
+# 
+# ########################################################################
+# - label: 'PE synth 23m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - test=mflowgen/test/test_module.sh
+#   - $$test full_chip tile_array Tile_PE --steps synthesis --debug
+# 
+# - wait: ~
+#   continue_on_failure: true
 
 ##############################################################################
-# FULL CHIP RUNS
-# 
-# To build the full chip through LVS, starting from scratch:
-#   (Note if you do it all at one go like this, it doesn't save anything
-#   til the very end, and then only if nothing failed along the way! :(
-# 
-# - label: 'full_chip 36h'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - 'mflowgen/test/test_module.sh full_chip
-#        --debug
-#        --update_cache /sim/buildkite-agent/gold.$$BUILDKITE_BUILD_NUMBER
-#        --steps lvs'
-# 
-# To build the full chip through LVS, starting from scratch, with discrete checkpoints
-# - label: 'full_chip 36h'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - 'mflowgen/test/test_module.sh full_chip
-#        --steps tile_array,dragonphy,global_controller,init,place,route,lvs'
-# 
-# To run *only* final LVS step, takes about an hour, using cache:
-# - label: 'full_chip lvs only 60m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - 'mflowgen/test/test_module.sh full_chip
-#        --debug
-#        --use_cached tile_array,global_controller,dragonphy,glb_top,gen_sram_macro,tsmc16,soc-rtl,rtl,constraints,synopsys-dc-synthesis,cadence-innovus-flowsetup,custom-power-chip,custom-init,io_file,init-fullchip,cadence-innovus-init,cadence-innovus-power,cadence-innovus-place,cadence-innovus-cts,cadence-innovus-postcts_hold,pre-route,cadence-innovus-route,cadence-innovus-postroute,cadence-innovus-postroute_hold,netlist-fixing,sealring,cadence-innovus-signoff
-#        --update_cache /sim/buildkite-agent/gold.$$BUILDKITE_BUILD_NUMBER
-#        --steps gdsmerge,lvs'
-# 
-# To build the full chip through LVS+DRC, starting from scratch:
-# - label: 'full_chip 36h'
-#   agents: { jobsize: "hours" }
-#   commands: mflowgen/test/test_module.sh full_chip --steps lvs,drc
-# 
-# To build a new gold cache /sim/buildkite-agent/gold.<build-number>:
-# --update_cache /sim/buildkite-agent/gold.$$BUILDKITE_BUILD_NUMBER
-# 
-# Runtimes as of 31 Jul 2020
-# --------------------------------------------------------------------------------
-# 0-constraints                       --                 0 sec
-# 1-custom-init                       --                 0 sec
-# 2-custom-lvs-rules                  --                 0 sec
-# 3-custom-power-chip                 --                 0 sec
-# 4-dragonphy                         --                 0 sec
-# 5-gen_sram_macro                    --          1 min  1 sec
-# 6-glb_top                           --    4 hr 19 min 22 sec
-# 7-global_controller                 --         35 min 15 sec
-# 9-netlist-fixing                    --                 0 sec
-# 10-pre-route                        --                 0 sec
-# 11-rtl                              --         31 min  6 sec
-# 12-sealring                         --                 0 sec
-# 13-soc-rtl                          --                 4 sec
-# 14-tile_array                       --    8 hr 56 min 50 sec
-# 15-tsmc16                           --                 0 sec
-# 16-io_file                          --                 0 sec
-# 17-synopsys-dc-synthesis            --    2 hr 14 min 12 sec
-# 18-cadence-innovus-flowsetup        --                15 sec
-# 19-init-fullchip                    --                 0 sec
-# 20-cadence-innovus-init             --         10 min 43 sec
-# 21-cadence-innovus-power            --         32 min 52 sec
-# 22-cadence-innovus-place            --    2 hr 15 min 26 sec
-# 24-cadence-innovus-cts              --    2 hr 19 min 56 sec
-# 26-cadence-innovus-postcts_hold     --         14 min 41 sec
-# 27-cadence-innovus-route            --    2 hr  1 min 21 sec
-# 28-cadence-innovus-postroute        --    4 hr 42 min 43 sec
-# 29-cadence-innovus-postroute_hold   --    3 hr  8 min 51 sec
-# 30-cadence-innovus-signoff          --         44 min 47 sec
-# 31-mentor-calibre-gdsmerge          --                44 sec
-# 33-gdsmerge-dragonphy-rdl           --          2 min  5 sec
-# 35-mentor-calibre-lvs               --         54 min 27 sec
-# --------------------------------------------------------------------------------
-# Total                               --   33 hr 46 min 41 sec
-
-
-
+# FULL CHIP RUNS - see pipeline_fullchip.yml
 
 ##############################################################################
 # TILE_ARRAY RUNS
 # 
-# TURN OFF ALL TILE-ARRAY TESTS until we can get them sorted
-# 
-# ########################################################################
-# # tile-array, fastest version, uses cached synthesis results, takes 5 min
-# - label: 'array init only 5m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - 'mflowgen/test/test_module.sh full_chip tile_array
-#        --debug
-#        --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
-#        --steps init'
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# ########################################################################
-# # tile-array middle version uses cached rtl but does synthesis, takes 22 minutes
-# - label: 'array syn+init 22m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - 'mflowgen/test/test_module.sh full_chip tile_array
-#        --debug
-#        --use_cached PE,MemCore,rtl
-#        --steps syn,init'
-# 
-# - wait: ~
-#   continue_on_failure: true
-# 
-# 
-# ########################################################################
-# # tile-array slowest version builds rtl from scratch, takes 1.5 hr maybe
-# # DOES NOT WORK (for now) b/c RTL generation is broken
-# - label: 'tile-array init 90m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - 'mflowgen/test/test_module.sh full_chip tile_array
-#        --debug
-#        --steps syn,init'
-# 
-# - wait: ~
-#   continue_on_failure: true
+########################################################################
+# tile-array, fastest version, uses cached synthesis results, takes 5 min
+- label: 'array init only 5m'
+  agents: { jobsize: "hours" }
+  commands:
+  - 'mflowgen/test/test_module.sh full_chip tile_array
+       --debug
+       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
+       --steps init'
+
+- wait: ~
+  continue_on_failure: true
+
+########################################################################
+# tile-array middle version uses cached rtl but does synthesis, takes 22 minutes
+- label: 'array syn+init 22m'
+  agents: { jobsize: "hours" }
+  commands:
+  - 'mflowgen/test/test_module.sh full_chip tile_array
+       --debug
+       --use_cached PE,MemCore,rtl
+       --steps syn,init'
+
+- wait: ~
+  continue_on_failure: true
+
+
+########################################################################
+# tile-array slowest version builds rtl from scratch, takes 1.5 hr maybe
+- label: 'tile-array init 90m'
+  agents: { jobsize: "hours" }
+  commands:
+  - 'mflowgen/test/test_module.sh full_chip tile_array
+       --debug
+       --steps syn,init'
+
+- wait: ~
+  continue_on_failure: true
 
 
 ########################################################################

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -14,7 +14,7 @@ steps:
 #   - test=mflowgen/test/test_module.sh
 #   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
 
-wait: { continue_on_failure: true }
+- wait: { continue_on_failure: true }
 
 ########################################################################
 - label: 'PE synth 23m'

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -3,22 +3,22 @@ steps:
 ##############################################################################
 # FULL CHIP RUNS - see pipeline_fullchip.yml
 
-# ##############################################################################
-# # INDIVIDUAL TILE RUNS
-# 
-# - label: 'MemCore synth 17m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - test=mflowgen/test/test_module.sh
-#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
-# - wait: { continue_on_failure: true } # One step at a time + continue on failure
-# 
-# - label: 'PE synth 23m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - test=mflowgen/test/test_module.sh
-#   - $$test full_chip tile_array Tile_PE --steps synthesis --debug
-# - wait: { continue_on_failure: true } # One step at a time + continue on failure
+##############################################################################
+# INDIVIDUAL TILE RUNS
+
+- label: 'MemCore synth 17m'
+  agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+- wait: { continue_on_failure: true } # One step at a time + continue on failure
+
+- label: 'PE synth 23m'
+  agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
+- wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -35,8 +35,9 @@ steps:
        --steps init'
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
+
 ########################################################################
-# Left this in (below) as option/example
+# Left this in (below) as option/example of longer tile array run
 ########################################################################
 # tile-array init step, middle version includes synthesis step, takes 22 minutes
 # - label: 'array syn+init 22m'

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -31,7 +31,7 @@ steps:
   commands:
   - 'mflowgen/test/test_module.sh full_chip tile_array
        --debug
-       --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
+       --use_cached constraints,MemCore,PE,rtl,synthesis
        --steps init'
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
 

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -14,7 +14,7 @@ steps:
 #   - test=mflowgen/test/test_module.sh
 #   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
 
-- wait: ~, continue_on_failure: true # Serialize the steps
+wait: { ~, continue_on_failure: true } # Serialize the steps
 
 COMMENT:
 ########################################################################

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -6,148 +6,47 @@ steps:
 ##############################################################################
 # INDIVIDUAL TILE RUNS
 
-########################################################################
 - label: 'MemCore synth 17m'
   agents: { jobsize: "hours" }
   commands:
-  - echo PASS
-#   - test=mflowgen/test/test_module.sh
-#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+- wait: { continue_on_failure: true } # One step at a time + continue on failure
 
-- wait: { continue_on_failure: true }
-
-########################################################################
 - label: 'PE synth 23m'
   agents: { jobsize: "hours" }
   commands:
   - test=mflowgen/test/test_module.sh
   - $$test full_chip tile_array Tile_PE --steps synthesis --debug
+- wait: { continue_on_failure: true } # One step at a time + continue on failure
 
-# Serialize the steps
-- wait: ~
-  continue_on_failure: true
+
 
 ##############################################################################
 # TILE_ARRAY RUNS
-# 
-########################################################################
-# tile-array, fastest version, uses cached synthesis results, takes 5 min
-- label: 'array init only 5m'
+
+# tile-array init step, fastest version, uses cached synthesis results, takes 5 min
+- label: 'array init 5m'
   agents: { jobsize: "hours" }
   commands:
   - 'mflowgen/test/test_module.sh full_chip tile_array
        --debug
        --use_cached MemCore,PE,constraints,rtl,tsmc16,synthesis
        --steps init'
-
-- wait: ~
-  continue_on_failure: true
+- wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 ########################################################################
-# tile-array middle version uses cached rtl but does synthesis, takes 22 minutes
-- label: 'array syn+init 22m'
-  agents: { jobsize: "hours" }
-  commands:
-  - 'mflowgen/test/test_module.sh full_chip tile_array
-       --debug
-       --use_cached PE,MemCore,rtl
-       --steps syn,init'
-
-- wait: ~
-  continue_on_failure: true
-
-
+# Left this in (below) as option/example
 ########################################################################
-# tile-array slowest version builds rtl from scratch, takes 1.5 hr maybe
-- label: 'tile-array init 90m'
-  agents: { jobsize: "hours" }
-  commands:
-  - 'mflowgen/test/test_module.sh full_chip tile_array
-       --debug
-       --steps syn,init'
+# tile-array init step, middle version includes synthesis step, takes 22 minutes
+# - label: 'array syn+init 22m'
+#   agents: { jobsize: "hours" }
+#   commands:
+#   - 'mflowgen/test/test_module.sh full_chip tile_array
+#        --debug
+#        --use_cached PE,MemCore,rtl
+#        --steps syn,init'
+# - wait: { continue_on_failure: true } # One step at a time + continue on failure
+# 
 
-- wait: ~
-  continue_on_failure: true
-
-
-########################################################################
-########################################################################
-########################################################################
-# NOTES / OLDER TESTS not ready to delete yet
-# Rest, from here down, is TBD
-# 
-# ###########################################################
-# # Non-hierarchical version
-# # - label: 'Tile_PE'
-# #   command: mflowgen/test/test_module.sh --verbose Tile_MemCore --steps synthesis
-# #   agents: { jobsize: "hours" }
-# 
-# ###########################################################
-# # FAILS after 5 hours as of 07/11/2020, see build 1719
-# # - label: 'Tile_PE'
-# #   command: mflowgen/test/test_module.sh --verbose Tile_PE
-# #   agents: { jobsize: "hours" }
-# # 
-# # - wait: ~
-# #   continue_on_failure: true
-# 
-# ###########################################################
-# # SUCCEEDS after 3h 17m as of 7/11/2020, see build 1719
-# # - label: 'Tile_MemCore'
-# #   command: mflowgen/test/test_module.sh Tile_MemCore
-# #   agents: { jobsize: "hours" }
-# # 
-# # 
-# # - wait: ~
-# #   continue_on_failure: true
-# 
-# ###########################################################
-# # 
-# # - label: 'icovl'
-# #   command: mflowgen/test/test_module.sh icovl
-# #   agents: { jobsize: "hours" }
-# # 
-# # - wait: ~
-# #   continue_on_failure: true
-# # 
-# ###########################################################
-# # 
-# # - label: 'pad_frame'
-# #   command: mflowgen/test/test_module.sh pad_frame
-# #   agents: { jobsize: "hours" }
-# # 
-# # - wait: ~
-# #   continue_on_failure: true
-# # 
-# ###########################################################
-# # 
-# # - label: 'glb_tile'
-# #   command: mflowgen/test/test_module.sh glb_tile
-# #   agents: { jobsize: "hours" }
-# # 
-# # 
-# # - wait: ~
-# #   continue_on_failure: true
-# # 
-# ###########################################################
-# 
-# 
-# ########################################################################
-# # OLD way using vars
-# # - label: 'tile-array init no-cache 60m'
-# #   agents: { jobsize: "hours" }
-# #   commands:
-# #   - test="mflowgen/test/test_module.sh --debug"
-# #   - cached=MemCore,PE,constraints,rtl,tsmc16,synthesis
-# #   - steps=init
-# #   # - $$test full_chip tile_array --use_cached $$cached --steps $$steps
-# #   # - $$test --debug full_chip tile_array --steps copy,rtl,syn,init
-# #   # Try a thing
-# #   - 'mflowgen/test/test_module.sh full_chip tile_array
-# #        --debug
-# #        --use_cached PE,MemCore,rtl
-# #        --steps syn,init'
-# #   - pwd
-# #   - gold=/sim/buildkite-agent/gold.tmp
-# #   - test -d $$gold || mkdir $$gold
-# #   - cp -rp . $gold
+# For more see pipeline_notes.yml

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,26 +1,21 @@
 steps:
 
 ##############################################################################
-# FULL CHIP RUNS - see pipeline_fullchip.yml
+# INDIVIDUAL TILE RUNS
 
-# ##############################################################################
-# # INDIVIDUAL TILE RUNS
-# 
-# - label: 'MemCore synth 17m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - test=mflowgen/test/test_module.sh
-#   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
-# - wait: { continue_on_failure: true } # One step at a time + continue on failure
-# 
-# - label: 'PE synth 23m'
-#   agents: { jobsize: "hours" }
-#   commands:
-#   - test=mflowgen/test/test_module.sh
-#   - $$test full_chip tile_array Tile_PE --steps synthesis --debug
-# - wait: { continue_on_failure: true } # One step at a time + continue on failure
+- label: 'MemCore synth 17m'
+  agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
+- wait: { continue_on_failure: true } # One step at a time + continue on failure
 
-
+- label: 'PE synth 23m'
+  agents: { jobsize: "hours" }
+  commands:
+  - test=mflowgen/test/test_module.sh
+  - $$test full_chip tile_array Tile_PE --steps synthesis --debug
+- wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 ##############################################################################
 # TILE_ARRAY RUNS
@@ -40,8 +35,6 @@ steps:
 # To build a cache:
 # --update_cache /sim/buildkite-agent/gold.$$BUILDKITE_BUILD_NUMBER
 
-
-
 ########################################################################
 # Left this in (below) as option/example of longer tile array run
 ########################################################################
@@ -56,4 +49,9 @@ steps:
 # - wait: { continue_on_failure: true } # One step at a time + continue on failure
 # 
 
+##############################################################################
+# FULL CHIP RUNS - see pipeline_fullchip.yml
+
 # For more see pipeline_notes.yml
+
+

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -14,7 +14,7 @@ steps:
 #   - test=mflowgen/test/test_module.sh
 #   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
 
-wait: { continue_on_failure: true } # Serialize the steps
+wait: { continue_on_failure: true }
 
 ########################################################################
 - label: 'PE synth 23m'

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -14,9 +14,8 @@ steps:
 #   - test=mflowgen/test/test_module.sh
 #   - $$test full_chip tile_array Tile_MemCore --steps synthesis --debug
 
-wait: { ~, continue_on_failure: true } # Serialize the steps
+wait: { continue_on_failure: true } # Serialize the steps
 
-COMMENT:
 ########################################################################
 - label: 'PE synth 23m'
   agents: { jobsize: "hours" }

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -403,7 +403,7 @@ if [ "$copy_list" ]; then
         echo "sp='$stashpath'"
         set -x
         mflowgen stash list --all
-        mflowgen stash list --all | egrep "$stashpath $step\$" || echo ''
+        mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
         set +x
         
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -349,87 +349,100 @@ for m in ${modlist[@]}; do
     final_module=$m
 done
 
-
-
-
-mflowgen stash link --path  /sim/buildkite-agent/stash/2020-0806-mflowgen-stash-8b4ada
-
+# ##############################################################################
+# # Copy pre-built steps from (gold) cache, if requested via '--use_cached'
+# if [ "$copy_list" ]; then 
+#     echo "+++ ......SETUP context from gold cache (`date +'%a %H:%M'`)"
+# 
+#     # Build the path to the gold cache
+#     gold=/sim/buildkite-agent/gold
+#     for m in ${modlist[@]}; do 
+#         ls $gold/*${m} >& /dev/null || echo FAIL
+#         if [ "$FAIL" == "true" ]; then
+#             echo "***ERROR could not find cache dir '$gold'"; exit 13; fi
+#         gold=`cd $gold/*${m}; pwd`
+#     done
+#     # [ "$DEBUG" ] && echo "  Found gold cache directory '$gold'"
+# 
+#     # Copy desired info from gold cache
+#     for step in ${copy_list[@]}; do
+#         
+#         # Expand aliases e.g. "syn" -> "synopsys-dc-synthesis"
+#         # echo "  $step -> `step_alias $step`"
+#         step=`step_alias $step`
+#     
+#         # NOTE if cd command fails, pwd (disastrously) defaults to current dir
+#         # cache=`cd $gold/*${step}; pwd` || FAIL=true
+#         # if [ "$FAIL" == "true" ]; then
+#         #     echo "***ERROR could not find cache dir '$gold'"; exit 13
+#         # fi
+# 
+#         cache=`cd $gold/*${step}` || FAIL=true
+#         if [ "$FAIL" == "true" ]; then
+#             echo "WARNING Could not find cache for step '${step}'"
+#             echo "Will try and go on without it..."
+#             continue
+#         fi
+# 
+#         cache=`cd $gold/*${step}; pwd`
+# #         echo "    cp -rpf $cache ."
+# #         cp -rpf $cache .
+# 
+#         echo '----'
+#         # echo "    NOT DOING: cp -rpf $cache ."
+# #         echo ""
+# #         echo "WANT STEP '$step'; is it here?"
+# 
+# 
+#         stash_path=`echo $firstmod ${modlist[@]}` ; # E.g. 'full_chip tile_array'
+#         # echo "sp='$stashpath'"
+#         # set -x
+#         # mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
+#         # mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''
+#         # set +x
+#         hash=`mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''`
+#         # echo hash=$hash
+# 
+#         echo "Step $step"
+#         mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
+#         echo mflowgen stash pull --hash $hash
+#         echo '----'
+#     done
+# fi
+# 
+# 
+# set -x
+# mflowgen stash list --all
+# 
+# mflowgen stash pull --hash 2c8dde; echo buildkite-agent full_chip tile_array constraints
+# mflowgen stash pull --hash 54a1af; echo buildkite-agent full_chip tile_array Tile_PE
+# mflowgen stash pull --hash 495f05; echo buildkite-agent full_chip tile_array Tile_MemCore
+# mflowgen stash pull --hash 7e3bfa; echo buildkite-agent full_chip tile_array rtl
+# mflowgen stash pull --hash 135892; echo buildkite-agent full_chip tile_array synopsys-dc-synthesis
+# set +x
 
 
 ##############################################################################
 # Copy pre-built steps from (gold) cache, if requested via '--use_cached'
 if [ "$copy_list" ]; then 
-    echo "+++ ......SETUP context from gold cache (`date +'%a %H:%M'`)"
-
-    # Build the path to the gold cache
-    gold=/sim/buildkite-agent/gold
-    for m in ${modlist[@]}; do 
-        ls $gold/*${m} >& /dev/null || echo FAIL
-        if [ "$FAIL" == "true" ]; then
-            echo "***ERROR could not find cache dir '$gold'"; exit 13; fi
-        gold=`cd $gold/*${m}; pwd`
-    done
-    [ "$DEBUG" ] && echo "  Found gold cache directory '$gold'"
+    stash_dir=/sim/buildkite-agent/stash/2020-0806-mflowgen-stash-8b4ada
+    mflowgen stash link --path $stash_dir
 
     # Copy desired info from gold cache
     for step in ${copy_list[@]}; do
-        
+
         # Expand aliases e.g. "syn" -> "synopsys-dc-synthesis"
         # echo "  $step -> `step_alias $step`"
         step=`step_alias $step`
-    
-        # NOTE if cd command fails, pwd (disastrously) defaults to current dir
-        # cache=`cd $gold/*${step}; pwd` || FAIL=true
-        # if [ "$FAIL" == "true" ]; then
-        #     echo "***ERROR could not find cache dir '$gold'"; exit 13
-        # fi
 
-        cache=`cd $gold/*${step}` || FAIL=true
-        if [ "$FAIL" == "true" ]; then
-            echo "WARNING Could not find cache for step '${step}'"
-            echo "Will try and go on without it..."
-            continue
-        fi
+        stash_path=`echo $firstmod ${modlist[@]}` ; # E.g. 'full_chip tile_array'
 
-        cache=`cd $gold/*${step}; pwd`
-#         echo "    cp -rpf $cache ."
-#         cp -rpf $cache .
-
-        echo '----'
-        echo "    NOT DOING: cp -rpf $cache ."
-#         echo ""
-#         echo "WANT STEP '$step'; is it here?"
-
-
-        stashpath=`echo "$firstmod ${modlist[@]}"`
-        # echo "sp='$stashpath'"
-        # set -x
+        # E.g. "- 495f05 [ 2020-0807 ] buildkite-agent Tile_MemCore -- full_chip tile_array Tile_MemCore"
         mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
-        mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''
-        # set +x
         hash=`mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''`
-        # echo hash=$hash
-
-        echo "Step $step"
-        mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
-        echo mflowgen stash pull --hash $hash
-        echo '----'
+        set -x; mflowgen stash pull --hash $hash; set +x
     done
 fi
-
-
-set -x
-mflowgen stash list --all
-
-mflowgen stash pull --hash 2c8dde; echo buildkite-agent full_chip tile_array constraints
-mflowgen stash pull --hash 54a1af; echo buildkite-agent full_chip tile_array Tile_PE
-mflowgen stash pull --hash 495f05; echo buildkite-agent full_chip tile_array Tile_MemCore
-mflowgen stash pull --hash 7e3bfa; echo buildkite-agent full_chip tile_array rtl
-mflowgen stash pull --hash 135892; echo buildkite-agent full_chip tile_array synopsys-dc-synthesis
-set +x
-
-
-
 
 ########################################################################
 # Run the makefiles for each step requested via '--step'

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -397,16 +397,15 @@ if [ "$copy_list" ]; then
 
         echo "    NOT DOING: cp -rpf $cache ."
         echo ""
-        echo "WANT STEP '$step'"
-        echo "is it here?"
+        echo "WANT STEP '$step'; is it here?"
         stashpath=`echo "$firstmod ${modlist[@]}"`
-        echo "sp='$stashpath'"
+        # echo "sp='$stashpath'"
         set -x
-        mflowgen stash list --all
         mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
+        mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''
         set +x
-        
-
+        hash=`mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''`
+        echo hash=$hash
 
     done
 fi

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -388,15 +388,12 @@ fi
 
 set -x
 mflowgen stash link --path  /sim/buildkite-agent/stash/2020-0806-mflowgen-stash-8b4ada
-mflowgen stash pull --hash 6bd5a1; echo buildkite-agent constraints -- 0
-mflowgen stash pull --hash 59231a; echo buildkite-agent dragonphy -- 5
-mflowgen stash pull --hash 75b87a; echo buildkite-agent custom-read-design -- 4
-mflowgen stash pull --hash 74008c; echo buildkite-agent gen_sram_macro -- 6
-mflowgen stash pull --hash 51bec0; echo buildkite-agent glb_top -- 7
-mflowgen stash pull --hash 471395; echo buildkite-agent global_controller -- 8
-mflowgen stash pull --hash 4fed2f; echo buildkite-agent pre-route -- 11
-mflowgen stash pull --hash 1266aa; echo buildkite-agent rtl -- 12
-mflowgen stash pull --hash 9c623c; echo buildkite-agent soc-rtl -- 14
+
+mflowgen stash pull --hash 17e3dc; echo buildkite-agent 11-Tile_PE
+mflowgen stash pull --hash 131208; echo buildkite-agent 10-Tile_MemCore
+mflowgen stash pull --hash 2d6c93; echo buildkite-agent 7-rtl
+mflowgen stash pull --hash e71a90; echo buildkite-agent 0-constraints
+mflowgen stash pull --hash 554757; echo buildkite-agent 12-synopsys-dc-synthesis
 set +x
 
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -438,7 +438,7 @@ if [ "$copy_list" ]; then
         stash_path=`echo $firstmod ${modlist[@]}` ; # E.g. 'full_chip tile_array'
 
         # E.g. "- 495f05 [ 2020-0807 ] buildkite-agent Tile_MemCore -- full_chip tile_array Tile_MemCore"
-        mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
+        # mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
         hash=`mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''`
 
         # The hash is yellow. Yellow.
@@ -446,10 +446,11 @@ if [ "$copy_list" ]; then
         # God damn it.
 
         # Thanks stackoverflow
+        echo "Fetching step '$step'..."
         hash=`echo $hash | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g"`
-        echo $hash
-
-        set -x; mflowgen stash pull --hash $hash || echo ''; set +x
+        echo mflowgen stash pull --hash $hash
+        mflowgen stash pull --hash $hash || echo ''
+        echo '---'
     done
 fi
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -449,9 +449,9 @@ if [ "$copy_list" ]; then
         hash=`echo $hash`
         echo mflowgen stash pull --hash $hash
         cmd="mflowgen stash pull --hash $hash"
-        $cmd
-        mflowgen stash pull --hash 495f05
-        mflowgen stash pull --hash $hash
+        $cmd || echo ''
+        mflowgen stash pull --hash 495f05 || echo ''
+        mflowgen stash pull --hash $hash || echo ''
         set +x
     done
 fi

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -377,10 +377,29 @@ if [ "$copy_list" ]; then
         fi
 
         cache=`cd $gold/*${step}; pwd`
-        echo "    cp -rpf $cache ."
-        cp -rpf $cache .
+#         echo "    cp -rpf $cache ."
+#         cp -rpf $cache .
+
+        echo "    NOT DOING: cp -rpf $cache ."
+
     done
 fi
+
+
+set -x
+mflowgen stash pull --hash 6bd5a1; echo buildkite-agent constraints -- 0
+mflowgen stash pull --hash 59231a; echo buildkite-agent dragonphy -- 5
+mflowgen stash pull --hash 75b87a; echo buildkite-agent custom-read-design -- 4
+mflowgen stash pull --hash 74008c; echo buildkite-agent gen_sram_macro -- 6
+mflowgen stash pull --hash 51bec0; echo buildkite-agent glb_top -- 7
+mflowgen stash pull --hash 471395; echo buildkite-agent global_controller -- 8
+mflowgen stash pull --hash 4fed2f; echo buildkite-agent pre-route -- 11
+mflowgen stash pull --hash 1266aa; echo buildkite-agent rtl -- 12
+mflowgen stash pull --hash 9c623c; echo buildkite-agent soc-rtl -- 14
+set +x
+
+
+
 
 ########################################################################
 # Run the makefiles for each step requested via '--step'

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -83,14 +83,9 @@ function step_alias {
     # set -x; make list | egrep "$step"'$' | awk '{ print $NR }'; set +x
     # Catch-all maybe?
     # Grab the *first* hit, want to aviod all the "debug-" aliases etc
-    set -x
-
-    make list |& egrep -- "$s"'$'
-
-    make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'
-
-
-
+#     set -x
+#     make list |& egrep -- "$s"'$'
+#     make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'
 
     s=`make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'`
 
@@ -454,7 +449,8 @@ for step in -route route rdl timing-signoff; do
 
 
     echo '----4'
-    echo "  '$step' -> '`step_alias $step`'"
+    echo "FOOOO  '$step' -> '`step_alias $step`'"
+#     echo "  '$step' -> '`step_alias $step`'"
 done
 make list
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -328,10 +328,10 @@ function build_module {
         dirname=$modpfx$modname; # E.g. "1-Tile_PE"
         echo "--- ...BUILD SUBGRAPH '$dirname'"
     fi
-    set -x
+    echo "mkdir $dirname; cd $dirname"
     mkdir $dirname; cd $dirname
+    echo "mflowgen run --design $garnet/mflowgen/$modname"
     mflowgen run --design $garnet/mflowgen/$modname
-    set +x
 
 #     # This is currently considered best practice for us I think?
 #     if [ "$modname" == "full_chip" ]; then
@@ -426,7 +426,7 @@ done
 # Copy pre-built steps from (gold) cache, if requested via '--use_cached'
 if [ "$copy_list" ]; then 
     stash_dir=/sim/buildkite-agent/stash/2020-0806-mflowgen-stash-8b4ada
-    mflowgen stash link --path $stash_dir
+    mflowgen stash link --path $stash_dir; echo ''
 
     # Copy desired info from gold cache
     for step in ${copy_list[@]}; do
@@ -446,7 +446,7 @@ if [ "$copy_list" ]; then
         # God damn it.
 
         # Thanks stackoverflow
-        echo "Fetching step '$step'..."
+        echo -n "Fetching step '$step'..."
         hash=`echo $hash | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g"`
         echo mflowgen stash pull --hash $hash
         mflowgen stash pull --hash $hash || echo ''

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -79,6 +79,12 @@ function step_alias {
 
         *)         s="$1" ;;
     esac
+
+    # set -x; make list | egrep "$step"'$' | awk '{ print $NR }'; set +x
+    # Catch-all maybe?
+    # Grab the *first* hit, want to aviod all the "debug-" aliases etc
+    make list | egrep "$step"'$' | awk '{ print $NR; exit }'
+
     echo $s
 }
 
@@ -90,10 +96,14 @@ if [ "$DEBUG"=="true" ]; then
     echo "MODULES to build"
     for m in ${modlist[@]}; do echo "  m=$m"; done
 
-    echo "STEPS to take"
-    for step in ${build_sequence[@]}; do
-        echo "  $step -> `step_alias $step`"
-    done
+# step_alias don't work yet maybe
+#     echo "+++ STEPS to take"
+#     echo "STEPS to take"
+#     for step in ${build_sequence[@]}; do
+#         echo "  $step -> `step_alias $step`"
+#     done
+
+
 fi
 
 ########################################################################
@@ -410,7 +420,20 @@ final_module=${modlist[-1]}
 
 
 
+    echo "+++ STEPS to take"
+    echo "STEPS to take"
+    for step in ${build_sequence[@]}; do
+        echo "  $step -> `step_alias $step`"
+    done
 
+for step in -route route rdl timing-signoff; do
+        echo "  $step -> `step_alias $step`"
+done
+make list
+
+exit
+exit
+exit
 
 
 
@@ -426,12 +449,12 @@ if [ "$copy_list" ]; then
     for step in ${copy_list[@]}; do
 
         # Expand aliases e.g. "syn" -> "synopsys-dc-synthesis"
-        # echo "  $step -> `step_alias $step`"
+        echo "  $step -> `step_alias $step`"
         step=`step_alias $step`
 
         echo "+++ FOO Nothing up my sleeve. Is this your step?"
         echo ""
-        set -x; make list | egrep "$step"'$'; set +x
+        set -x; make list | egrep "$step"'$' | awk '{ print $NR }'; set +x
         echo ""
 
         stash_path=`echo $firstmod ${modlist[@]}` ; # E.g. 'full_chip tile_array'

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -60,23 +60,26 @@ fi
 # E.g. 'step_alias syn' returns 'synopsys-dc-synthesis'
 function step_alias {
     case "$1" in
-        syn)       echo synopsys-dc-synthesis ;;
-        synthesis) echo synopsys-dc-synthesis ;;
+        syn)       s=synopsys-dc-synthesis ;;
+        synthesis) s=synopsys-dc-synthesis ;;
 
-        init)      echo cadence-innovus-init      ;;
-        route)     echo cadence-innovus-route     ;;
-        postroute) echo cadence-innovus-postroute ;;
+        init)      s=cadence-innovus-init      ;;
+        cts)       s=cadence-innovus-cts       ;;
+        place)     s=cadence-innovus-place     ;;
+        route)     s=cadence-innovus-route     ;;
+        postroute) s=cadence-innovus-postroute ;;
 
-        gds)       echo mentor-calibre-gdsmerge ;;
-        tape)      echo mentor-calibre-gdsmerge ;;
-        merge)     echo mentor-calibre-gdsmerge ;;
-        gdsmerge)  echo mentor-calibre-gdsmerge ;;
+        gds)       s=mentor-calibre-gdsmerge ;;
+        tape)      s=mentor-calibre-gdsmerge ;;
+        merge)     s=mentor-calibre-gdsmerge ;;
+        gdsmerge)  s=mentor-calibre-gdsmerge ;;
 
-        lvs)       echo mentor-calibre-lvs ;;
-        drc)       echo mentor-calibre-drc ;;
+        lvs)       s=mentor-calibre-lvs ;;
+        drc)       s=mentor-calibre-drc ;;
 
-        *)         echo "$1" ;;
+        *)         s="$1" ;;
     esac
+    echo $s
 }
 
 ########################################################################

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -439,7 +439,7 @@ for step in -route route rdl timing-signoff; do
 
     s=$step
 
-    set -x
+    set +x
 
     echo '----1'
     make list |& egrep -- "$s"'$'
@@ -454,7 +454,7 @@ for step in -route route rdl timing-signoff; do
 
 
     echo '----4'
-    echo "  $step -> `step_alias $step`"
+    echo "  '$step' -> '`step_alias $step`'"
 done
 make list
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -430,9 +430,9 @@ if [ "$copy_list" ]; then
         step=`step_alias $step`
 
         echo "+++ FOO Nothing up my sleeve. Is this your step?"
-        set -x
-        make list | awk '$NR == "'$step'" { print }'
-        set +x
+        echo ""
+        set -x; make list | egrep "$step"'$'; set +x
+        echo ""
 
         stash_path=`echo $firstmod ${modlist[@]}` ; # E.g. 'full_chip tile_array'
 
@@ -492,16 +492,17 @@ for step in ${build_sequence[@]}; do
         exit 13
     fi
 
-    # Optionally update (gold) cache after each step
-    if [ "$update_cache" ]; then
-        gold="$update_cache"; # E.g. gold="/sim/buildkite-agent/gold.13"
-        echo "+++ SAVE RESULTS so far to cache '$gold'"
-        test -d $gold || mkdir $gold
-        set -x
-        cp -rpf $build/full_chip $gold
-        set +x
-        ls -l $gold/full_chip || PASS
-    fi
+# Don't need this no more maybe
+#     # Optionally update (gold) cache after each step
+#     if [ "$update_cache" ]; then
+#         gold="$update_cache"; # E.g. gold="/sim/buildkite-agent/gold.13"
+#         echo "+++ SAVE RESULTS so far to cache '$gold'"
+#         test -d $gold || mkdir $gold
+#         set -x
+#         cp -rpf $build/full_chip $gold
+#         set +x
+#         ls -l $gold/full_chip || PASS
+#     fi
     
 done
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -349,6 +349,13 @@ for m in ${modlist[@]}; do
     final_module=$m
 done
 
+
+
+
+mflowgen stash link --path  /sim/buildkite-agent/stash/2020-0806-mflowgen-stash-8b4ada
+
+
+
 ##############################################################################
 # Copy pre-built steps from (gold) cache, if requested via '--use_cached'
 if [ "$copy_list" ]; then 
@@ -405,7 +412,6 @@ fi
 
 
 set -x
-mflowgen stash link --path  /sim/buildkite-agent/stash/2020-0806-mflowgen-stash-8b4ada
 mflowgen stash list --all
 
 mflowgen stash pull --hash 2c8dde; echo buildkite-agent full_chip tile_array constraints

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -406,8 +406,13 @@ for step in ${build_sequence[@]}; do
         && filter="gawk -f $script_home/filters/$step.awk" \
             || filter="cat"
 
-    make $step |& tee make.log | $filter || set FAIL
-    if [ "$FAIL" ]; then
+    # Try a thing with this "touch" command
+    failfile=/tmp/test_module_failfile.$$
+    test -f $failfile && /bin/rm $failfile || echo -n ''
+    (make $step || touch $failfile) |& tee make-$step.log | $filter
+    # if [ "$FAIL" ]; then
+    if test -f $failfile; then
+        /bin/rm $failfile
         echo '+++ RUNTIMES'; make runtimes
         echo '+++ FAIL'
         echo 'Looks like we failed, here are some errors maybe:'

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -387,6 +387,7 @@ fi
 
 
 set -x
+mflowgen stash link --path  /sim/buildkite-agent/stash/2020-0806-mflowgen-stash-8b4ada
 mflowgen stash pull --hash 6bd5a1; echo buildkite-agent constraints -- 0
 mflowgen stash pull --hash 59231a; echo buildkite-agent dragonphy -- 5
 mflowgen stash pull --hash 75b87a; echo buildkite-agent custom-read-design -- 4

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -440,6 +440,12 @@ if [ "$copy_list" ]; then
         # E.g. "- 495f05 [ 2020-0807 ] buildkite-agent Tile_MemCore -- full_chip tile_array Tile_MemCore"
         mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
         hash=`mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''`
+
+        # The hash is yellow. Yellow.
+        # That means instead of 495f05 I get '\033]0;%s@%s:%s\007'
+        # God damn it.
+        hash=`echo $hash`
+
         set -x; mflowgen stash pull --hash $hash; set +x
     done
 fi

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -83,6 +83,15 @@ function step_alias {
     # set -x; make list | egrep "$step"'$' | awk '{ print $NR }'; set +x
     # Catch-all maybe?
     # Grab the *first* hit, want to aviod all the "debug-" aliases etc
+    set -x
+
+    make list | egrep -- "$s"'$'
+
+    make list | egrep -- "$s"'$' | awk '{ print $NF; exit }'
+
+
+
+
     s=`make list | egrep -- "$s"'$' | awk '{ print $NR; exit }'`
 
     echo $s

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -395,18 +395,25 @@ if [ "$copy_list" ]; then
 #         echo "    cp -rpf $cache ."
 #         cp -rpf $cache .
 
+        echo '----'
         echo "    NOT DOING: cp -rpf $cache ."
-        echo ""
-        echo "WANT STEP '$step'; is it here?"
+#         echo ""
+#         echo "WANT STEP '$step'; is it here?"
+
+
         stashpath=`echo "$firstmod ${modlist[@]}"`
         # echo "sp='$stashpath'"
-        set -x
+        # set -x
         mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
         mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''
-        set +x
+        # set +x
         hash=`mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''`
-        echo hash=$hash
+        # echo hash=$hash
 
+        echo "Step $step"
+        mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
+        echo mflowgen stash pull --hash $hash
+        echo '----'
     done
 fi
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -445,8 +445,11 @@ if [ "$copy_list" ]; then
         # That means instead of 495f05 I get '\033]0;%s@%s:%s\007'
         # God damn it.
         set -x
+
         echo $hash
-        hash=`echo $hash`
+        hash=`echo $hash | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g"`
+        echo $hash
+
         echo mflowgen stash pull --hash $hash
         cmd="mflowgen stash pull --hash $hash"
         $cmd || echo ''

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -245,16 +245,23 @@ $garnet/bin/requirements_check.sh -v --debug --pd_only
 
 ########################################################################
 # Make a build space for mflowgen; clone mflowgen
-echo "--- CLONE MFLOWGEN REPO"
+echo "--- CLONE *AND INSTALL* MFLOWGEN REPO"
 [ "$VERBOSE" == "true" ] && (echo ""; echo "--- pwd="`pwd`; echo "")
 if [ "$USER" == "buildkite-agent" ]; then
     build=$garnet/mflowgen/test
 else
     build=/sim/$USER
 fi
+
 test  -d $build || mkdir $build; cd $build
 test  -d $build/mflowgen || git clone https://github.com/cornell-brg/mflowgen.git
 mflowgen=$build/mflowgen
+
+# INSTALL
+pushd $mflowgen
+  TOP=$PWD; pip install -e .; which mflowgen; pip list | grep mflowgen
+popd
+
 echo ""
 
 ########################################################################
@@ -326,14 +333,15 @@ function build_module {
     mflowgen run --design $garnet/mflowgen/$modname
     set +x
 
-    # This is currently considered best practice for us I think?
-    if [ "$modname" == "full_chip" ]; then
-        set -x
-        echo "Fetch pre-built RTL from stash"
-        mflowgen stash link --path /home/ajcars/tile-array-rtl-stash/2020-0724-mflowgen-stash-75007d
-        mflowgen stash pull --hash 2fbc7a
-        set +x
-    fi
+#     # This is currently considered best practice for us I think?
+#     if [ "$modname" == "full_chip" ]; then
+#         set -x
+#         echo "Fetch pre-built RTL from stash"
+#         mflowgen stash link --path /home/ajcars/tile-array-rtl-stash/2020-0724-mflowgen-stash-75007d
+#         mflowgen stash pull --hash 2fbc7a
+#         set +x
+#     fi
+
 }
 # E.g. build_module full_chip; build_module tile_array; build_module Tile_PE
 for m in ${modlist[@]}; do 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -83,7 +83,7 @@ function step_alias {
     # set -x; make list | egrep "$step"'$' | awk '{ print $NR }'; set +x
     # Catch-all maybe?
     # Grab the *first* hit, want to aviod all the "debug-" aliases etc
-    make list | egrep -- "$step"'$' | awk '{ print $NR; exit }'
+    s=`make list | egrep -- "$s"'$' | awk '{ print $NR; exit }'`
 
     echo $s
 }

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -434,25 +434,8 @@ set -x
 for step in -route route rdl timing-signoff; do
 
     s=$step
-
-
-#     echo '----1'
-#     make list |& egrep -- "$s"'$'
-# 
-#     echo '----2'
-#     make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'
-# 
-#     echo '----3'
-#     s=`make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'`
-#     echo $s
-
-
-
-    echo '----4'
     echo "FOOOO  '$step' -> '`step_alias $step`'"
-#     echo "  '$step' -> '`step_alias $step`'"
 done
-make list
 
 exit
 exit

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -444,18 +444,12 @@ if [ "$copy_list" ]; then
         # The hash is yellow. Yellow.
         # That means instead of 495f05 I get '\033]0;%s@%s:%s\007'
         # God damn it.
-        set -x
 
-        echo $hash
+        # Thanks stackoverflow
         hash=`echo $hash | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g"`
         echo $hash
 
-        echo mflowgen stash pull --hash $hash
-        cmd="mflowgen stash pull --hash $hash"
-        $cmd || echo ''
-        mflowgen stash pull --hash 495f05 || echo ''
-        mflowgen stash pull --hash $hash || echo ''
-        set +x
+        set -x; mflowgen stash pull --hash $hash || echo ''; set +x
     done
 fi
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -430,21 +430,21 @@ final_module=${modlist[-1]}
         echo "  $step -> `step_alias $step`"
     done
 
+set -x
 for step in -route route rdl timing-signoff; do
 
     s=$step
 
-    set +x
 
-    echo '----1'
-    make list |& egrep -- "$s"'$'
-
-    echo '----2'
-    make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'
-
-    echo '----3'
-    s=`make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'`
-    echo $s
+#     echo '----1'
+#     make list |& egrep -- "$s"'$'
+# 
+#     echo '----2'
+#     make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'
+# 
+#     echo '----3'
+#     s=`make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'`
+#     echo $s
 
 
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -67,7 +67,6 @@ if [ "$DEBUG"=="true" ]; then
     # ---
     echo "STEPS to take"
     for step in ${build_sequence[@]}; do echo "  $step"; done
-    done
 fi
 
 ########################################################################

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -444,7 +444,12 @@ if [ "$copy_list" ]; then
         # The hash is yellow. Yellow.
         # That means instead of 495f05 I get '\033]0;%s@%s:%s\007'
         # God damn it.
+        set -x
+        echo $hash
         hash=`echo $hash`
+        echo mflowgen stash pull --hash $hash
+        cmd="mflowgen stash pull --hash $hash"
+        $cmd
 
         set -x; mflowgen stash pull --hash $hash; set +x
     done

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -85,14 +85,14 @@ function step_alias {
     # Grab the *first* hit, want to aviod all the "debug-" aliases etc
     set -x
 
-    make list | egrep -- "$s"'$'
+    make list |& egrep -- "$s"'$'
 
-    make list | egrep -- "$s"'$' | awk '{ print $NF; exit }'
-
-
+    make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'
 
 
-    s=`make list | egrep -- "$s"'$' | awk '{ print $NR; exit }'`
+
+
+    s=`make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'`
 
     echo $s
 }
@@ -436,7 +436,25 @@ final_module=${modlist[-1]}
     done
 
 for step in -route route rdl timing-signoff; do
-        echo "  $step -> `step_alias $step`"
+
+    s=$step
+
+    set -x
+
+    echo '----1'
+    make list |& egrep -- "$s"'$'
+
+    echo '----2'
+    make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'
+
+    echo '----3'
+    s=`make list |& egrep -- "$s"'$' | awk '{ print $NF; exit }'`
+    echo $s
+
+
+
+    echo '----4'
+    echo "  $step -> `step_alias $step`"
 done
 make list
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -318,6 +318,43 @@ function build_module {
     if ! test -f Makefile; then 
         dirname="$modname"; # E.g. "full_chip"
         echo "--- ...BUILD MODULE '$dirname'"
+
+
+        # if caching results;
+        # here is where we would build the target dir;
+        # make a symlink to the target dir;
+        # cd into the symnlink and continue;
+        # something like
+        
+##############################################################################
+#     if [ "$update_cache" ]; then
+#         gold="$update_cache"; # E.g. gold="/sim/buildkite-agent/gold.13"
+#         echo "+++ SAVE RESULTS so far to cache '$gold'"
+#         test -d $gold || mkdir $gold
+# 
+#         # or could use mkdir -p maybe?
+#         test -d $gold/$dirname || mkdir $gold/$dirname
+# 
+#         # TODO is it trouble if target directory already exists?
+#         # test -d $gold/$dirname && echo TROUBLE # ??
+# 
+#         ln -s $gold/$dirname; cd $dirname
+# 
+#         # set -x
+#         # cp -rpf $build/full_chip $gold
+#         # set +x
+# 
+# 
+#         # ls -l $gold/full_chip || PASS
+#     fi
+#     else
+##############################################################################
+
+        echo "mkdir $dirname; cd $dirname"
+
+
+
+        mkdir $dirname; cd $dirname
     else
         # Find appropriate directory name for subgraph e.g. "14-tile_array"
         # Looking for a "make list" line that matches modname e.g.
@@ -327,9 +364,9 @@ function build_module {
         modpfx=`make list | awk '$NF == "'$modname'" {print $2 "-"}'`
         dirname=$modpfx$modname; # E.g. "1-Tile_PE"
         echo "--- ...BUILD SUBGRAPH '$dirname'"
+        echo "mkdir $dirname; cd $dirname"
+        mkdir $dirname; cd $dirname
     fi
-    echo "mkdir $dirname; cd $dirname"
-    mkdir $dirname; cd $dirname
     echo "mflowgen run --design $garnet/mflowgen/$modname"
     mflowgen run --design $garnet/mflowgen/$modname
 
@@ -348,79 +385,6 @@ for m in ${modlist[@]}; do
     build_module $m;
     final_module=$m
 done
-
-# ##############################################################################
-# # Copy pre-built steps from (gold) cache, if requested via '--use_cached'
-# if [ "$copy_list" ]; then 
-#     echo "+++ ......SETUP context from gold cache (`date +'%a %H:%M'`)"
-# 
-#     # Build the path to the gold cache
-#     gold=/sim/buildkite-agent/gold
-#     for m in ${modlist[@]}; do 
-#         ls $gold/*${m} >& /dev/null || echo FAIL
-#         if [ "$FAIL" == "true" ]; then
-#             echo "***ERROR could not find cache dir '$gold'"; exit 13; fi
-#         gold=`cd $gold/*${m}; pwd`
-#     done
-#     # [ "$DEBUG" ] && echo "  Found gold cache directory '$gold'"
-# 
-#     # Copy desired info from gold cache
-#     for step in ${copy_list[@]}; do
-#         
-#         # Expand aliases e.g. "syn" -> "synopsys-dc-synthesis"
-#         # echo "  $step -> `step_alias $step`"
-#         step=`step_alias $step`
-#     
-#         # NOTE if cd command fails, pwd (disastrously) defaults to current dir
-#         # cache=`cd $gold/*${step}; pwd` || FAIL=true
-#         # if [ "$FAIL" == "true" ]; then
-#         #     echo "***ERROR could not find cache dir '$gold'"; exit 13
-#         # fi
-# 
-#         cache=`cd $gold/*${step}` || FAIL=true
-#         if [ "$FAIL" == "true" ]; then
-#             echo "WARNING Could not find cache for step '${step}'"
-#             echo "Will try and go on without it..."
-#             continue
-#         fi
-# 
-#         cache=`cd $gold/*${step}; pwd`
-# #         echo "    cp -rpf $cache ."
-# #         cp -rpf $cache .
-# 
-#         echo '----'
-#         # echo "    NOT DOING: cp -rpf $cache ."
-# #         echo ""
-# #         echo "WANT STEP '$step'; is it here?"
-# 
-# 
-#         stash_path=`echo $firstmod ${modlist[@]}` ; # E.g. 'full_chip tile_array'
-#         # echo "sp='$stashpath'"
-#         # set -x
-#         # mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
-#         # mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''
-#         # set +x
-#         hash=`mflowgen stash list --all | egrep "${stashpath}.*${step}\$" | awk '{print $2}' || echo ''`
-#         # echo hash=$hash
-# 
-#         echo "Step $step"
-#         mflowgen stash list --all | egrep "${stashpath}.*${step}\$" || echo ''
-#         echo mflowgen stash pull --hash $hash
-#         echo '----'
-#     done
-# fi
-# 
-# 
-# set -x
-# mflowgen stash list --all
-# 
-# mflowgen stash pull --hash 2c8dde; echo buildkite-agent full_chip tile_array constraints
-# mflowgen stash pull --hash 54a1af; echo buildkite-agent full_chip tile_array Tile_PE
-# mflowgen stash pull --hash 495f05; echo buildkite-agent full_chip tile_array Tile_MemCore
-# mflowgen stash pull --hash 7e3bfa; echo buildkite-agent full_chip tile_array rtl
-# mflowgen stash pull --hash 135892; echo buildkite-agent full_chip tile_array synopsys-dc-synthesis
-# set +x
-
 
 ##############################################################################
 # Copy pre-built steps from (gold) cache, if requested via '--use_cached'

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -389,6 +389,16 @@ if [ "$copy_list" ]; then
 #         cp -rpf $cache .
 
         echo "    NOT DOING: cp -rpf $cache ."
+        echo ""
+        echo "WANT STEP '$step'"
+        echo "is it here?"
+        echo "$firstmod ${modlist[@]}"
+        set -x
+        mflowgen stash list --all
+        mflowgen stash list --all | egrep "$firstmod ${modlist[@]}"'$'
+        set +x
+        
+
 
     done
 fi
@@ -396,12 +406,13 @@ fi
 
 set -x
 mflowgen stash link --path  /sim/buildkite-agent/stash/2020-0806-mflowgen-stash-8b4ada
+mflowgen stash list --all
 
-mflowgen stash pull --hash 17e3dc; echo buildkite-agent 11-Tile_PE
-mflowgen stash pull --hash 131208; echo buildkite-agent 10-Tile_MemCore
-mflowgen stash pull --hash 2d6c93; echo buildkite-agent 7-rtl
-mflowgen stash pull --hash e71a90; echo buildkite-agent 0-constraints
-mflowgen stash pull --hash 554757; echo buildkite-agent 12-synopsys-dc-synthesis
+mflowgen stash pull --hash 2c8dde; echo buildkite-agent full_chip tile_array constraints
+mflowgen stash pull --hash 54a1af; echo buildkite-agent full_chip tile_array Tile_PE
+mflowgen stash pull --hash 495f05; echo buildkite-agent full_chip tile_array Tile_MemCore
+mflowgen stash pull --hash 7e3bfa; echo buildkite-agent full_chip tile_array rtl
+mflowgen stash pull --hash 135892; echo buildkite-agent full_chip tile_array synopsys-dc-synthesis
 set +x
 
 
@@ -485,9 +496,9 @@ done
 
 echo '+++ PASS/FAIL info maybe, to make you feel good'
 function PASS { return 0; }
-cat -n make.log | grep -i error  | tail | tee -a tmp.summary || PASS; echo "-----"
-cat -n make.log | grep    FAIL   | tail | tee -a tmp.summary || PASS; echo "-----"
-cat -n make.log | grep -i passed | tail | tee -a tmp.summary || PASS; echo ""
+cat -n make*.log | grep -i error  | tail | tee -a tmp.summary || PASS; echo "-----"
+cat -n make*.log | grep    FAIL   | tail | tee -a tmp.summary || PASS; echo "-----"
+cat -n make*.log | grep -i passed | tail | tee -a tmp.summary || PASS; echo ""
 
 ########################################################################
 echo '+++ SUMMARY of what we did'

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -450,8 +450,9 @@ if [ "$copy_list" ]; then
         echo mflowgen stash pull --hash $hash
         cmd="mflowgen stash pull --hash $hash"
         $cmd
-
-        set -x; mflowgen stash pull --hash $hash; set +x
+        mflowgen stash pull --hash 495f05
+        mflowgen stash pull --hash $hash
+        set +x
     done
 fi
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -403,7 +403,7 @@ if [ "$copy_list" ]; then
         echo "sp='$stashpath'"
         set -x
         mflowgen stash list --all
-        mflowgen stash list --all | egrep "$stashpath\$"
+        mflowgen stash list --all | egrep "$stashpath $step\$" || echo ''
         set +x
         
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -399,10 +399,11 @@ if [ "$copy_list" ]; then
         echo ""
         echo "WANT STEP '$step'"
         echo "is it here?"
-        echo "$firstmod ${modlist[@]}"
+        stashpath=`echo "$firstmod ${modlist[@]}"`
+        echo "sp='$stashpath'"
         set -x
         mflowgen stash list --all
-        mflowgen stash list --all | egrep "$firstmod ${modlist[@]}"'$'
+        mflowgen stash list --all | egrep "$stashpath\$"
         set +x
         
 

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -83,7 +83,7 @@ function step_alias {
     # set -x; make list | egrep "$step"'$' | awk '{ print $NR }'; set +x
     # Catch-all maybe?
     # Grab the *first* hit, want to aviod all the "debug-" aliases etc
-    make list | egrep "$step"'$' | awk '{ print $NR; exit }'
+    make list | egrep -- "$step"'$' | awk '{ print $NR; exit }'
 
     echo $s
 }


### PR DESCRIPTION
Fixes multiple problems w/ existing full-chip test, including
- *install* new mflowgen after cloning it, instead of using the old one `:o`
- halt on error instead of continue `:|`
- builds directly in target cache dir instead of "cp -r" afterwards `:)`
- doesn't overwrite and destroy the same 'make.log' after every step `:(`
