### PR TITLE
Pegasus steps

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
 
@@ -97,10 +98,12 @@ def construct():
   signoff        = Step( 'cadence-innovus-signoff',        default=True )
   pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
   genlibdb       = Step( 'cadence-genus-genlib',           default=True )
-  drc            = Step( 'mentor-calibre-drc',             default=True )
-  # Define pegasus as alternative DRC path for now - enables local DRC testing in calibre
-  alt_drc        = Step( 'cadence-pegasus-drc',            default=True )
-  lvs            = Step( 'mentor-calibre-lvs',             default=True )
+  if which("calibre") is not None:
+      drc            = Step( 'mentor-calibre-drc',             default=True )
+      lvs            = Step( 'mentor-calibre-lvs',             default=True )
+  else:
+      drc            = Step( 'cadence-pegasus-drc',            default=True )
+      lvs            = Step( 'cadence-pegasus-lvs',            default=True )
   debugcalibre   = Step( 'cadence-innovus-debug-calibre',  default=True )
 
 
@@ -194,7 +197,6 @@ def construct():
   g.add_step( genlibdb_constraints )
   g.add_step( genlibdb             )
   g.add_step( drc                  )
-  g.add_step( alt_drc              )
   g.add_step( lvs                  )
   g.add_step( custom_lvs           )
   g.add_step( debugcalibre         )
@@ -229,7 +231,6 @@ def construct():
   g.connect_by_name( adk,      postroute_hold )
   g.connect_by_name( adk,      signoff        )
   g.connect_by_name( adk,      drc            )
-  g.connect_by_name( adk,      alt_drc        )
   g.connect_by_name( adk,      lvs            )
 
   g.connect_by_name( gen_sram,      synth          )
@@ -282,10 +283,8 @@ def construct():
   g.connect_by_name( postroute,      postroute_hold )
   g.connect_by_name( postroute_hold, signoff        )
   g.connect_by_name( signoff,        drc            )
-  g.connect_by_name( signoff,        alt_drc        )
   g.connect_by_name( signoff,        lvs            )
   g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
-  g.connect(signoff.o('design-merged.gds'), alt_drc.i('design_merged.gds'))
   g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
   g.connect_by_name( signoff,              genlibdb )

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
 
@@ -124,10 +125,12 @@ def construct():
   signoff      = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
   genlibdb     = Step( 'cadence-genus-genlib',          default=True )
-  drc          = Step( 'mentor-calibre-drc',            default=True )
-  # Define pegasus as alternative DRC path for now - enables local DRC testing in calibre
-  alt_drc      = Step( 'cadence-pegasus-drc',           default=True )
-  lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  if which("calibre") is not None:
+      drc          = Step( 'mentor-calibre-drc',            default=True )
+      lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  else:
+      drc          = Step( 'cadence-pegasus-drc',           default=True )
+      lvs          = Step( 'cadence-pegasus-lvs',           default=True )
   debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
 
   # Add custom timing scripts
@@ -201,7 +204,6 @@ def construct():
   g.add_step( genlibdb_constraints     )
   g.add_step( genlibdb                 )
   g.add_step( drc                      )
-  g.add_step( alt_drc                  )
   g.add_step( lvs                      )
   g.add_step( debugcalibre             )
 
@@ -239,7 +241,6 @@ def construct():
   g.connect_by_name( adk,      postroute    )
   g.connect_by_name( adk,      signoff      )
   g.connect_by_name( adk,      drc          )
-  g.connect_by_name( adk,      alt_drc      )
   g.connect_by_name( adk,      lvs          )
   g.connect_by_name( adk,      pt_power_gl  )
 
@@ -292,10 +293,8 @@ def construct():
   g.connect_by_name( route,        postroute    )
   g.connect_by_name( postroute,    signoff      )
   g.connect_by_name( signoff,      drc          )
-  g.connect_by_name( signoff,      alt_drc      )
   g.connect_by_name( signoff,      lvs          )
   g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
-  g.connect(signoff.o('design-merged.gds'), alt_drc.i('design_merged.gds'))
   g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
   g.connect_by_name( signoff,              genlibdb )

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
 
@@ -122,8 +123,12 @@ def construct():
   signoff        = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff     = Step( 'synopsys-pt-timing-signoff',    default=True )
   merge_rdl      = Step( 'mentor-calibre-gdsmerge-child', default=True )
-  drc            = Step( 'mentor-calibre-drc',            default=True )
-  lvs            = Step( 'mentor-calibre-lvs',            default=True )
+  if which("calibre") is not None:
+      drc            = Step( 'mentor-calibre-drc',            default=True )
+      lvs            = Step( 'mentor-calibre-lvs',            default=True )
+  else:
+      drc            = Step( 'cadence-pegasus-drc',           default=True )
+      lvs            = Step( 'cadence-pegasus-lvs',           default=True )
   debugcalibre   = Step( 'cadence-innovus-debug-calibre', default=True )
   fill           = Step( 'mentor-calibre-fill',           default=True )
   merge_fill     = Step( 'mentor-calibre-gdsmerge-child', default=True )

--- a/mflowgen/glb_tile/construct.py
+++ b/mflowgen/glb_tile/construct.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
 
@@ -83,8 +84,12 @@ def construct():
   signoff           = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff        = Step( 'synopsys-pt-timing-signoff',    default=True )
   genlib            = Step( 'cadence-genus-genlib',          default=True )
