### PR TITLE
Virtualization

### DIFF
--- a/cgra/util.py
+++ b/cgra/util.py
@@ -178,11 +178,11 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
 
     interconnect.finalize()
     if global_signal_wiring == GlobalSignalWiring.Meso:
-        apply_global_meso_wiring(interconnect, io_sides=io_sides)
+        apply_global_meso_wiring(interconnect)
     elif global_signal_wiring == GlobalSignalWiring.Fanout:
-        apply_global_fanout_wiring(interconnect, io_sides=io_sides)
+        apply_global_fanout_wiring(interconnect)
     elif global_signal_wiring == GlobalSignalWiring.ParallelMeso:
-        apply_global_meso_wiring(interconnect, io_sides=io_sides)
+        apply_global_meso_wiring(interconnect)
     if add_pd:
         add_aon_read_config_data(interconnect)
 

--- a/cgra/util.py
+++ b/cgra/util.py
@@ -81,7 +81,8 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
                     or x in range(x_max + 1, width) \
                     or y in range(y_min) \
                     or y in range(y_max + 1, height):
-                core = IOCore()
+                core = IOCore(config_addr_width=reg_addr_width,
+                              config_data_width=config_data_width)
             else:
                 use_mem_core = (x - x_min) % tile_max >= mem_tile_ratio
                 if use_mem_core:

--- a/garnet.py
+++ b/garnet.py
@@ -29,6 +29,7 @@ class Garnet(Generator):
     def __init__(self, width, height, add_pd, interconnect_only: bool = False,
                  use_sram_stub: bool = True, standalone: bool = False,
                  add_pond: bool = True,
+                 use_io_valid: bool = False,
                  pipeline_config_interval: int = 8):
         super().__init__()
 
@@ -106,6 +107,7 @@ class Garnet(Generator):
                                    num_tracks=num_tracks,
                                    add_pd=add_pd,
                                    add_pond=add_pond,
+                                   use_io_valid=use_io_valid,
                                    use_sram_stub=use_sram_stub,
                                    global_signal_wiring=wiring,
                                    pipeline_config_interval=pipeline_config_interval,
@@ -342,6 +344,7 @@ def main():
     parser.add_argument("--dump-config-reg", action="store_true")
     parser.add_argument("--virtualize-group-size", type=int, default=4)
     parser.add_argument("--virtualize", action="store_true")
+    parser.add_argument("--use-io-valid", action="store_true")
     args = parser.parse_args()
 
     if not args.interconnect_only:
@@ -353,6 +356,7 @@ def main():
                     add_pd=not args.no_pd,
                     pipeline_config_interval=args.pipeline_config_interval,
                     add_pond=not args.no_pond,
+                    use_io_valid=args.use_io_valid,
                     interconnect_only=args.interconnect_only,
                     use_sram_stub=not args.no_sram_stub,
                     standalone=args.standalone)

--- a/garnet.py
+++ b/garnet.py
@@ -276,10 +276,10 @@ class Garnet(Generator):
         partition_result = archipelago.pnr_virtualize(self.interconnect, (netlist, bus), cwd="temp",
                                                       id_to_name=id_to_name, max_group=max_group)
         result = {}
-        for c_id, (placement, routing) in partition_result.items():
+        for c_id, ((placement, routing), p_id_to_name) in partition_result.items():
             bitstream = []
             bitstream += self.interconnect.get_route_bitstream(routing)
-            bitstream += self.get_placement_bitstream(placement, id_to_name,
+            bitstream += self.get_placement_bitstream(placement, p_id_to_name,
                                                       instance_to_instr)
             skip_addr = self.interconnect.get_skip_addr()
             bitstream = compress_config_data(bitstream, skip_compression=skip_addr)

--- a/garnet.py
+++ b/garnet.py
@@ -256,7 +256,8 @@ class Garnet(Generator):
                                              id_to_name=id_to_name,
                                              fixed_pos=fixed_io,
                                              compact=compact)
-        routing_fix = archipelago.power.reduce_switching(routing, self.interconnect)
+        routing_fix = archipelago.power.reduce_switching(routing, self.interconnect,
+                                                         compact=compact)
         routing.update(routing_fix)
         bitstream = []
         bitstream += self.interconnect.get_route_bitstream(routing)

