### PR TITLE
update register pass to extract config reg map

### DIFF
--- a/garnet.py
+++ b/garnet.py
@@ -13,6 +13,8 @@ from mini_mapper import map_app, has_rom
 from cgra import glb_glc_wiring, glb_interconnect_wiring, \
         glc_interconnect_wiring, create_cgra, compress_config_data
 import json
+from passes.collateral_pass.config_register import get_interconnect_regs, \
+    get_core_registers
 import math
 import archipelago
 
@@ -299,6 +301,7 @@ def main():
     parser.add_argument("--no-sram-stub", action="store_true")
     parser.add_argument("--standalone", action="store_true")
     parser.add_argument("--unconstrained-io", action="store_true")
+    parser.add_argument("--dump-config-reg", action="store_true")
     args = parser.parse_args()
 
     if not args.interconnect_only:
@@ -351,6 +354,12 @@ def main():
             bs = ["{0:08X} {1:08X}".format(entry[0], entry[1]) for entry
                   in bitstream]
             f.write("\n".join(bs))
+    if args.dump_config_reg:
+        ic = garnet.interconnect
+        ic_reg = get_interconnect_regs(ic)
+        core_reg = get_core_registers(ic)
+        with open("config.json", "w+") as f:
+            json.dump(ic_reg + core_reg, f)
 
 
 if __name__ == "__main__":

--- a/passes/collateral_pass/config_register.py
+++ b/passes/collateral_pass/config_register.py
@@ -99,7 +99,7 @@ def get_core_registers(interconnect: Interconnect):
             # memory has couple features
             base_feat_addr = tile.features().index(core)
             regs = list(core.registers.keys())
-            for reg_name in enumerate(regs):
+            for reg_name in regs:
                 reg_addr, lo, hi = core.get_reg_info(reg_name)
                 width = core.registers[reg_name].width
                 addr = interconnect.get_config_addr(reg_addr, base_feat_addr,

--- a/passes/collateral_pass/config_register.py
+++ b/passes/collateral_pass/config_register.py
@@ -15,51 +15,53 @@ def get_interconnect_regs(interconnect: Interconnect):
         for cb_name, cb in tile.cbs.items():
             # get the index
             index = tile.features().index(cb)
-            # reg space is always 0 for CB
-            reg_addr = 0
             # need to get range
             # notice that we may already replace the mux with aoi + const
             # so we need to get the height from the actual mux
             mux = cb.mux
             mux_range = mux.height
+            if mux_range <= 1:
+                continue
+            reg_addr, lo, hi = cb.get_reg_info(get_mux_sel_name(cb.node))
             config_addr = interconnect.get_config_addr(reg_addr, index,
                                                        x, y)
             result.append({
                 "name": cb_name,
                 "addr": config_addr,
-                "range": mux_range
+                "range": mux_range - 1,
+                "lo": lo,
+                "hi": hi
             })
 
         for switchbox in tile.sbs.values():
             index = tile.features().index(switchbox)
-            # sort the reg names
-            reg_names = list(switchbox.registers.keys())
-            reg_names.sort()
             for sb, sb_mux in switchbox.sb_muxs.values():
                 if sb_mux.height > 1:
                     config_name = get_mux_sel_name(sb)
-                    assert config_name in reg_names
-                    reg_addr = reg_names.index(config_name)
+                    reg_addr, lo, hi = switchbox.get_reg_info(config_name)
                     mux_range = sb_mux.height
                     config_addr = interconnect.get_config_addr(reg_addr, index,
                                                                x, y)
                     result.append({
                         "name": str(sb),
                         "addr": config_addr,
-                        "range": mux_range
+                        "range": mux_range - 1,
+                        "lo": lo,
+                        "hi": hi
                     })
             for node, reg_mux in switchbox.reg_muxs.values():
                 if reg_mux.height > 1:
                     config_name = get_mux_sel_name(node)
-                    assert config_name in reg_names
-                    reg_addr = reg_names.index(config_name)
+                    reg_addr, lo, hi = switchbox.get_reg_info(config_name)
                     mux_range = reg_mux.height
                     config_addr = interconnect.get_config_addr(reg_addr, index,
                                                                x, y)
                     result.append({
                         "name": str(node),
                         "addr": config_addr,
-                        "range": mux_range
+                        "range": mux_range - 1,
+                        "lo": lo,
+                        "hi": hi
                     })
 
     return result
@@ -86,26 +88,31 @@ def get_core_registers(interconnect: Interconnect):
                 result.append({
                     "name": reg_name,
                     "addr": addr,
-                    "range": 1 << width
+                    "range": (1 << width) - 1,
+                    "lo": 0,
+                    "hi": width + 1
                 })
         elif isinstance(core, MemCore):
-            # memory has five features
+            # memory has couple features
             base_feat_addr = tile.features().index(core)
             regs = list(core.registers.keys())
-            regs.sort()
-            for idx, reg_name in enumerate(regs):
-                reg_addr = idx
+            for reg_name in enumerate(regs):
+                reg_addr, lo, hi = core.get_reg_info(reg_name)
                 width = core.registers[reg_name].width
                 addr = interconnect.get_config_addr(reg_addr, base_feat_addr,
                                                     x, y)
                 result.append({
                     "name": reg_name,
                     "addr": addr,
-                    "range": 1 << width
+                    "range": 1 << width,
+                    "lo": lo,
+                    "hi": hi
                 })
 
             # SRAM
-            for sram_index in range(4):
+            num_sram = core.num_sram_features
+            repeat = core.mem_width // core.data_width
+            for sram_index in range(num_sram):
                 for reg_addr in range(256):
                     addr = \
                         interconnect.get_config_addr(
@@ -113,6 +120,7 @@ def get_core_registers(interconnect: Interconnect):
                     result.append({
                         "name": f"SRAM_{sram_index}_{reg_addr}",
                         "addr": addr,
-                        "range": 1 << 16
+                        "range": (1 << 16) - 1,
+                        "repeat": repeat
                     })
     return result

--- a/passes/collateral_pass/config_register.py
+++ b/passes/collateral_pass/config_register.py
@@ -30,7 +30,8 @@ def get_interconnect_regs(interconnect: Interconnect):
                 "addr": config_addr,
                 "range": mux_range - 1,
                 "lo": lo,
-                "hi": hi
+                "hi": hi,
+                "reg_name": f"config_reg_{reg_addr}"
             })
 
         for switchbox in tile.sbs.values():
