### PR TITLE
Full_chip genus

### DIFF
--- a/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
+++ b/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
@@ -15,11 +15,4 @@ if { $::env(soc_only) } {
   read_hdl -define {ARM_CODEMUX=1 TLX_FWD_DATA_LO_WIDTH=16 TLX_REV_DATA_LO_WIDTH=45} -sv $design_files
 }
 
-if {[file exists [which setup-design-params.txt]]} {
-  #elaborate $dc_design_name -file_parameters setup-design-params.txt
-  #rename_design $dc_design_name* $dc_design_name
-  puts "Error: parameter files not supported"
-  exit 1  
-} else {
-  elaborate $design_name
-}
+elaborate $design_name

--- a/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
+++ b/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
@@ -5,7 +5,7 @@ source inputs/rtl-scripts/pad_frame_design_files.tcl
 
 set design_files [concat $soc_design_files $cgra_design_files $pad_frame_design_files]
 
-set_attr init_hdl_search_path $search_path
+#set_attr init_hdl_search_path $search_path
 
 echo "DA WIDTH: ${::env(TLX_REV_DATA_LO_WIDTH)}"
 

--- a/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
+++ b/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
@@ -8,14 +8,16 @@ set design_files [concat $soc_design_files $cgra_design_files $pad_frame_design_
 echo "DA WIDTH: ${::env(TLX_REV_DATA_LO_WIDTH)}"
 
 if { $::env(soc_only) } {
-  if { ![analyze -define {ARM_CODEMUX=1 NO_CGRA=1 TLX_FWD_DATA_LO_WIDTH=16 TLX_REV_DATA_LO_WIDTH=45} -format sverilog $design_files] } { exit 1 }
+  if { ![read_hdl -define {ARM_CODEMUX=1 NO_CGRA=1 TLX_FWD_DATA_LO_WIDTH=16 TLX_REV_DATA_LO_WIDTH=45} -sv $design_files] } { exit 1 }
 } else {
-  if { ![analyze -define {ARM_CODEMUX=1 TLX_FWD_DATA_LO_WIDTH=16 TLX_REV_DATA_LO_WIDTH=45} -format sverilog $design_files] } { exit 1 }
+  if { ![read_hdl -define {ARM_CODEMUX=1 TLX_FWD_DATA_LO_WIDTH=16 TLX_REV_DATA_LO_WIDTH=45} -sv $design_files] } { exit 1 }
 }
 
 if {[file exists [which setup-design-params.txt]]} {
-  elaborate $dc_design_name -file_parameters setup-design-params.txt
-  rename_design $dc_design_name* $dc_design_name
+  #elaborate $dc_design_name -file_parameters setup-design-params.txt
+  #rename_design $dc_design_name* $dc_design_name
+  puts "Error: parameter files not supported"
+  exit 1  
 } else {
-  elaborate $dc_design_name
+  elaborate $design_name
 }

--- a/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
+++ b/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
@@ -5,6 +5,8 @@ source inputs/rtl-scripts/pad_frame_design_files.tcl
 
 set design_files [concat $soc_design_files $cgra_design_files $pad_frame_design_files]
 
+set_attr init_hdl_search_path $search_path
+
 echo "DA WIDTH: ${::env(TLX_REV_DATA_LO_WIDTH)}"
 
 if { $::env(soc_only) } {

--- a/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
+++ b/mflowgen/common/fc-custom-read-design/outputs/read-design.tcl
@@ -10,9 +10,9 @@ set design_files [concat $soc_design_files $cgra_design_files $pad_frame_design_
 echo "DA WIDTH: ${::env(TLX_REV_DATA_LO_WIDTH)}"
 
 if { $::env(soc_only) } {
-  if { ![read_hdl -define {ARM_CODEMUX=1 NO_CGRA=1 TLX_FWD_DATA_LO_WIDTH=16 TLX_REV_DATA_LO_WIDTH=45} -sv $design_files] } { exit 1 }
+  read_hdl -define {ARM_CODEMUX=1 NO_CGRA=1 TLX_FWD_DATA_LO_WIDTH=16 TLX_REV_DATA_LO_WIDTH=45} -sv $design_files
 } else {
-  if { ![read_hdl -define {ARM_CODEMUX=1 TLX_FWD_DATA_LO_WIDTH=16 TLX_REV_DATA_LO_WIDTH=45} -sv $design_files] } { exit 1 }
+  read_hdl -define {ARM_CODEMUX=1 TLX_FWD_DATA_LO_WIDTH=16 TLX_REV_DATA_LO_WIDTH=45} -sv $design_files
 }
 
 if {[file exists [which setup-design-params.txt]]} {

--- a/mflowgen/common/power-domains/configure.yml
+++ b/mflowgen/common/power-domains/configure.yml
@@ -14,7 +14,6 @@ outputs:
   - add-power-switches.tcl
   - pe-load-upf.tcl
   - mem-load-upf.tcl 
-  - designer-interface.tcl
   - pd-mem-floorplan.tcl
   - pd-globalnetconnect.tcl        
   - pe-constraints.tcl

--- a/mflowgen/common/soc-rtl-v2/rtl-scripts/soc_include_paths.tcl
+++ b/mflowgen/common/soc-rtl-v2/rtl-scripts/soc_include_paths.tcl
@@ -31,17 +31,16 @@ source inputs/rtl-scripts/tlx_include_paths.tcl
 source inputs/rtl-scripts/nic400_include_paths.tcl
 
 # All SoC Include Paths
-#set_attr init_hdl_search_path [concat \
-#  $soc_inc_cm3 \
-#  $soc_inc_cmsdk \
-#  $soc_inc_rtc \
-#  $soc_inc_dma \
-#  $soc_inc_tlx \
-#  $soc_inc_nic400]
-
-lappend search_path [concat \
+set_attr init_hdl_search_path [concat \
   $soc_inc_cm3 \
   $soc_inc_cmsdk \
   $soc_inc_dma \
   $soc_inc_tlx \
   $soc_inc_nic400]
+
+#lappend search_path [concat \
+#  $soc_inc_cm3 \
+#  $soc_inc_cmsdk \
+#  $soc_inc_dma \
+#  $soc_inc_tlx \
+#  $soc_inc_nic400]

--- a/mflowgen/full_chip/constraints/cons_scripts/clocks_0_params.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/clocks_0_params.tcl
@@ -12,7 +12,7 @@
 # Clock Period
 # ------------------------------------------------------------------------------
 
-set cgra_master_clk_period          ${dc_clock_period}
+set cgra_master_clk_period          ${clock_period}
 set soc_master_clk_period           1.0
 
 # ------------------------------------------------------------------------------

--- a/mflowgen/full_chip/constraints/cons_scripts/clocks_1_master.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/clocks_1_master.tcl
@@ -45,6 +45,7 @@ foreach idx $clk_div_factors {
       -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_master_clock_switch/CLK_OUT] \
       -divide_by ${idx} \
       -master_clock m_clk_0 \
+      -add \
       [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_div/CLK_by_${idx}]
 
   # From Master 1

--- a/mflowgen/full_chip/constraints/cons_scripts/clocks_2_sys.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/clocks_2_sys.tcl
@@ -26,6 +26,7 @@ create_generated_clock -name sys_clk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_sys_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock sys_by_${soc_clk_div_factor}_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_sys_fclk/Q]
 
 ## CPU Clock
@@ -33,6 +34,7 @@ create_generated_clock -name cpu_clk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_sys_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock sys_by_${soc_clk_div_factor}_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_cpu_gclk/Q]
 
 ## DAP Clock
@@ -40,6 +42,7 @@ create_generated_clock -name dap_clk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_sys_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock sys_by_${soc_clk_div_factor}_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_dap_gclk/Q]
 
 ## DMA0 Clock
@@ -47,6 +50,7 @@ create_generated_clock -name dma0_clk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_sys_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock sys_by_${soc_clk_div_factor}_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_dma0_gclk/Q]
 
 ## DMA1 Clock
@@ -54,6 +58,7 @@ create_generated_clock -name dma1_clk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_sys_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock sys_by_${soc_clk_div_factor}_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_dma1_gclk/Q]
 
 ## SRAM Clock
