### PR TITLE
remove clock_gate assertion in tile array flow

### DIFF
--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -343,6 +343,14 @@ def construct():
   order.insert( main_idx, 'cts-overrides.tcl' )
   cts.update_params( { 'order': order } )
 
+                                                                                                   
+  # Remove 
+  dc_postconditions = dc.get_postconditions()
+  for postcon in dc_postconditions:
+      if 'percent_clock_gated' in postcon:
+          dc_postconditions.remove(postcon)
+  dc.set_postconditions( dc_postconditions )
+
   return g
 
 


### PR DESCRIPTION
Removes the assertion that at least 50% of registers are clock gated in the tile array flow. All registers at the tile array top level are pipeline registers for configuration signals, which we cannot clock gate.