### PR TITLE
Reduce mem tile width and move AON left to fix LVS

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -42,7 +42,7 @@ def construct():
     'bc_corner'           : "ffg0p88v125c",
     'partial_write'       : False,
     # Utilization target
-    'core_density_target' : 0.70,
+    'core_density_target' : 0.74,
     # RTL Generation
     'interconnect_only'   : True,
     # Power Domains

--- a/mflowgen/common/power-domains/outputs/pd-mem-floorplan.tcl
+++ b/mflowgen/common/power-domains/outputs/pd-mem-floorplan.tcl
@@ -18,9 +18,9 @@ source inputs/dont-touch-constraints.tcl
    set polypitch_x [dbGet top.fPlan.coreSite.size_x] 
    
    set aon_height_snap [expr ceil($aon_height/$polypitch_y)*$polypitch_y]
-   set aon_lx [expr $width * 0.25 - $aon_width/2 + $offset - 0.18]
+   set aon_lx [expr $width * 0.15 - $aon_width/2 + $offset - 0.18]
    set aon_lx_snap [expr ceil($aon_lx/$polypitch_x)*$polypitch_x]
-   set aon_ux [expr $width * 0.25 + $aon_width/2 + $offset - 3]
+   set aon_ux [expr $width * 0.15 + $aon_width/2 + $offset - 3]
    set aon_ux_snap [expr ceil($aon_ux/$polypitch_x)*$polypitch_x]
    modifyPowerDomainAttr AON -box $aon_lx_snap  [expr $height - $aon_height_snap - 10*$polypitch_y] $aon_ux_snap [expr $height - 10*$polypitch_y]  -minGaps $polypitch_y $polypitch_y [expr $polypitch_x*6] [expr $polypitch_x*6]
 


### PR DESCRIPTION
Quick fix for mem tile LVS. The width change associated with the diet lake merge caused a power-domains related LVS failure. A more robust fix is coming soon, but this works for now.