@@ -61,6 +66,7 @@ create_generated_clock -name sram_clk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_sys_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock sys_by_${soc_clk_div_factor}_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_sram_gclk/Q]
 
 ## NIC Clock
@@ -68,4 +74,5 @@ create_generated_clock -name nic_clk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_sys_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock sys_by_${soc_clk_div_factor}_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_nic_gclk/Q]

--- a/mflowgen/full_chip/constraints/cons_scripts/clocks_3_tlx.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/clocks_3_tlx.tcl
@@ -27,6 +27,7 @@ create_generated_clock -name tlx_fwd_fclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_tlx_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock tlx_by_4_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_tlx_fclk/Q]
 
 ## Gated Clock
@@ -34,6 +35,7 @@ create_generated_clock -name tlx_fwd_gclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_tlx_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock tlx_by_4_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_tlx_gclk/Q]
 
 ## TLX FWD STROBE (Forwarded Clock)

--- a/mflowgen/full_chip/constraints/cons_scripts/clocks_4_cgra.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/clocks_4_cgra.tcl
@@ -26,6 +26,7 @@ create_generated_clock -name cgra_fclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_cgra_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock cgra_by_${cgra_clk_div_factor}_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_cgra_fclk/Q]
 
 ## Gated Clock