--- a/garnet.py
+++ b/garnet.py
@@ -243,7 +243,7 @@ class Garnet(Generator):
         return input_interface, output_interface,\
                (reset_port_name, valid_port_name, en_port_name)
 
-    def compile(self, halide_src, unconstrained_io=False):
+    def compile(self, halide_src, unconstrained_io=False, compact=False):
         id_to_name, instance_to_instr, netlist, bus = self.map(halide_src)
         if unconstrained_io:
             fixed_io = None
@@ -252,7 +252,8 @@ class Garnet(Generator):
         placement, routing = archipelago.pnr(self.interconnect, (netlist, bus),
                                              cwd="temp",
                                              id_to_name=id_to_name,
-                                             fixed_pos=fixed_io)
+                                             fixed_pos=fixed_io,
+                                             compact=compact)
         routing_fix = archipelago.power.reduce_switching(routing, self.interconnect)
         routing.update(routing_fix)
         bitstream = []
@@ -334,6 +335,7 @@ def main():
     parser.add_argument("--no-pd", "--no-power-domain", action="store_true")
     parser.add_argument("--no-pond", action="store_true")
     parser.add_argument("--interconnect-only", action="store_true")
+    parser.add_argument("--compact", action="store_true")
     parser.add_argument("--no-sram-stub", action="store_true")
     parser.add_argument("--standalone", action="store_true")
     parser.add_argument("--unconstrained-io", action="store_true")
@@ -366,7 +368,7 @@ def main():
             and len(args.output) > 0 and not args.virtualize:
         # do PnR and produce bitstream
         bitstream, (inputs, outputs, reset, valid, \
-            en, delay) = garnet.compile(args.app, args.unconstrained_io)
+            en, delay) = garnet.compile(args.app, args.unconstrained_io, compact=args.compact)
         # write out the config file
         if len(inputs) > 1:
             if reset in inputs:

--- a/global_buffer/io_placement.py
+++ b/global_buffer/io_placement.py
@@ -44,7 +44,6 @@ def place_io_blk(id_to_name):
 
     # place it on the interconnect
     # input and outputs are placed on the same IO tiles
-    # place it on the interconnect
     group_index = 0
     for idx, input_blk in enumerate(inputs):
         placement[input_blk] = (group_index * 2, 0)

--- a/io_core/io_core_magma.py
+++ b/io_core/io_core_magma.py
@@ -27,7 +27,7 @@ class ValidIOCore(Generator):
         self.valid = self.var("valid", 1)
         # only if the state is in counting and count is larger or equal to max_cycle
         self.wire(self.valid,
-                  (self.has_start == self.start_state.io_valid_count) & (self.count >= self.max_cycle))
+                  (self.has_start == self.start_state.io_valid_count) & (self.count < self.max_cycle))
         # normal output
         self.f2io_1 = self.input("f2io_1", 1)
         # mode
@@ -39,8 +39,7 @@ class ValidIOCore(Generator):
         # counter enable logic
         self.cen = self.var("cen", 1)
         self.wire(self.cen,
-                  self.stall & (self.has_start == self.start_state.io_valid_count) & (self.count <= self.max_cycle) & (
-                      ~self.stall))
+                  (self.has_start == self.start_state.io_valid_count) & (self.count < self.max_cycle) & (~self.stall))
 
         # add code blocks
         self.add_always(self.start_signal)
@@ -50,7 +49,7 @@ class ValidIOCore(Generator):
     def start_signal(self):
         if self.rst:
             self.has_start = self.start_state.io_valid_idle
-        else:
+        elif self.start:
             self.has_start = self.start_state.io_valid_count
 
     @always_ff((posedge, "clk"), (posedge, "reset"))

--- a/io_core/io_core_magma.py
+++ b/io_core/io_core_magma.py
@@ -1,10 +1,75 @@
 import magma
