### PR TITLE
Fix dragonphy outputs error in netlist-fixing

### DIFF
--- a/mflowgen/common/fc-netlist-fixing/outputs/netlist-fixing.tcl
+++ b/mflowgen/common/fc-netlist-fixing/outputs/netlist-fixing.tcl
@@ -74,7 +74,9 @@ foreach port $bump_to_iphy {
 }
 
 foreach port $iphy_to_bump {
-  deleteNet $port
+  if {[sizeof_collection [get_nets -quiet $port]] > 0} {
+    deleteNet $port
+  }
   addModulePort - $port output
   attachTerm -noNewPort iphy $port $port
 }


### PR DESCRIPTION
Updates fullchip netlist-fixing script to not try to delete non-existent dragonphy output nets. I realized that the constraints fix in #669 only preserved the dragonphy input nets. Since there's no actual need to preserve nets on the dragonphy outputs, I decided to fix the error in fullchip error this way instead of preserving output nets from the beginning.