### PR TITLE
Pin lake to pre-lake-diet commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ coreir  # should be first so we get the latest version
 -e git://github.com/Kuree/karst.git#egg=karst
 -e git://github.com/joyliu37/BufferMapping#egg=buffer_mapping
 -e git+git://github.com/pyhdi/pyverilog.git#egg=pyverilog
--e git+https://github.com/StanfordAHA/lake#egg=lake
+# lake pinned to most recent passing version (before lake diet merge)
+-e git+https://github.com/StanfordAHA/lake@3e35017#egg=lake
 -e git://github.com/phanrahan/magma.git#egg=magma-lang
 -e git://github.com/phanrahan/mantle.git#egg=mantle
 ordered_set


### PR DESCRIPTION
Pins lake to commit hash currently being used in aha so that the master branch is passing travis tests. We can remove this once the compiler issues around the new lake-diet are resolved such that all aha tests pass with the latest version of lake.