### PR TITLE
PnR quality improvement

### DIFF
--- a/garnet.py
+++ b/garnet.py
@@ -17,6 +17,7 @@ from passes.collateral_pass.config_register import get_interconnect_regs, \
     get_core_registers
 import math
 import archipelago
+import archipelago.power
 
 # set the debug mode to false to speed up construction
 set_debug_mode(False)
@@ -242,6 +243,8 @@ class Garnet(Generator):
                                              cwd="temp",
                                              id_to_name=id_to_name,
                                              fixed_pos=fixed_io)
+        routing_fix = archipelago.power.reduce_switching(routing, self.interconnect)
+        routing.update(routing_fix)
         bitstream = []
         bitstream += self.interconnect.get_route_bitstream(routing)
         bitstream += self.get_placement_bitstream(placement, id_to_name,


### PR DESCRIPTION
Just realized that I had this written long time ago that's never been used in the actual garnet PnR. Enable this basically gives us two benefits:

1. Switching power is reduced significantly during runtime.
2. Possible combination loops are avoided during runtime.

The downside is it usually increase the routing part of bitstream by 20-30% (when the code was written). Given the condensed register feature just introduced, I expect this to be a little bit smaller.