### PR TITLE
fix fnb symlink bug

### DIFF
--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -342,7 +342,7 @@ echo ""
 #    % multivt -> ../../../mflowgen/adks/tsmc16/multivt/
 
 mflowgen_orig=$mflowgen
-ln -s $mflowgen_orig
+test -e mflowgen || ln -s $mflowgen_orig
 mflowgen=`pwd`/mflowgen
 
 


### PR DESCRIPTION
One-line fix for why the latest Friday Night Build broke. Prevents setup script from unnecessarily trying (and failing) to overwrite a perfectly good already-existing link to the mflowgen repo.