### PR TITLE
Add param to include/not include sealring in fullchip

### DIFF
--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -41,6 +41,8 @@ def construct():
     'soc_only'          : False,
     # Include SoC core? (use 0 for false, 1 for true)
     'include_core'      : 1,
+    # Include sealring?
+    'include_sealring'  : False,
     # SRAM macros
     'num_words'         : 2048,
     'word_size'         : 64,
@@ -437,9 +439,11 @@ def construct():
   order.insert( 0, 'pre-route.tcl' )
   route.update_params( { 'order': order } )
 
-  # Add sealring at beginning of signoff, so it's in before we stream out GDS
+  # Signoff order additions
   order = signoff.get_param('order')
-  order.insert(0, 'add-sealring.tcl')
+  # Add sealring at beginning of signoff, so it's in before we stream out GDS
+  if parameters['include_sealring'] == True:
+      order.insert(0, 'add-sealring.tcl')
   # Add netlist-fixing script before we save new netlist
   index = order.index( 'generate-results.tcl' )
   order.insert( index, 'netlist-fixing.tcl' )


### PR DESCRIPTION
This PR adds a param to the full_chip flow that controls whether or not the seal ring is included. I'm setting it to False because @ctorng mentioned that TSMC will be taking care of the sealring for the upcoming tapeout, so we don't have to add it. I'll update the drc rule deck in the ADK accordingly.