### PR TITLE
Force delete context

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,7 +16,10 @@ collect_ignore = [
 @pytest.fixture(autouse=True)
 def magma_test():
     clear_cachedFunctions()
-    libcoreir_c.COREDeleteContext(coreir_.CoreIRContextSingleton().get_instance().context)
+    ctx = coreir_.CoreIRContextSingleton().get_instance()
+    # Set flag so __del__ doesn't free twice
+    ctx.external_pointer = True
+    libcoreir_c.COREDeleteContext(ctx.context)
     coreir_.CoreIRContextSingleton().reset_instance()
     clear_generator_cache()
 

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,8 @@ collect_ignore = [
 def magma_test():
     clear_cachedFunctions()
     ctx = coreir_.CoreIRContextSingleton().get_instance()
+    if ctx in coreir_._context_to_modules:
+        del coreir_._context_to_modules[ctx]
     # Set flag so __del__ doesn't free twice
     ctx.external_pointer = True
     libcoreir_c.COREDeleteContext(ctx.context)

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from magma import clear_cachedFunctions
-import magma.frontend.coreir_ as coreir_
+import magma
 from gemstone.generator import clear_generator_cache
 from coreir.lib import libcoreir_c
 
@@ -16,7 +16,13 @@ collect_ignore = [
 @pytest.fixture(autouse=True)
 def magma_test():
     clear_cachedFunctions()
-    coreir_.ResetCoreIR()
+    ctx = magma.backend.coreir_.CoreIRContextSingleton().get_instance()
+    if ctx in magma.backend.coreir_._context_to_modules:
+        del magma.backend.coreir_._context_to_modules[ctx]
+    # Set flag so __del__ doesn't free twice
+    ctx.external_ptr = True
+    libcoreir_c.COREDeleteContext(ctx.context)
+    magma.frontend.coreir_.ResetCoreIR()
     clear_generator_cache()
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,8 +2,7 @@ import pytest
 from magma import clear_cachedFunctions
 import magma.backend.coreir_ as coreir_
 from gemstone.generator import clear_generator_cache
-
-import gc
+from coreir.lib import libcoreir_c
 
 collect_ignore = [
     # TODO(rsetaluri): Remove this once it is moved to canal!
@@ -17,10 +16,9 @@ collect_ignore = [
 @pytest.fixture(autouse=True)
 def magma_test():
     clear_cachedFunctions()
+    libcoreir_c.COREDeleteContext(coreir_.CoreIRContextSingleton().get_instance().context)
     coreir_.CoreIRContextSingleton().reset_instance()
     clear_generator_cache()
-    # Force garbage collection to free memory and avoid oom
-    gc.collect()
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,11 @@ def magma_test():
         del magma.backend.coreir_._context_to_modules[ctx]
     # Set flag so __del__ doesn't free twice
     ctx.external_ptr = True
+    # Force memory free to avoid memory leak issue, see
+    # https://github.com/rdaly525/coreir/issues/896
+    # and https://github.com/StanfordAHA/garnet/pull/638
+    # TODO: We should add a cleaner API for this to magma/pycoreir and update
+    # this code accordingly
     libcoreir_c.COREDeleteContext(ctx.context)
     magma.frontend.coreir_.ResetCoreIR()
     clear_generator_cache()

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,8 @@ from magma import clear_cachedFunctions
 import magma.backend.coreir_ as coreir_
 from gemstone.generator import clear_generator_cache
 
+import gc
+
 collect_ignore = [
     # TODO(rsetaluri): Remove this once it is moved to canal!
     "experimental",  # directory for experimental projects
@@ -15,10 +17,10 @@ collect_ignore = [
 @pytest.fixture(autouse=True)
 def magma_test():
     clear_cachedFunctions()
-    inst = coreir_.CoreIRContextSingleton().get_instance()
-    del inst
     coreir_.CoreIRContextSingleton().reset_instance()
     clear_generator_cache()
+    # Force garbage collection to free memory and avoid oom
+    gc.collect()
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,8 @@ collect_ignore = [
 @pytest.fixture(autouse=True)
 def magma_test():
     clear_cachedFunctions()
+    inst = coreir_.CoreIRContextSingleton().get_instance()
+    del inst
     coreir_.CoreIRContextSingleton().reset_instance()
     clear_generator_cache()
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from magma import clear_cachedFunctions
-import magma.backend.coreir_ as coreir_
+import magma.frontend.coreir_ as coreir_
 from gemstone.generator import clear_generator_cache
 from coreir.lib import libcoreir_c
 
@@ -16,13 +16,7 @@ collect_ignore = [
 @pytest.fixture(autouse=True)
 def magma_test():
     clear_cachedFunctions()
-    ctx = coreir_.CoreIRContextSingleton().get_instance()
-    if ctx in coreir_._context_to_modules:
-        del coreir_._context_to_modules[ctx]
-    # Set flag so __del__ doesn't free twice
-    ctx.external_pointer = True
-    libcoreir_c.COREDeleteContext(ctx.context)
-    coreir_.CoreIRContextSingleton().reset_instance()
+    coreir_.ResetCoreIR()
     clear_generator_cache()
 
 


### PR DESCRIPTION
This fixes the out of memory issue on travis.  First, we were using an old API to reset the magma coreir context, using the frontend api fixes an issue where a few references to the context singleton still existed in the coreir backend (the frontend api resets both the context singleton and the coreir backend reference to it).  This prevented it from being properly garbage collected.  Next, rather than rely on the Python garbage collection to clean up the context (will eventually call __del__ to free the memory), we explicitly call the low-level API between each test to ensure we have free memory.  We should add a better API for this in pycoreir, but for now we just access the context pointer directly and call the C-api function.  We hack the logic to avoid a double free by setting the external_ptr attribute on the context object (if pycoreir sees an external pointer, it won't call the context delete logic when the object is cleaned up).