### PR TITLE
add 1x1 cgra test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coreir>=2.0.123  # should be first so we get the latest version
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git#egg=canal
+-e git://github.com/StanfordAHA/canal.git@1x1#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coreir>=2.0.123  # should be first so we get the latest version
 -e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git@1x1#egg=canal
+-e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git://github.com/rdaly525/MetaMapper.git#egg=metamapper

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -10,7 +10,7 @@ from archipelago import pnr
 import pytest
 import random
 from cgra import create_cgra, compress_config_data
-from memory_core.memory_mode import Mode
+import magma
 from memory_core.memory_core_magma import config_mem_tile
 from collections import deque
 
@@ -38,8 +38,7 @@ def test_1x1():
     circuit = interconnect.circuit()
     with tempfile.TemporaryDirectory() as temp:
         filename = os.path.join(temp, "1x1")
-        import magma
-        magma.compile(filename, circuit, output="coreir-verilog")
+        magma.compile(filename, circuit)
         assert os.path.isfile(filename + ".v")
 
 

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -32,6 +32,17 @@ def dw_files():
     return result_filenames
 
 
+def test_1x1():
+    # this is all PE
+    interconnect = create_cgra(1, 1, IOSide.None_, num_tracks=3, mem_ratio=(0, 1))
+    circuit = interconnect.circuit()
+    with tempfile.TemporaryDirectory() as temp:
+        filename = os.path.join(temp, "1x1")
+        import magma
+        magma.compile(filename, circuit, output="coreir-verilog")
+        assert os.path.isfile(filename + ".v")
+
+
 @pytest.mark.parametrize("batch_size", [100])
 def test_interconnect_point_wise(batch_size: int, dw_files, io_sides):
     # we test a simple point-wise multiplier function


### PR DESCRIPTION
This PR adds a test on minimal 1x1 CGRA. You can control which core to use by adjusting the `mem_ratio`. Notice that `IOSide` has to be set to `None_` to avoid creating IO tiles.

Depends on https://github.com/StanfordAHA/canal/pull/34