### PR TITLE
Make reset type consistent, use convert API for wiring up reset port

### DIFF
--- a/global_buffer/global_buffer_magma_helper.py
+++ b/global_buffer/global_buffer_magma_helper.py
@@ -62,7 +62,7 @@ def _get_raw_interface(params: GlobalBufferParams):
         clk                               = m.In(m.Clock),
         stall                             = m.In(m.Bit),
         cgra_stall_in                     = m.In(m.Bit),
-        reset                             = m.In(m.Reset),
+        reset                             = m.In(m.AsyncReset),
         cgra_soft_reset                   = m.In(m.Bit),
 
         # proc

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -395,7 +395,8 @@ class MemCore(ConfigurableCore):
         # Need to invert this
         self.resetInverter = FromMagma(mantle.DefineInvert(1))
         self.wire(self.resetInverter.ports.I[0], self.ports.reset)
-        self.wire(self.as_async_reset(self.resetInverter.ports.O[0]),
+        self.wire(self.convert(self.resetInverter.ports.O[0],
+                               magma.asyncreset),
                   self.underlying.ports.rst_n)
         self.wire(self.ports.clk, self.underlying.ports.clk)
 

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -395,7 +395,8 @@ class MemCore(ConfigurableCore):
         # Need to invert this
         self.resetInverter = FromMagma(mantle.DefineInvert(1))
         self.wire(self.resetInverter.ports.I[0], self.ports.reset)
-        self.wire(self.resetInverter.ports.O[0], self.underlying.ports.rst_n)
+        self.wire(self.as_async_reset(self.resetInverter.ports.O[0]),
+                  self.underlying.ports.rst_n)
         self.wire(self.ports.clk, self.underlying.ports.clk)
 
         # Mem core uses clk_en (essentially active low stall)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coreir  # should be first so we get the latest version
--e git://github.com/StanfordAHA/gemstone.git@enable-cast#egg=gemstone
--e git://github.com/StanfordAHA/canal.git@as-enable#egg=canal
+-e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
+-e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coreir  # should be first so we get the latest version
 -e git://github.com/StanfordAHA/gemstone.git@enable-cast#egg=gemstone
--e git://github.com/StanfordAHA/canal.git#egg=canal
+-e git://github.com/StanfordAHA/canal.git@as-enable#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coreir  # should be first so we get the latest version
--e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
+-e git://github.com/StanfordAHA/gemstone.git@enable-cast#egg=gemstone
 -e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen


### PR DESCRIPTION
Fixes type error:

    TypeError: Cannot wire reset (T=Out(AsyncReset)) to reset (T=In(Reset))

global_buffer/global_buffer_magma.py defines reset as `AsyncReset` so I
changed the helper to match