### PR TITLE
Add utilization target param to glc

### DIFF
--- a/mflowgen/global_controller/construct.py
+++ b/mflowgen/global_controller/construct.py
@@ -36,7 +36,9 @@ def construct():
     # Power Domains (leave this false)
     'PWR_AWARE'         : False,
     # hold target slack
-    'hold_target_slack' : 0.030
+    'hold_target_slack' : 0.030,
+    # Utilization target
+    'core_density_target' : 0.50
   }
 
   #-----------------------------------------------------------------------
@@ -193,6 +195,9 @@ def construct():
   floorplan_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
   order.insert( floorplan_idx + 1, 'add-endcaps-welltaps.tcl' ) # add here
   init.update_params( { 'order': order } )
+  
+  # Add density target parameter
+  init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
 
   # Increase hold slack on postroute_hold step
   postroute_hold.update_params( { 'hold_target_slack': parameters['hold_target_slack'] }, allow_new=True  )

--- a/mflowgen/global_controller/custom-init/configure.yml
+++ b/mflowgen/global_controller/custom-init/configure.yml
@@ -10,4 +10,5 @@ name: custom-init
 
 outputs:
   - add-endcaps-welltaps.tcl
+  - floorplan.tcl
 

--- a/mflowgen/global_controller/custom-init/outputs/floorplan.tcl
+++ b/mflowgen/global_controller/custom-init/outputs/floorplan.tcl
@@ -1,0 +1,53 @@
+#=========================================================================
+# floorplan.tcl
+#=========================================================================
+# Author : Christopher Torng
+# Date   : March 26, 2018
+
+#-------------------------------------------------------------------------
+# Floorplan variables
+#-------------------------------------------------------------------------
+
+# Set the floorplan to target a reasonable placement density with a good
+# aspect ratio (height:width). An aspect ratio of 2.0 here will make a
+# rectangular chip with a height that is twice the width.
+
+set core_aspect_ratio   1.00; # Aspect ratio 1.0 for a square chip
+set core_density_target $::env(core_density_target); # Placement density of 70% is reasonable
+
+# Make room in the floorplan for the core power ring
+
+set pwr_net_list {VDD VSS}; # List of power nets in the core power ring
+
+set M1_min_width   [dbGet [dbGetLayerByZ 1].minWidth]
+set M1_min_spacing [dbGet [dbGetLayerByZ 1].minSpacing]
+
+set savedvars(p_ring_width)   [expr 48 * $M1_min_width];   # Arbitrary!
+set savedvars(p_ring_spacing) [expr 24 * $M1_min_spacing]; # Arbitrary!
+
+# Core bounding box margins
+
+set core_margin_t [expr ([llength $pwr_net_list] * ($savedvars(p_ring_width) + $savedvars(p_ring_spacing))) + $savedvars(p_ring_spacing)]
+set core_margin_b [expr ([llength $pwr_net_list] * ($savedvars(p_ring_width) + $savedvars(p_ring_spacing))) + $savedvars(p_ring_spacing)]
+set core_margin_r [expr ([llength $pwr_net_list] * ($savedvars(p_ring_width) + $savedvars(p_ring_spacing))) + $savedvars(p_ring_spacing)]
+set core_margin_l [expr ([llength $pwr_net_list] * ($savedvars(p_ring_width) + $savedvars(p_ring_spacing))) + $savedvars(p_ring_spacing)]
+
+#-------------------------------------------------------------------------
+# Floorplan
+#-------------------------------------------------------------------------
+
+# Calling floorPlan with the "-r" flag sizes the floorplan according to
+# the core aspect ratio and a density target (70% is a reasonable
+# density).
+#
+
+floorPlan -r $core_aspect_ratio $core_density_target \
+             $core_margin_l $core_margin_b $core_margin_r $core_margin_t
+
+setFlipping s
+
+# Use automatic floorplan synthesis to pack macros (e.g., SRAMs) together
+
+planDesign
+
+

--- a/mflowgen/global_controller/custom-init/outputs/floorplan.tcl
+++ b/mflowgen/global_controller/custom-init/outputs/floorplan.tcl
@@ -13,7 +13,7 @@
 # rectangular chip with a height that is twice the width.
 
 set core_aspect_ratio   1.00; # Aspect ratio 1.0 for a square chip
-set core_density_target $::env(core_density_target); # Placement density of 70% is reasonable
+set core_density_target $::env(core_density_target);
 
 # Make room in the floorplan for the core power ring
 


### PR DESCRIPTION
Creates target utilization parameter for glc flow and relaxes the target because I was seeing near 100% density in Innovus.