### PR TITLE
add core density target to PE to combat smaller synth area

### DIFF
--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -35,7 +35,8 @@ def construct():
     # RTL Generation
     'interconnect_only' : True,
     # Power Domains
-    'PWR_AWARE'         : pwr_aware
+    'PWR_AWARE'         : pwr_aware,
+    'core_density_target': 0.63
   
   }
 
@@ -291,6 +292,7 @@ def construct():
   # steps, we modify the order parameter for that node which determines
   # which scripts get run and when they get run.
 
+  init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
   # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
   # and 'additional-path-groups' after 'make_path_groups'
 

--- a/mflowgen/Tile_PE/custom-init/outputs/floorplan.tcl
+++ b/mflowgen/Tile_PE/custom-init/outputs/floorplan.tcl
@@ -11,7 +11,7 @@
 #-------------------------------------------------------------------------
 
 # Density target: width will be adjusted to meet this cell density
-set core_density_target 0.70; # Placement density of 65% is reasonable
+set core_density_target $::env(core_density_target); # Placement density of 65% is reasonable
 # Core height : number of vertical pitches in height of core area
 # We fix this value because the height of the memory and PE tiles
 # must be the same to allow for abutment at the top level


### PR DESCRIPTION
This PR just adds the `core_density_target` parameter to the PE graph, similar to memtile.

Since the PE genus flow is about ~10% smaller than DC, we also need to drop the density target so that we don't see >= 90% congestion levels from the fixed buffering overhead to meet min_delay on passthrough ports.