@@ -33,6 +34,7 @@ create_generated_clock -name cgra_gclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_cgra_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock cgra_by_${cgra_clk_div_factor}_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_cgra_gclk/Q]
 
 ## CGRA Clock from global controller

--- a/mflowgen/full_chip/constraints/cons_scripts/clocks_5_periph.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/clocks_5_periph.tcl
@@ -37,6 +37,7 @@ create_generated_clock -name timer0_fclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_timer0_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock timer0_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_timer0_fclk/Q]
 
 # Gated
@@ -44,6 +45,7 @@ create_generated_clock -name timer0_gclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_timer0_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock timer0_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_timer0_gclk/Q]
 
 
@@ -65,6 +67,7 @@ create_generated_clock -name timer1_fclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_timer1_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock timer1_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_timer1_fclk/Q]
 
 # Gated
@@ -72,6 +75,7 @@ create_generated_clock -name timer1_gclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_timer1_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock timer1_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_timer1_gclk/Q]
 
 
@@ -93,6 +97,7 @@ create_generated_clock -name uart0_fclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_uart0_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock uart0_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_uart0_fclk/Q]
 
 # Gated
@@ -100,6 +105,7 @@ create_generated_clock -name uart0_gclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_uart0_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock uart0_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_uart0_gclk/Q]
 
 # ------------------------------------------------------------------------------
@@ -120,6 +126,7 @@ create_generated_clock -name uart1_fclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_uart1_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock uart1_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_uart1_fclk/Q]
 
 # Gated
@@ -127,6 +134,7 @@ create_generated_clock -name uart1_gclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_uart1_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock uart1_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_uart1_gclk/Q]
 
 # ------------------------------------------------------------------------------
@@ -147,6 +155,7 @@ create_generated_clock -name wdog_fclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_wdog_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock wdog_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_wdog_fclk/Q]
 
 # Gated
@@ -154,4 +163,5 @@ create_generated_clock -name wdog_gclk \
     -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_clk_selector_wdog_clk/CLK_OUT] \
     -divide_by 1 \
     -master_clock wdog_by_1_clk \
+    -add \
     [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_wdog_gclk/Q]

--- a/mflowgen/full_chip/constraints/cons_scripts/design_context.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/design_context.tcl
@@ -38,4 +38,4 @@ set_driving_cell -no_design_rule \
                  -lib_cell ${clock_driving_cell} \
                  [get_ports ${clock_ports}]
 
-set_max_area 0
+#set_max_area 0

--- a/mflowgen/full_chip/constraints/cons_scripts/design_context.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/design_context.tcl
@@ -21,10 +21,10 @@ set clock_ports   [list   $port_names(btfy_jtag_clk) \
                   ]
 
 # Set the maximum fanout value on the design
-set_max_fanout 32 ${dc_design_name}
+set_max_fanout 32 ${design_name}
 
 # Set the maximum transition value on the design
-set_max_transition $max_transition ${dc_design_name}
+set_max_transition $max_transition ${design_name}
 
 # Load all outputs with suitable capacitance
 set_load $output_load [all_outputs]

--- a/mflowgen/full_chip/constraints/cons_scripts/design_context.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/design_context.tcl
@@ -36,6 +36,6 @@ set_driving_cell -no_design_rule \
 
 set_driving_cell -no_design_rule \
                  -lib_cell ${clock_driving_cell} \
-                 ${clock_ports}
+                 [get_ports ${clock_ports}]
 
 set_max_area 0

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -146,10 +146,10 @@ def construct():
 
   # Add cgra tile macro inputs to downstream nodes
 
