### PR TITLE
Prevent dc from tying floating dragonphy inputs to 0

### DIFF
--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -463,6 +463,7 @@ def construct():
   dc_postconditions = dc.get_postconditions()
   dc_postconditions.remove( "assert 'Unresolved references' not in File( 'logs/dc.log' )" )
   dc_postconditions.remove( "assert 'Unable to resolve' not in File( 'logs/dc.log' )" )
+  dc_postconditions.append( """assert "has '1' unresolved references" in File( 'logs/dc.log' )""" )
   dc.set_postconditions( dc_postconditions )
   return g
 

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -150,7 +150,9 @@ def construct():
   dc.extend_inputs( ['glb_top.db'] )
   dc.extend_inputs( ['global_controller.db'] )
   dc.extend_inputs( ['sram_tt.db'] )
-  dc.extend_inputs( ['dragonphy_top_tt.db'] )
+  # Remove dragonphy_top from dc inputs to prevent floating
+  # dragonphy inputs from being tied to 0
+  # dc.extend_inputs( ['dragonphy_top_tt.db'] )
   pt_signoff.extend_inputs( ['tile_array.db'] )
   pt_signoff.extend_inputs( ['glb_top.db'] )
   pt_signoff.extend_inputs( ['global_controller.db'] )
@@ -456,6 +458,12 @@ def construct():
 
   # Antenna DRC node needs to use antenna rule deck
   antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'] } )
+
+  # Remove unresolved reference assertion from DC because dragonphy is an unresolved reference
+  dc_postconditions = dc.get_postconditions()
+  dc_postconditions.remove( "assert 'Unresolved references' not in File( 'logs/dc.log' )" )
+  dc_postconditions.remove( "assert 'Unable to resolve' not in File( 'logs/dc.log' )" )
+  dc.set_postconditions( dc_postconditions )
   return g
 
 


### PR DESCRIPTION
After providing the dragonphy db file to synthesis in #627, dc started tying floating dragonphy inputs to 0. This broke the full chip PD flow, because these inputs are connected directly to bumps my the dragonphy_RDL gds that we merge in at the end of the flow. To fix this, I've removed the dragonphy db from the dc step inputs. This makes the dragonphy and unresolved reference, so I've also removed the unresolved reference assertions from the dc step.