### PR TITLE
Switch to pytest-pycodestyle and unspilt tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ install:
     - docker run -d -it --name garnet keyiz/garnet-flow bash
     - docker cp ../garnet garnet:/
     - docker exec -i garnet bash -c "pip install -r /garnet/requirements.txt" 
-    - docker exec -i garnet bash -c "pip install pytest==5.4.3 python-coveralls"
-    - docker exec -i garnet bash -c "pip install pytest-cov pytest-codestyle z3-solver" 
+    - docker exec -i garnet bash -c "pip install pytest python-coveralls"
+    - docker exec -i garnet bash -c "pip install pytest-cov pytest-pycodestyle z3-solver" 
       #- docker exec -i garnet bash -c "wget https://web.stanford.edu/~makaim/files/yosys-static -O ./bin/yosys"
       #- docker exec -i garnet bash -c "chmod +x ./bin/yosys"
       #- docker exec -i garnet bash -c "pysmt-install --confirm-agreement --msat"

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -8,21 +8,10 @@ export PYTEST_ADDOPTS="--color=yes"
 
 cd /garnet/
 
-pytest --pycodestyle        \
-    --cov global_controller \
-    --cov io_core           \
-    --cov memory_core       \
-    --ignore=filecmp.py     \
-    --ignore=Genesis2/      \
-    --ignore=tests/test_interconnect \
-    -v --cov-report term-missing tests
-
-# coreir has memory leak. split them into two to get around
-pytest --pycodestyle        \
-    --cov global_controller \
-    --cov io_core           \
-    --cov memory_core       \
-    --ignore=filecmp.py     \
-    --ignore=Genesis2/      \
-    --ignore=tests/test_memory_core \
-    -v --cov-report term-missing tests/test_interconnect
+ pytest --pycodestyle          \ 
+     --cov global_controller \ 
+     --cov io_core           \ 
+     --cov memory_core       \ 
+     --ignore=filecmp.py     \ 
+     --ignore=Genesis2/      \ 
+     -v --cov-report term-missing tests 

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -8,10 +8,10 @@ export PYTEST_ADDOPTS="--color=yes"
 
 cd /garnet/
 
-pytest --pycodestyle           \ 
-       --cov global_controller \ 
-       --cov io_core           \ 
-       --cov memory_core       \ 
-       --ignore=filecmp.py     \ 
-       --ignore=Genesis2/      \ 
-       -v --cov-report term-missing tests 
+pytest --pycodestyle           \
+       --cov global_controller \
+       --cov io_core           \
+       --cov memory_core       \
+       --ignore=filecmp.py     \
+       --ignore=Genesis2/      \
+       -v --cov-report term-missing tests

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -8,10 +8,10 @@ export PYTEST_ADDOPTS="--color=yes"
 
 cd /garnet/
 
- pytest --pycodestyle          \ 
-     --cov global_controller \ 
-     --cov io_core           \ 
-     --cov memory_core       \ 
-     --ignore=filecmp.py     \ 
-     --ignore=Genesis2/      \ 
-     -v --cov-report term-missing tests 
+pytest --pycodestyle           \ 
+       --cov global_controller \ 
+       --cov io_core           \ 
+       --cov memory_core       \ 
+       --ignore=filecmp.py     \ 
+       --ignore=Genesis2/      \ 
+       -v --cov-report term-missing tests 


### PR DESCRIPTION
The old package `pytest-codestyle` has been deprecated, the newest version should work with pytest 6