-  synth.extend_inputs( ['tile_array_tt.lib'] )
-  synth.extend_inputs( ['glb_tob_tt.lib'] )
-  synth.extend_inputs( ['global_controller_tt.lib'] )
-  synth.extend_inputs( ['sram_tt.lib'] )
+  synth.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'] )
+  synth.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'] )
+  synth.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'] )
+  synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
   # Exclude dragonphy_top from synth inputs to prevent floating
   # dragonphy inputs from being tied to 0
   pt_signoff.extend_inputs( ['tile_array.db'] )

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -107,7 +107,7 @@ def construct():
 
   info           = Step( 'info',                          default=True )
   #constraints    = Step( 'constraints',                   default=True )
-  dc             = Step( 'synopsys-dc-synthesis',         default=True )
+  synth          = Step( 'cadence-genus-synthesis',       default=True )
   iflow          = Step( 'cadence-innovus-flowsetup',     default=True )
   init           = Step( 'cadence-innovus-init',          default=True )
   power          = Step( 'cadence-innovus-power',         default=True )
@@ -146,13 +146,12 @@ def construct():
 
   # Add cgra tile macro inputs to downstream nodes
 
-  dc.extend_inputs( ['tile_array.db'] )
-  dc.extend_inputs( ['glb_top.db'] )
-  dc.extend_inputs( ['global_controller.db'] )
-  dc.extend_inputs( ['sram_tt.db'] )
-  # Remove dragonphy_top from dc inputs to prevent floating
+  synth.extend_inputs( ['tile_array_tt.lib'] )
+  synth.extend_inputs( ['glb_tob_tt.lib'] )
+  synth.extend_inputs( ['global_controller_tt.lib'] )
+  synth.extend_inputs( ['sram_tt.lib'] )
+  # Exclude dragonphy_top from synth inputs to prevent floating
   # dragonphy inputs from being tied to 0
-  # dc.extend_inputs( ['dragonphy_top_tt.db'] )
   pt_signoff.extend_inputs( ['tile_array.db'] )
   pt_signoff.extend_inputs( ['glb_top.db'] )
   pt_signoff.extend_inputs( ['global_controller.db'] )
@@ -202,9 +201,9 @@ def construct():
   init.extend_inputs( init_fc.all_outputs() )
   power.extend_inputs( custom_power.all_outputs() )
 
-  dc.extend_inputs( soc_rtl.all_outputs() )
-  dc.extend_inputs( read_design.all_outputs() )
-  dc.extend_inputs( ["cons_scripts"] )
+  synth.extend_inputs( soc_rtl.all_outputs() )
+  synth.extend_inputs( read_design.all_outputs() )
+  synth.extend_inputs( ["cons_scripts"] )
 
   power.extend_outputs( ["design.gds.gz"] )
 
@@ -222,7 +221,7 @@ def construct():
   g.add_step( dragonphy         )
   g.add_step( constraints       )
   g.add_step( read_design       )
-  g.add_step( dc                )
+  g.add_step( synth             )
   g.add_step( iflow             )
   g.add_step( init              )
   g.add_step( init_fc           )
@@ -262,7 +261,7 @@ def construct():
   # Connect by name
 
   g.connect_by_name( adk,      gen_sram       )
-  g.connect_by_name( adk,      dc             )
+  g.connect_by_name( adk,      synth          )
   g.connect_by_name( adk,      iflow          )
   g.connect_by_name( adk,      init           )
   g.connect_by_name( adk,      power          )
@@ -290,7 +289,7 @@ def construct():
   if parameters['soc_only'] == False:
       blocks = [tile_array, glb_top, global_controller, dragonphy]
       for block in blocks:
-          g.connect_by_name( block, dc             )
+          g.connect_by_name( block, synth          )
           g.connect_by_name( block, iflow          )
           g.connect_by_name( block, init           )
           g.connect_by_name( block, power          )
@@ -309,18 +308,18 @@ def construct():
       # Tile_array can use rtl from rtl node
       g.connect_by_name( rtl, tile_array )
 
-  g.connect_by_name( rtl,         dc        )
-  g.connect_by_name( soc_rtl,     dc        )
-  g.connect_by_name( constraints, dc        )
-  g.connect_by_name( read_design, dc        )
+  g.connect_by_name( rtl,         synth     )
+  g.connect_by_name( soc_rtl,     synth        )
+  g.connect_by_name( constraints, synth        )
+  g.connect_by_name( read_design, synth        )
 
   g.connect_by_name( soc_rtl,  io_file      )
 
