### PR TITLE
Remove redundant (unused?) setup.cfg entries

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,3 @@ max-line-length = 120
 # E741: do not use variables named ‘l’, ‘O’, or ‘I’
 # We ignore this because I and O is currently idiomatic magma for port names
 ignore = E741
-
-[tool:pytest]
-codestyle_max_line_length = 120
-codestyle_ignore = E741


### PR DESCRIPTION
On my system I'm getting warnings related to unknown config keys:
```
/Users/lenny/miniconda3/lib/python3.8/site-packages/_pytest/config/__init__.py:1148
  /Users/lenny/miniconda3/lib/python3.8/site-packages/_pytest/config/__init__.py:1148: PytestConfigWarning: Un
known config ini key: codestyle_ignore

    self._warn_or_fail_if_strict("Unknown config ini key: {}\n".format(key))

/Users/lenny/miniconda3/lib/python3.8/site-packages/_pytest/config/__init__.py:1148
  /Users/lenny/miniconda3/lib/python3.8/site-packages/_pytest/config/__init__.py:1148: PytestConfigWarning: Un
known config ini key: codestyle_max_line_length

    self._warn_or_fail_if_strict("Unknown config ini key: {}\n".format(key))
```

it seems these entries are redundant with the `[pycodestyle]` section, and it seems that those are the section being used by the linter.  Perhaps these are just left-over from an old tool we were using? (maybe when we switched from the `codestyle` and the `pycodestyle` package? don't remember which one was the newer version, but I do remember a switch)