-from gemstone.common.core import Core, PnRTag
+from gemstone.common.core import ConfigurableCore, PnRTag, ConfigurationType
+from gemstone.generator import FromMagma
+from kratos import Generator, posedge, always_ff, mux
+from kratos.util import to_magma
 
 
-class IOCore(Core):
-    def __init__(self):
-        super().__init__()
+class ValidIOCore(Generator):
+    __cache = {}
+
+    def __init__(self, count_width):
+        super().__init__("ValidIO")
+        # the upper count as an IO from output config
+        self.max_cycle = self.input("max_cycle", count_width)
+        # start signal
+        self.start = self.input("start", 1)
+        # clks and reset
+        # CGRA uses posedge reset
+        self.clk = self.clock("clk")
+        self.rst = self.reset("reset")
+        self.stall = self.input("stall", 1)
+        self.start_state = self.enum("start_state", {"io_valid_idle": 0,
+                                                     "io_valid_count": 1})
+        self.has_start = self.var("has_start", self.start_state)
+        self.count = self.var("count", count_width)
+        # valid output
+        self.valid = self.var("valid", 1)
+        # only if the state is in counting and count is larger or equal to max_cycle
+        self.wire(self.valid,
+                  (self.has_start == self.start_state.io_valid_count) & (self.count >= self.max_cycle))
+        # normal output
+        self.f2io_1 = self.input("f2io_1", 1)
+        # mode
+        self.mode = self.input("mode", 1)
+        # output
+        self.out = self.output("out", 1)
+        self.wire(self.out, mux(self.mode == 1, self.valid, self.f2io_1))
+
+        # add code blocks
+        self.add_always(self.start_signal)
+        self.add_always(self.count_cycle)
+
+    @always_ff((posedge, "clk"), (posedge, "reset"))
+    def start_signal(self):
+        if self.rst:
+            self.has_start = self.start_state.io_valid_idle
+        else:
+            self.has_start = self.start_state.io_valid_count
+
+    @always_ff((posedge, "clk"), (posedge, "reset"))
+    def count_cycle(self):
+        if self.rst:
+            self.count = 0
+        elif (self.has_start == self.start_state.io_valid_count) & (self.count <= self.max_cycle) & (~self.stall):
+            self.count = self.count + 1
+
+    @staticmethod
+    def get_core(width):
+        if width in ValidIOCore.__cache:
+            return ValidIOCore.__cache[width]
+        else:
+            core = ValidIOCore(width)
+            circ = to_magma(core)
+            ValidIOCore.__cache[width] = circ
+            return circ
+
+
+class IOCore(ConfigurableCore):
+    def __init__(self, config_addr_width=8, config_data_width=32):
+        super().__init__(config_addr_width, config_data_width)
+
+        max_cycle_width = 22
 
         self.add_ports(
             glb2io_16=magma.In(magma.Bits[16]),
@@ -15,12 +80,28 @@ class IOCore(Core):
             f2io_1=magma.In(magma.Bits[1]),
             io2f_16=magma.Out(magma.Bits[16]),
             io2f_1=magma.Out(magma.Bits[1]),
+            stall=magma.In(magma.Bits[1])
         )
+
+        self.add_port("config", magma.In(ConfigurationType(self.config_addr_width, self.config_data_width)))
 
         self.wire(self.ports.glb2io_16, self.ports.io2f_16)
         self.wire(self.ports.glb2io_1, self.ports.io2f_1)
         self.wire(self.ports.f2io_16, self.ports.io2glb_16)
-        self.wire(self.ports.f2io_1, self.ports.io2glb_1)
+
+        self.core = FromMagma(ValidIOCore.get_core(22))
+        for p in {"clk", "reset", "stall"}:
+            self.wire(self.ports[p], self.core.ports[p])
+        self.add_config("max_cycle", max_cycle_width)
+        self.add_config("mode", 1)
+
+        self.wire(self.registers["max_cycle"].ports.O, self.core.ports.max_cycle)
+        self.wire(self.registers["mode"].ports.O, self.core.ports.mode)
+        self.wire(self.ports.f2io_1, self.core.ports.f2io_1)
+        self.wire(self.ports.io2glb_1, self.core.ports.out)
+        self.wire(self.ports.glb2io_1, self.core.ports.start)
+
+        self._setup_config()
 
     def inputs(self):
         return [self.ports.glb2io_16, self.ports.glb2io_1,
@@ -35,4 +116,15 @@ class IOCore(Core):
 
     def pnr_info(self):
         return [PnRTag("I", 2, self.DEFAULT_PRIORITY),
-		PnRTag("i", 1, self.DEFAULT_PRIORITY)]
+                PnRTag("i", 1, self.DEFAULT_PRIORITY)]
+
+    def get_config_bitstream(self, instr):
+        return []  # pragma: nocover
+
+    def instruction_type(self):
+        raise NotImplementedError()  # pragma: nocover
+
+
+if __name__ == "__main__":
+    core = IOCore(8, 32)
+    magma.compile("io", core.circuit())