-  drc               = Step( 'mentor-calibre-drc',            default=True )
-  lvs               = Step( 'mentor-calibre-lvs',            default=True )
+  if which("calibre") is not None:
+      drc               = Step( 'mentor-calibre-drc',            default=True )
+      lvs               = Step( 'mentor-calibre-lvs',            default=True )
+  else:
+      drc               = Step( 'cadence-pegasus-drc',           default=True )
+      lvs               = Step( 'cadence-pegasus-lvs',           default=True )
   debugcalibre      = Step( 'cadence-innovus-debug-calibre', default=True )
 
   # Add (dummy) parameters to the default innovus init step

--- a/mflowgen/glb_top/construct.py
+++ b/mflowgen/glb_top/construct.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
 
@@ -74,8 +75,12 @@ def construct():
   signoff        = Step( 'cadence-innovus-signoff',         default=True )
   pt_signoff     = Step( 'synopsys-pt-timing-signoff',      default=True )
   genlib         = Step( 'cadence-genus-genlib',            default=True )
-  drc            = Step( 'mentor-calibre-drc',              default=True )
-  lvs            = Step( 'mentor-calibre-lvs',              default=True )
+  if which("calibre") is not None:
+      drc            = Step( 'mentor-calibre-drc',            default=True )
+      lvs            = Step( 'mentor-calibre-lvs',            default=True )
+  else:
+      drc            = Step( 'cadence-pegasus-drc',           default=True )
+      lvs            = Step( 'cadence-pegasus-lvs',           default=True )
   debugcalibre   = Step( 'cadence-innovus-debug-calibre',   default=True )
 
   # Add (dummy) parameters to the default innovus init step

--- a/mflowgen/global_controller/construct.py
+++ b/mflowgen/global_controller/construct.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
 
@@ -76,8 +77,12 @@ def construct():
   signoff      = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
   genlib       = Step( 'cadence-genus-genlib',        default=True )
-  drc          = Step( 'mentor-calibre-drc',            default=True )
-  lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  if which("calibre") is not None:
+      drc          = Step( 'mentor-calibre-drc',            default=True )
+      lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  else:
+      drc          = Step( 'cadence-pegasus-drc',           default=True )
+      lvs          = Step( 'cadence-pegasus-lvs',           default=True )
   debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
 
   # Add extra input edges to innovus steps that need custom tweaks

--- a/mflowgen/icovl/construct.py
+++ b/mflowgen/icovl/construct.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
   g = Graph()
@@ -73,7 +74,10 @@ def construct():
 #   pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
 #   genlibdb     = Step( 'synopsys-ptpx-genlibdb',        default=True )
   gdsmerge     = Step( 'mentor-calibre-gdsmerge',       default=True )
-  drc          = Step( 'mentor-calibre-drc',            default=True )
+  if which("calibre") is not None:
+      drc          = Step( 'mentor-calibre-drc',            default=True )
+  else:
+      drc          = Step( 'cadence-pegasus-drc',           default=True )
 #   lvs          = Step( 'mentor-calibre-lvs',            default=True )
 #   debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
 

--- a/mflowgen/pad_frame/construct.py
+++ b/mflowgen/pad_frame/construct.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
   g = Graph()
@@ -82,9 +83,13 @@ def construct():
   signoff      = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
   genlibdb     = Step( 'synopsys-ptpx-genlibdb',        default=True )
-  drc          = Step( 'mentor-calibre-drc',            default=True )
   init_fill    = Step( 'mentor-calibre-fill',           default=True )
-  lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  if which("calibre") is not None:
+      drc          = Step( 'mentor-calibre-drc',            default=True )
+      lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  else:
+      drc          = Step( 'cadence-pegasus-drc',           default=True )
+      lvs          = Step( 'cadence-pegasus-lvs',           default=True )
   debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
 
   # Die if unconnected bumps (why was this deleted?)

--- a/mflowgen/soc/construct.py
+++ b/mflowgen/soc/construct.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
 
@@ -86,8 +87,12 @@ def construct():
   postroute    = Step( 'cadence-innovus-postroute',     default=True )
   signoff      = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
-  drc          = Step( 'mentor-calibre-drc',            default=True )
-  lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  if which("calibre") is not None:
+      drc          = Step( 'mentor-calibre-drc',            default=True )
+      lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  else:
+      drc          = Step( 'cadence-pegasus-drc',           default=True )
+      lvs          = Step( 'cadence-pegasus-lvs',           default=True )
   debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
 
   # Add cgra tile macro inputs to downstream nodes

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from mflowgen.components import Graph, Step
+from shutil import which
 
 def construct():
 
@@ -89,8 +90,12 @@ def construct():
   #pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
   #genlibdb     = Step( 'synopsys-ptpx-genlibdb',        default=True )
   genlib       = Step( 'cadence-genus-genlib',        default=True )
-  drc          = Step( 'mentor-calibre-drc',            default=True )
-  lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  if which("calibre") is not None:
+      drc          = Step( 'mentor-calibre-drc',            default=True )
+      lvs          = Step( 'mentor-calibre-lvs',            default=True )
+  else:
+      drc          = Step( 'cadence-pegasus-drc',           default=True )
+      lvs          = Step( 'cadence-pegasus-lvs',           default=True )
   debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
   vcs_sim      = Step( 'synopsys-vcs-sim',              default=True )
 


### PR DESCRIPTION
Adds Pegasus DRC/LVS nodes to all graphs in a way that allows everything to work on both our machines and VDE without any manual edits.

Basically if Calibre is available, it will use Calibre. Otherwise it will use Pegasus.