### PR TITLE
Glb cleaning some files

### DIFF
--- a/global_buffer/copy-annotate.sh
+++ b/global_buffer/copy-annotate.sh
@@ -1,6 +1,0 @@
-scp /sim/kongty/mflowgen/build-glb-power/18-cadence-innovus-signoff/results/global_buffer.vcs.v r7arm-aha:/sim/kongty/pnr_annotate/global_buffer.v
-scp /sim/kongty/mflowgen/build-glb-power/18-cadence-innovus-signoff/results/global_buffer.sdf r7arm-aha:/sim/kongty/pnr_annotate/global_buffer.sdf
-scp /sim/kongty/mflowgen/build-glb-power/18-cadence-innovus-signoff/typical.spef.gz r7arm-aha:/sim/kongty/pnr_annotate/global_buffer.spef.gz
-scp /sim/kongty/mflowgen/build-glb-power/4-glb_tile/18-cadence-innovus-signoff/results/glb_tile.vcs.v r7arm-aha:/sim/kongty/pnr_annotate/glb_tile.v
-scp /sim/kongty/mflowgen/build-glb-power/4-glb_tile/18-cadence-innovus-signoff/results/glb_tile.sdf r7arm-aha:/sim/kongty/pnr_annotate/glb_tile.sdf
-scp /sim/kongty/mflowgen/build-glb-power/4-glb_tile/18-cadence-innovus-signoff/typical.spef.gz r7arm-aha:/sim/kongty/pnr_annotate/glb_tile.spef.gz

--- a/global_buffer/dump.tcl
+++ b/global_buffer/dump.tcl
@@ -1,3 +1,0 @@
-dump -aggregates -add /
-run
-exit

--- a/global_buffer/rtl/global_buffer_param.svh
+++ b/global_buffer/rtl/global_buffer_param.svh
@@ -1,0 +1,29 @@
+`ifndef GLOBAL_BUFFER_PARAM
+`define GLOBAL_BUFFER_PARAM
+package global_buffer_param;
+localparam int NUM_GLB_TILES = 16;
+localparam int TILE_SEL_ADDR_WIDTH = 4;
+localparam int NUM_CGRA_TILES = 32;
+localparam int CGRA_PER_GLB = 2;
+localparam int BANKS_PER_TILE = 2;
+localparam int BANK_SEL_ADDR_WIDTH = 1;
+localparam int BANK_DATA_WIDTH = 64;
+localparam int BANK_ADDR_WIDTH = 17;
+localparam int BANK_BYTE_OFFSET = 3;
+localparam int GLB_ADDR_WIDTH = 22;
+localparam int CGRA_DATA_WIDTH = 16;
+localparam int CGRA_BYTE_OFFSET = 1;
+localparam int AXI_ADDR_WIDTH = 12;
+localparam int AXI_DATA_WIDTH = 32;
+localparam int AXI_STRB_WIDTH = 4;
+localparam int AXI_BYTE_OFFSET = 2;
+localparam int MAX_NUM_WORDS_WIDTH = 21;
+localparam int MAX_STRIDE_WIDTH = 11;
+localparam int MAX_NUM_CFGS_WIDTH = 19;
+localparam int CGRA_CFG_ADDR_WIDTH = 32;
+localparam int CGRA_CFG_DATA_WIDTH = 32;
+localparam int QUEUE_DEPTH = 4;
+localparam int LOOP_LEVEL = 4;
+localparam int LATENCY_WIDTH = 5;
+endpackage
+`endif


### PR DESCRIPTION
1. Remove unused files (`copy-annotate.sh` and `dump.tcl`)
2. Add default `global_buffer_param.svh` file.
- This header file is generated from running some python/magma code. However, just in case where python and magma is not available, I added the default header file.