### PR TITLE
update genlibdb constraints to work with unflattened netlist (for pwr…

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -357,6 +357,9 @@ def construct():
   # Core density target param
   init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
 
+  # Need to know whether or not hierarchy is flattened to select pipeline config
+  # regs during .lib generation
+  genlibdb.update_params( { 'flatten_effort': parameters['flatten_effort'] }, True )
 
   # Disable pwr aware flow
   #init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, allow_new=True )

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -376,6 +376,10 @@ def construct():
   init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
   # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
   # and 'additional-path-groups' after 'make_path_groups'
+  
+  # Need to know whether or not hierarchy is flattened to select pipeline config
+  # regs during .lib generation
+  genlibdb.update_params( { 'flatten_effort': parameters['flatten_effort'] }, True )
 
   order = init.get_param('order') # get the default script run order
   path_group_idx = order.index( 'make-path-groups.tcl' )

--- a/mflowgen/common/custom-genlibdb-constraints/genlibdb-constraints.tcl
+++ b/mflowgen/common/custom-genlibdb-constraints/genlibdb-constraints.tcl
@@ -24,7 +24,13 @@ set config_reg_name config_reg_0
 
 for {set bit $min_bit} {[expr $bit - $min_bit] < $num_bits} {incr bit} {
     # Name of config register in netlist
-    set config_regs [get_cells -hierarchical *${SB_name}*${config_reg_name}_Register*[$bit] -filter "is_sequential==True"]
+    if {$::env(flatten_effort) == 0} {
+      # When we don't flatten, the config reg is buried under multiple levels of hierarchy
+      set config_regs [get_cells ${SB_name}/${config_reg_name}/*/*/*[$bit] -filter "is_sequential==True"]
+    } else {
+      # When we flatten, we don't need slashes since there is no hierarchy
+      set config_regs [get_cells -hierarchical *${SB_name}*${config_reg_name}_Register*[$bit] -filter "is_sequential==True"]
+    }
     set config_reg_outs [get_pins -of_objects $config_regs -filter "direction==out"]
     # Set config reg values to 1 so that all pipeline regs are activated
     set_case_analysis 1 $config_reg_outs


### PR DESCRIPTION
The previous genlibdb constraints only worked with flattening on. This update fixes the constraints to properly identify the config registers that control the SB pipeline registers regardless of the flatten_effort setting.