### PR TITLE
Use mc from adk instead of stashed copy somewhere on machine

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -202,6 +202,7 @@ def construct():
 
   # Connect by name
 
+  g.connect_by_name( adk,      gen_sram       )
   g.connect_by_name( adk,      synth          )
   g.connect_by_name( adk,      iflow          )
   g.connect_by_name( adk,      init           )

--- a/mflowgen/common/gen_sram_macro/configure.yml
+++ b/mflowgen/common/gen_sram_macro/configure.yml
@@ -3,6 +3,9 @@ name: gen_sram_macro
 commands:
   - bash gen_srams.sh
 
+inputs:
+  - adk
+
 outputs:
   - sram.v
   - sram_pwr.v

--- a/mflowgen/common/gen_sram_macro/gen_srams.sh
+++ b/mflowgen/common/gen_sram_macro/gen_srams.sh
@@ -1,14 +1,14 @@
 echo "${num_words}x${word_size}m${mux_size}s" >> config.txt
 
-export MC_HOME=mc/tsn16ffcllhdspsbsram_20131200_130a
-export PATH="${PATH}:mc/MC2_2013.12.00.f/bin"
+export MC_HOME=inputs/adk/mc/tsn16ffcllhdspsbsram_20131200_130a
+export PATH="${PATH}:inputs/adk/mc/MC2_2013.12.00.f/bin"
 sram_name="ts1n16ffcllsblvtc${num_words}x${word_size}m${mux_size}s"
 if [ $partial_write == True ]; then
   sram_name+="w"
 fi
 
 sram_name+="_130a"
-cmd="./mc/tsn16ffcllhdspsbsram_130a.pl -file config.txt -NonBIST -NonSLP -NonDSLP -NonSD"
+cmd="./inputs/adk/mc/tsn16ffcllhdspsbsram_130a.pl -file config.txt -NonBIST -NonSLP -NonDSLP -NonSD"
 if [ ! $partial_write == True ]; then
   cmd+=" -NonBWEB"
 fi

--- a/mflowgen/common/gen_sram_macro/mc
+++ b/mflowgen/common/gen_sram_macro/mc
@@ -1,1 +1,0 @@
-/sim/ajcars/mc_clean

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -261,6 +261,7 @@ def construct():
 
   # Connect by name
 
+  g.connect_by_name( adk,      gen_sram       )
   g.connect_by_name( adk,      dc             )
   g.connect_by_name( adk,      iflow          )
   g.connect_by_name( adk,      init           )

--- a/mflowgen/glb_tile/construct.py
+++ b/mflowgen/glb_tile/construct.py
@@ -156,6 +156,7 @@ def construct():
 
   # Connect by name
 
+  g.connect_by_name( adk,      gen_sram       )
   g.connect_by_name( adk,      dc             )
   g.connect_by_name( adk,      iflow          )
   g.connect_by_name( adk,      init           )

--- a/mflowgen/soc/construct.py
+++ b/mflowgen/soc/construct.py
@@ -155,6 +155,7 @@ def construct():
 
   # Connect by name
 
+  g.connect_by_name( adk,      gen_sram     )
   g.connect_by_name( adk,      dc           )
   g.connect_by_name( adk,      iflow        )
   g.connect_by_name( adk,      init         )


### PR DESCRIPTION
Instead of relying on a copy of the memory compiler somewhere on the machine, I've added the memory compiler to the ADK. This PR updates our flows to use this copy of the memory compiler. 

You'll all have to pull the latest version of the ADK for this PR to work.

P.S. Sorry for the screwed up commit history. I accidentally pushed these changes to master initially.