--- a/io_core/io_core_magma.py
+++ b/io_core/io_core_magma.py
@@ -36,6 +36,12 @@ class ValidIOCore(Generator):
         self.out = self.output("out", 1)
         self.wire(self.out, mux(self.mode == 1, self.valid, self.f2io_1))
 
+        # counter enable logic
+        self.cen = self.var("cen", 1)
+        self.wire(self.cen,
+                  self.stall & (self.has_start == self.start_state.io_valid_count) & (self.count <= self.max_cycle) & (
+                      ~self.stall))
+
         # add code blocks
         self.add_always(self.start_signal)
         self.add_always(self.count_cycle)
@@ -51,7 +57,7 @@ class ValidIOCore(Generator):
     def count_cycle(self):
         if self.rst:
             self.count = 0
-        elif (self.has_start == self.start_state.io_valid_count) & (self.count <= self.max_cycle) & (~self.stall):
+        elif self.cen:
             self.count = self.count + 1
 
     @staticmethod

--- a/passes/clk_pass/clk_pass.py
+++ b/passes/clk_pass/clk_pass.py
@@ -45,7 +45,7 @@ def clk_physical(interconnect: Interconnect):
         tile = interconnect.tile_circuits[(x, y)]
         tile_core = tile.core
         # We only want to do this on PE and memory tiles
-        if isinstance(tile_core, IOCore) or tile_core is None:
+        if tile_core is None or "clk" not in tile_core.ports:
             continue
         elif isinstance(tile_core, MemCore):
             if (x, y+1) in interconnect.tile_circuits:

--- a/passes/clk_pass/clk_pass.py
+++ b/passes/clk_pass/clk_pass.py
@@ -1,4 +1,4 @@
-from io_core.io_core_magma import IOCore
+from io_core.io_core_magma import IOCoreBase
 from memory_core.memory_core_magma import MemCore
 from canal.interconnect import Interconnect
 import magma
@@ -45,7 +45,7 @@ def clk_physical(interconnect: Interconnect):
         tile = interconnect.tile_circuits[(x, y)]
         tile_core = tile.core
         # We only want to do this on PE and memory tiles
-        if tile_core is None or "clk" not in tile_core.ports:
+        if tile_core is None or isinstance(tile_core, IOCoreBase):
             continue
         elif isinstance(tile_core, MemCore):
             if (x, y+1) in interconnect.tile_circuits:

--- a/passes/pipeline_config_pass/pipeline_config_pass.py
+++ b/passes/pipeline_config_pass/pipeline_config_pass.py
@@ -1,4 +1,4 @@
-from io_core.io_core_magma import IOCore
+from io_core.io_core_magma import IOCoreValid
 from canal.interconnect import Interconnect
 import magma
 from mantle import FF
@@ -56,7 +56,7 @@ def pipeline_config_signals(interconnect: Interconnect, interval):
         tile = interconnect.tile_circuits[(x, y)]
         tile_core = tile.core
         # We only want to do this on PE and memory tiles
-        if isinstance(tile_core, IOCore) or tile_core is None:
+        if tile_core is None or "config" not in tile_core.ports:
             continue
         else:
             if interval != 0 and y % interval == 0 and ((x, y+1) in interconnect.tile_circuits):

--- a/passes/pipeline_config_pass/pipeline_config_pass.py
+++ b/passes/pipeline_config_pass/pipeline_config_pass.py
@@ -55,7 +55,7 @@ def pipeline_config_signals(interconnect: Interconnect, interval):
         tile = interconnect.tile_circuits[(x, y)]
         tile_core = tile.core
         # We only want to do this on PE and memory tiles
-        if tile_core is None or "config" not in tile_core.ports:
+        if tile_core is None or "config" not in tile_core.ports or y == 0:
             continue
         else:
             if interval != 0 and y % interval == 0 and ((x, y+1) in interconnect.tile_circuits):

--- a/passes/pipeline_config_pass/pipeline_config_pass.py
+++ b/passes/pipeline_config_pass/pipeline_config_pass.py
@@ -1,4 +1,3 @@
-from io_core.io_core_magma import IOCoreValid
 from canal.interconnect import Interconnect
 import magma
 from mantle import FF

