### PR TITLE
Glb use fullchip

### DIFF
--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -299,6 +299,8 @@ def construct():
       g.connect_by_name( rtl, tile_array )
       # glb_top can use rtl from rtl node
       g.connect_by_name( rtl, glb_top )
+      # global_controller can use rtl from rtl node
+      g.connect_by_name( rtl, global_controller )
 
   g.connect_by_name( rtl,         synth     )
   g.connect_by_name( soc_rtl,     synth        )

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -297,6 +297,8 @@ def construct():
           g.connect_by_name( block, lvs            )
       # Tile_array can use rtl from rtl node
       g.connect_by_name( rtl, tile_array )
+      # glb_top can use rtl from rtl node
+      g.connect_by_name( rtl, glb_top )
 
   g.connect_by_name( rtl,         synth     )
   g.connect_by_name( soc_rtl,     synth        )

--- a/mflowgen/full_chip/glb_top/configure.yml
+++ b/mflowgen/full_chip/glb_top/configure.yml
@@ -3,6 +3,9 @@ name: glb_top
 commands:
   - bash get_glb_top_outputs.sh
 
+inputs:
+  - design.v
+
 outputs:
   - glb_top_tt.lib
   - glb_top.lef

--- a/mflowgen/full_chip/global_controller/configure.yml
+++ b/mflowgen/full_chip/global_controller/configure.yml
@@ -3,6 +3,9 @@ name: global_controller
 commands:
   - bash get_global_controller_outputs.sh
 
+inputs:
+  - design.v
+
 outputs:
   - global_controller_tt.lib
   - global_controller.lef

--- a/mflowgen/glb_tile/rtl/gen_rtl.sh
+++ b/mflowgen/glb_tile/rtl/gen_rtl.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
-
-# SystemRDL run
-make -C $GARNET_HOME/global_buffer rtl
-
-rm -f outputs/design.v
-
-while read F  ; do
-    echo "Reading design file: $F"
-    cat $GARNET_HOME/global_buffer/rtl/$F >> outputs/design.v
-done <$GARNET_HOME/global_buffer/rtl/glb_tile.filelist
+# Glb can accept rtl as an input from parent graph
+if [ -f ../inputs/design.v ]; then
+  echo "Using RTL from parent graph"
+  mkdir -p outputs
+  (cd outputs; ln -s ../../inputs/design.v)
+else
+  # SystemRDL run
+  make -C $GARNET_HOME/global_buffer rtl
+  
+  rm -f outputs/design.v
+  
+  while read F  ; do
+      echo "Reading design file: $F"
+      cat $GARNET_HOME/global_buffer/rtl/$F >> outputs/design.v
+  done <$GARNET_HOME/global_buffer/rtl/glb_tile.filelist
+fi

--- a/mflowgen/glb_top/construct.py
+++ b/mflowgen/glb_top/construct.py
@@ -195,6 +195,9 @@ def construct():
   g.connect_by_name( rtl,         synth        )
   g.connect_by_name( constraints, synth        )
 
+  # glb_tile can use the same rtl as glb_top
+  g.connect_by_name( rtl,         glb_tile      )
+
   g.connect_by_name( synth,       iflow        )
   g.connect_by_name( synth,       init         )
   g.connect_by_name( synth,       power        )

--- a/mflowgen/glb_top/glb_tile/configure.yml
+++ b/mflowgen/glb_top/glb_tile/configure.yml
@@ -3,6 +3,9 @@ name: glb_tile
 commands:
   - bash get_glb_outputs.sh
 
+inputs:
+  - design.v
+
 outputs:
   - glb_tile_tt.lib
   - glb_tile.lef

--- a/mflowgen/glb_top/rtl/gen_rtl.sh
+++ b/mflowgen/glb_top/rtl/gen_rtl.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
-
-# SystemRDL run
-make clean
-make -C $GARNET_HOME/global_buffer rtl CGRA_WIDTH=${cgra_width} NUM_GLB_TILES=${num_glb_tiles}
-
-rm -f outputs/design.v
-
-while read F  ; do
-    echo "Reading design file: $F"
-    cat $GARNET_HOME/global_buffer/rtl/$F >> outputs/design.v
-done <$GARNET_HOME/global_buffer/rtl/global_buffer.filelist
+# Glb can accept rtl as an input from parent graph
+if [ -f ../inputs/design.v ]; then
+  echo "Using RTL from parent graph"
+  mkdir -p outputs
+  (cd outputs; ln -s ../../inputs/design.v)
+else
+  # SystemRDL run
+  make clean
+  make -C $GARNET_HOME/global_buffer rtl CGRA_WIDTH=${cgra_width} NUM_GLB_TILES=${num_glb_tiles}
+  
+  rm -f outputs/design.v
+  
+  while read F  ; do
+      echo "Reading design file: $F"
+      cat $GARNET_HOME/global_buffer/rtl/$F >> outputs/design.v
+  done <$GARNET_HOME/global_buffer/rtl/global_buffer.filelist
+fi

--- a/mflowgen/global_controller/rtl/gen_rtl.sh
+++ b/mflowgen/global_controller/rtl/gen_rtl.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
-
-# SystemRDL run
-make -C $GARNET_HOME/global_controller rtl
-
-while read F  ; do
-  if [[ "$F" =~ "DW" ]]; then
-    echo "Reading design file: $F"
-    cat $F >> outputs/design.v
-  else
-    echo "Reading design file: $F"
-    cat $GARNET_HOME/global_controller/$F >> outputs/design.v
-  fi
-done <$GARNET_HOME/global_controller/global_controller.filelist
+if [ -f ../inputs/design.v ]; then
+  echo "Using RTL from parent graph"
+  mkdir -p outputs
+  (cd outputs; ln -s ../../inputs/design.v)
+else
+  # SystemRDL run
+  make -C $GARNET_HOME/global_controller rtl
+  
+  while read F  ; do
+    if [[ "$F" =~ "DW" ]]; then
+      echo "Reading design file: $F"
+      cat $F >> outputs/design.v
+    else
+      echo "Reading design file: $F"
+      cat $GARNET_HOME/global_controller/$F >> outputs/design.v
+    fi
+  done <$GARNET_HOME/global_controller/global_controller.filelist
+fi

--- a/mflowgen/global_controller/rtl/gen_rtl.sh
+++ b/mflowgen/global_controller/rtl/gen_rtl.sh
@@ -6,14 +6,9 @@ if [ -f ../inputs/design.v ]; then
 else
   # SystemRDL run
   make -C $GARNET_HOME/global_controller rtl
-  
+
   while read F  ; do
-    if [[ "$F" =~ "DW" ]]; then
-      echo "Reading design file: $F"
-      cat $F >> outputs/design.v
-    else
-      echo "Reading design file: $F"
-      cat $GARNET_HOME/global_controller/$F >> outputs/design.v
-    fi
+    echo "Reading design file: $F"
+    cat $GARNET_HOME/global_controller/$F >> outputs/design.v
   done <$GARNET_HOME/global_controller/global_controller.filelist
 fi


### PR DESCRIPTION
Since the common rtl node can now generate rtl for glb_top, glb_tile, and glc, this PR makes it such that rtl can be generated in one single location in the hierarchical graphs, rather than generating rtl separately wtihin glb_top, glb_tile, and glc subgraphs.