@@ -47,7 +48,8 @@ def get_interconnect_regs(interconnect: Interconnect):
                         "addr": config_addr,
                         "range": mux_range - 1,
                         "lo": lo,
-                        "hi": hi
+                        "hi": hi,
+                        "reg_name": f"config_reg_{reg_addr}"
                     })
             for node, reg_mux in switchbox.reg_muxs.values():
                 if reg_mux.height > 1:
@@ -61,7 +63,8 @@ def get_interconnect_regs(interconnect: Interconnect):
                         "addr": config_addr,
                         "range": mux_range - 1,
                         "lo": lo,
-                        "hi": hi
+                        "hi": hi,
+                        "reg_name": f"config_reg_{reg_addr}"
                     })
 
     return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coreir>=2.0.123  # should be first so we get the latest version
--e git://github.com/StanfordAHA/gemstone.git@reg_info#egg=gemstone
+-e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
 -e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coreir>=2.0.123  # should be first so we get the latest version
--e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
+-e git://github.com/StanfordAHA/gemstone.git@reg_info#egg=gemstone
 -e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen


### PR DESCRIPTION
This should dump all the config register information, including feature addr, reg addr, lo and hi. Here is some example of the output:
```json
{"name": "RMUX_T0_EAST_B1", "addr": 393217, "range": 1, "lo": 0, "hi": 1, "reg_name": "config_reg_0"}, 
{"name": "RMUX_T0_WEST_B1", "addr": 393217,  "range": 1, "lo": 3, "hi": 4, "reg_name": "config_reg_0"}, 
{"name": "RMUX_T1_NORTH_B1", "addr": 393217, "range": 1, "lo": 5, "hi": 6, "reg_name": "config_reg_0"}, 
{"name": "RMUX_T1_SOUTH_B1", "addr": 393217, "range": 1, "lo": 6, "hi": 7, "reg_name": "config_reg_0"}, 
{"name": "RMUX_T1_EAST_B1", "addr": 393217, "range": 1, "lo": 4, "hi": 5, "reg_name": "config_reg_0"}, 
{"name": "RMUX_T1_WEST_B1", "addr": 393217, "range": 1, "lo": 7, "hi": 8, "reg_name": "config_reg_0"}
```

Notice that lo and hi are in the format of `[lo, hi)`

This should allow PD scripts to figure out which constraint to put automatically.