### PR TITLE
Hierarchical postconditions

### DIFF
--- a/mflowgen/full_chip/glb_top/configure.yml
+++ b/mflowgen/full_chip/glb_top/configure.yml
@@ -15,3 +15,12 @@ outputs:
   - glb_top.lvs.v
   - glb_top.sram.spi
 
+postconditions:
+  - assert File( 'outputs/glb_top_tt.lib' ) # must exist
+  - assert File( 'outputs/glb_top.lef' ) # must exist
+  - assert File( 'outputs/glb_top.gds' ) # must exist
+  - assert File( 'outputs/glb_top.vcs.v' ) # must exist
+  - assert File( 'outputs/glb_top.sdf' ) # must exist
+  - assert File( 'outputs/glb_top.lvs.v' ) # must exist
+  - assert File( 'outputs/glb_top.sram.spi' ) # must exist
+

--- a/mflowgen/full_chip/global_controller/configure.yml
+++ b/mflowgen/full_chip/global_controller/configure.yml
@@ -14,3 +14,11 @@ outputs:
   - global_controller.sdf
   - global_controller.lvs.v
 
+postconditions:
+  - assert File( 'outputs/global_controller_tt.lib' ) # must exist
+  - assert File( 'outputs/global_controller.lef' ) # must exist
+  - assert File( 'outputs/global_controller.gds' ) # must exist
+  - assert File( 'outputs/global_controller.vcs.v' ) # must exist
+  - assert File( 'outputs/global_controller.sdf' ) # must exist
+  - assert File( 'outputs/global_controller.lvs.v' ) # must exist
+

--- a/mflowgen/full_chip/tile_array/configure.yml
+++ b/mflowgen/full_chip/tile_array/configure.yml
@@ -9,10 +9,18 @@ inputs:
 outputs:
   - tile_array_tt.lib
   - tile_array.lef
-  - tile_array.db
   - tile_array.gds
   - tile_array.vcs.v
   - tile_array.sdf
   - tile_array.lvs.v
   - tile_array.sram.spi
+
+postconditions:
+  - assert File( 'outputs/tile_array_tt.lib' ) # must exist
+  - assert File( 'outputs/tile_array.lef' ) # must exist
+  - assert File( 'outputs/tile_array.gds' ) # must exist
+  - assert File( 'outputs/tile_array.vcs.v' ) # must exist
+  - assert File( 'outputs/tile_array.sdf' ) # must exist
+  - assert File( 'outputs/tile_array.lvs.v' ) # must exist
+  - assert File( 'outputs/tile_array.sram.spi' ) # must exist
 

--- a/mflowgen/glb_top/glb_tile/configure.yml
+++ b/mflowgen/glb_top/glb_tile/configure.yml
@@ -13,3 +13,10 @@ outputs:
   - glb_tile.lvs.v
   - sram.spi
 
+postconditions:
+  - assert File( 'outputs/glb_tile_tt.lib' ) # must exist
+  - assert File( 'outputs/glb_tile.lef' ) # must exist
+  - assert File( 'outputs/glb_tile.gds' ) # must exist
+  - assert File( 'outputs/glb_tile.lvs.v' ) # must exist
+  - assert File( 'outputs/sram.spi' ) # must exist
+

--- a/mflowgen/tile_array/Tile_MemCore/configure.yml
+++ b/mflowgen/tile_array/Tile_MemCore/configure.yml
@@ -9,10 +9,18 @@ inputs:
 outputs:
   - Tile_MemCore_tt.lib
   - Tile_MemCore.lef
-  - Tile_MemCore.db
   - Tile_MemCore.gds
   - Tile_MemCore.vcs.v
   - Tile_MemCore.lvs.v
   - Tile_MemCore.sdf
   - sram.spi
+
+postconditions:
+  - assert File( 'outputs/Tile_MemCore_tt.lib' ) # must exist
+  - assert File( 'outputs/Tile_MemCore.lef' ) # must exist
+  - assert File( 'outputs/Tile_MemCore.gds' ) # must exist
+  - assert File( 'outputs/Tile_MemCore.vcs.v' ) # must exist
+  - assert File( 'outputs/Tile_MemCore.lvs.v' ) # must exist
+  - assert File( 'outputs/Tile_MemCore.sdf' ) # must exist
+  - assert File( 'outputs/sram.spi' ) # must exist
 

--- a/mflowgen/tile_array/Tile_PE/configure.yml
+++ b/mflowgen/tile_array/Tile_PE/configure.yml
@@ -9,9 +9,16 @@ inputs:
 outputs:
   - Tile_PE_tt.lib
   - Tile_PE.lef
-  - Tile_PE.db
   - Tile_PE.gds
   - Tile_PE.vcs.v
   - Tile_PE.lvs.v
   - Tile_PE.sdf
+
+postconditions:
+  - assert File( 'outputs/Tile_PE_tt.lib' ) # must exist
+  - assert File( 'outputs/Tile_PE.lef' ) # must exist
+  - assert File( 'outputs/Tile_PE.gds' ) # must exist
+  - assert File( 'outputs/Tile_PE.vcs.v' ) # must exist
+  - assert File( 'outputs/Tile_PE.lvs.v' ) # must exist
+  - assert File( 'outputs/Tile_PE.sdf' ) # must exist
 


### PR DESCRIPTION
This PR adds assertions on hierarchical blocks that all sub-block outputs must exist. Prevents the annoying scenario where something fails in a hierarchical block and the block is still marked as complete by make. Also removes some old .db outputs which are no longer valid.