-  g.connect_by_name( dc,       iflow        )
-  g.connect_by_name( dc,       init         )
-  g.connect_by_name( dc,       power        )
-  g.connect_by_name( dc,       place        )
-  g.connect_by_name( dc,       cts          )
+  g.connect_by_name( synth,       iflow        )
+  g.connect_by_name( synth,       init         )
+  g.connect_by_name( synth,       power        )
+  g.connect_by_name( synth,       place        )
+  g.connect_by_name( synth,       cts          )
 
   g.connect_by_name( iflow,    init           )
   g.connect_by_name( iflow,    power          )
@@ -337,7 +336,7 @@ def construct():
   g.connect_by_name( custom_power, power    )
 
   # SRAM macro
-  g.connect_by_name( gen_sram, dc             )
+  g.connect_by_name( gen_sram, synth          )
   g.connect_by_name( gen_sram, iflow          )
   g.connect_by_name( gen_sram, init           )
   g.connect_by_name( gen_sram, power          )
@@ -390,7 +389,7 @@ def construct():
   g.connect_by_name( signoff,      pt_signoff   )
 
   g.connect_by_name( adk,      debugcalibre )
-  g.connect_by_name( dc,       debugcalibre )
+  g.connect_by_name( synth,    debugcalibre )
   g.connect_by_name( iflow,    debugcalibre )
   g.connect_by_name( signoff,  debugcalibre )
   g.connect_by_name( drc,      debugcalibre )
@@ -414,10 +413,10 @@ def construct():
   # which scripts get run and when they get run.
 
   # DC needs these param to set the NO_CGRA macro
-  dc.update_params({'soc_only': parameters['soc_only']}, True)
+  synth.update_params({'soc_only': parameters['soc_only']}, True)
   # DC needs these params to set macros in soc rtl
-  dc.update_params({'TLX_FWD_DATA_LO_WIDTH' : parameters['TLX_FWD_DATA_LO_WIDTH']}, True)
-  dc.update_params({'TLX_REV_DATA_LO_WIDTH' : parameters['TLX_REV_DATA_LO_WIDTH']}, True)
+  synth.update_params({'TLX_FWD_DATA_LO_WIDTH' : parameters['TLX_FWD_DATA_LO_WIDTH']}, True)
+  synth.update_params({'TLX_REV_DATA_LO_WIDTH' : parameters['TLX_REV_DATA_LO_WIDTH']}, True)
   init.update_params({'soc_only': parameters['soc_only']}, True)
 
   init.update_params(
@@ -461,11 +460,9 @@ def construct():
   antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'] } )
 
   # Remove unresolved reference assertion from DC because dragonphy is an unresolved reference
-  dc_postconditions = dc.get_postconditions()
-  dc_postconditions.remove( "assert 'Unresolved references' not in File( 'logs/dc.log' )" )
-  dc_postconditions.remove( "assert 'Unable to resolve' not in File( 'logs/dc.log' )" )
-  dc_postconditions.append( """assert "has '1' unresolved references" in File( 'logs/dc.log' )""" )
-  dc.set_postconditions( dc_postconditions )
+  synth_postconditions = synth.get_postconditions()
+  synth_postconditions.remove( "assert 'Cannot resolve reference' not in File( 'logs/genus.log' )" )
+  synth.set_postconditions( synth_postconditions )
   return g
 
 

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -150,6 +150,7 @@ def construct():
   synth.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'] )
   synth.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'] )
   synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
+  synth.extend_inputs( ['dragonphy_top.lef'] )
   # Exclude dragonphy_top from synth inputs to prevent floating
   # dragonphy inputs from being tied to 0
   pt_signoff.extend_inputs( ['tile_array.db'] )
@@ -459,10 +460,6 @@ def construct():
   # Antenna DRC node needs to use antenna rule deck
   antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'] } )
 
-  # Remove unresolved reference assertion from DC because dragonphy is an unresolved reference
-  synth_postconditions = synth.get_postconditions()
-  synth_postconditions.remove( "assert 'Cannot resolve reference' not in File( 'logs/genus.log' )" )
-  synth.set_postconditions( synth_postconditions )
   return g
 
 

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -29,7 +29,7 @@ def construct():
     'adk'               : adk_name,
     'adk_view'          : adk_view,
     # Synthesis
-    'flatten_effort'    : 1,
+    'flatten_effort'    : 0,
     'topographical'     : True,
     # RTL Generation
     'array_width'       : 32,


### PR DESCRIPTION
Converts full_chip flow to use genus for synthesis. Depends on [this mflowgen PR](https://github.com/cornell-brg/mflowgen/pull/71). Also removes designer-interface.tcl for power domains node, as overriding the designer-interface script is no longer necessary with the Genus node we are now using.