--- a/passes/power_domain/pd_pass.py
+++ b/passes/power_domain/pd_pass.py
@@ -1,6 +1,6 @@
 from gemstone.common.mux_wrapper_aoi import AOIMuxWrapper, AOIMuxType
 from gemstone.common.transform import replace, Generator, FromMagma
-from io_core.io_core_magma import IOCore
+from io_core.io_core_magma import IOCoreValid
 from canal.interconnect import Interconnect
 from gemstone.common.configurable import Configurable, ConfigurationType
 from canal.circuit import flatten_mux

--- a/passes/power_domain/pd_pass.py
+++ b/passes/power_domain/pd_pass.py
@@ -36,7 +36,7 @@ def add_power_domain(interconnect: Interconnect):
     for (x, y) in interconnect.tile_circuits:
         tile = interconnect.tile_circuits[(x, y)]
         tile_core = tile.core
-        if isinstance(tile_core, IOCore) or tile_core is None:
+        if tile_core is None or "config" not in tile_core.ports:
             continue
         # Add PS config register
         pd_feature = PowerDomainConfigReg(tile.config_addr_width,

--- a/passes/tile_id_pass/tile_id_pass.py
+++ b/passes/tile_id_pass/tile_id_pass.py
@@ -1,4 +1,4 @@
-from io_core.io_core_magma import IOCore
+from io_core.io_core_magma import IOCoreValid
 from canal.interconnect import Interconnect
 import magma
 from gemstone.generator.const import Const
@@ -21,7 +21,7 @@ def tile_id_physical(interconnect: Interconnect):
     for (x, y) in interconnect.tile_circuits:
         tile = interconnect.tile_circuits[(x, y)]
         tile_core = tile.core
-        if isinstance(tile_core, IOCore) or tile_core is None:
+        if isinstance(tile_core, IOCoreValid) or tile_core is None:
             continue
         tile.add_ports(
             hi=magma.Out(magma.Bits[tie_hi_width]),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coreir>=2.0.123  # should be first so we get the latest version
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git@virtualization#egg=canal
+-e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coreir>=2.0.123  # should be first so we get the latest version
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git@virtualization#egg=canal
+-e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper
@@ -14,6 +14,6 @@ ordered_set
 cosa
 -e git://github.com/leonardt/fault.git#egg=fault
 hwtypes
--e git+git://github.com/Kuree/archipelago.git@virtualization#egg=archipelago
+-e git+git://github.com/Kuree/archipelago.git#egg=archipelago
 peakrdl-html
 ralbot-html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coreir>=2.0.123  # should be first so we get the latest version
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git#egg=canal
+-e git://github.com/StanfordAHA/canal.git@virtualization#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper
@@ -14,6 +14,6 @@ ordered_set
 cosa
 -e git://github.com/leonardt/fault.git#egg=fault
 hwtypes
-archipelago
+-e git+git://github.com/Kuree/archipelago.git@virtualization#egg=archipelago
 peakrdl-html
 ralbot-html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coreir>=2.0.123  # should be first so we get the latest version
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git#egg=canal
+-e git://github.com/StanfordAHA/canal.git@virtualization#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper

--- a/tests/test_io_core/test_io_core_magma.py
+++ b/tests/test_io_core/test_io_core_magma.py
@@ -1,13 +1,13 @@
 import tempfile
 from gemstone.common.testers import BasicTester
 from gemstone.common.util import compress_config_data
-from io_core.io_core_magma import IOCore
+from io_core.io_core_magma import IOCoreValid
 from fault.tester import Tester
 from fault.random import random_bv
 
 
 def test_regression():
-    io_core = IOCore()
+    io_core = IOCoreValid()
     io_core_circuit = io_core.circuit()
     tester = Tester(io_core_circuit)
 
@@ -35,7 +35,7 @@ def test_regression():
 
 
 def test_valid_generation():
-    io_core = IOCore()
+    io_core = IOCoreValid()
     io_core_circuit = io_core.circuit()
     tester = BasicTester(io_core_circuit, io_core_circuit.clk, io_core_circuit.reset)
 

--- a/tests/test_io_core/test_io_core_magma.py
+++ b/tests/test_io_core/test_io_core_magma.py
@@ -1,5 +1,6 @@
 import tempfile
-from hwtypes import BitVector
+from gemstone.common.testers import BasicTester
+from gemstone.common.util import compress_config_data
 from io_core.io_core_magma import IOCore
 from fault.tester import Tester
 from fault.random import random_bv
@@ -25,6 +26,63 @@ def test_regression():
         tester.eval()
         tester.expect(io_core_circuit.io2glb_1, _f2io_1)
         tester.expect(io_core_circuit.io2f_1, _glb2io_1)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        tester.compile_and_run(target="verilator",
+                               magma_output="coreir-verilog",
+                               directory=tempdir,
+                               flags=["-Wno-fatal"])
+
+
+def test_valid_generation():
+    io_core = IOCore()
+    io_core_circuit = io_core.circuit()
+    tester = BasicTester(io_core_circuit, io_core_circuit.clk, io_core_circuit.reset)
+
+    max_cycle = 16
+
+    # mode set to 1
+    # max cycle set to 16
+    config_data = [io_core.get_config_data("mode", 1), io_core.get_config_data("max_cycle", max_cycle)]
+    config_data = compress_config_data(config_data)
+
+    tester.zero_inputs()
+    tester.poke(io_core_circuit.stall, 1)
+
+    for addr, data in config_data:
+        tester.configure(addr, data)
+        tester.config_read(addr)
+        tester.eval()
+        tester.expect(io_core_circuit.read_config_data, data)
+
+    # un-stall
+    tester.poke(io_core_circuit.stall, 0)
+
+    # it should stay low regardless of the IO as long as the reset signal is never high
+    for _f2io_16 in [random_bv(16) for _ in range(10)]:
+        tester.poke(io_core_circuit.f2io_16, _f2io_16)
+        tester.eval()
+        tester.expect(io_core_circuit.io2glb_16, _f2io_16)
+        tester.expect(io_core_circuit.io2glb_1, 0)
+
+    # hit the start  signal
+    tester.poke(io_core_circuit.glb2io_1, 1)
+    tester.eval()
+    # rising clock edge
+    tester.step(2)
+    # de-assert the reset/start signal
+    tester.poke(io_core_circuit.glb2io_1, 0)
+    tester.eval()
+
+    # from now on it should output 1 until it reaches max cycle
+    for _ in range(max_cycle):
+        tester.expect(io_core_circuit.io2glb_1, 1)
+        tester.step(2)
+
+    # then stay low
+    for _ in range(max_cycle):
+        tester.expect(io_core_circuit.io2glb_1, 0)
+        tester.step(2)
 
     with tempfile.TemporaryDirectory() as tempdir:
         tester.compile_and_run(target="verilator",


### PR DESCRIPTION
## Changes to software stack:
Most changes are already done in the upstream (i.e. canal and PnR toolchain)
1. Adjust function calls based on upstream API changes
2. Add ability to PnR virtualized apps
    - Input application netlist is cut to fit inside predefined column group size (offset at origin (0, 0))
    - Multiple bitstream will be generated accordingly
    - `--virtualize` and `--virtualize-group-size`
3. Add ability to PnR apps in a compact fashion:
    - Use updated upstream PnR API to minimize column usage
    - Useful to fit multiple apps in the same fabric simultaneously
    - `--compact`

## Changes to RTL:
Major RTL change so far is regarding the IO tiles.
1. Introduce a new IO Core that has configurable logic. PnR tools can configure the IO core to generate valid for certain cycles
   - This is turned off by default when generating hardware, but turned on during AHA flow regression
   - Even when turned on, without configuration it will behaves like the old IO core, i.e. pass through
   - Unit tests are added to test the functionality thoroughly
   - `--use-io-valid`
2. (merged) more condensed/compressed configuration register space.

## Potential future changes:
- I'm not sure about the status of parallel configuration. @kongty please confirm this. If it hasn't been implemented/tested, please file a separate PR to merged into this PR.
- A 1-bit cross-bar like interface is need between GLB and IO cores since the start signal currently are not wired to the output IO cores. @kongty will handle that.

## PD Concerns and Discussion:
1. I bypass the clk passthrough pass for the new IO cores. I don't know the PD situation well enough to modify the pass. @alexcarsello please let me know if you have any concerns since you wrote that pass.
2. I'm not sure if we need a separate tile flow for the IO tiles.

Mark suggested to file a PR with the new IO core. The new IO core control logic is essential to run virtualized application since it's one of the optimal way to produce valid bit to GLB. However, depends on the PD schedule we may not put it in Amber chip. 

## Integration test here:
https://github.com/StanfordAHA/aha/pull/928