### PR TITLE
Loopbreak fix

### DIFF
--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -157,3 +157,7 @@ if $::env(PWR_AWARE) {
 set_false_path -to [get_ports hi]
 set_false_path -to [get_ports lo]
 
+# Preserve the RMUXes so that we can easily constrain them later
+set rmux_cells [get_cells -hier RMUX_T*sel_inst0]
+set_dont_touch $rmux_cells true
+set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true

--- a/mflowgen/Tile_PE/constraints/common.tcl
+++ b/mflowgen/Tile_PE/constraints/common.tcl
@@ -177,3 +177,8 @@ set_false_path -from [get_ports tile_id]
 #set_tlu_plus_files -max_tluplus  $tluplus_max \
 #                   -min_tluplus  $tluplus_min \
 #                   -tech2itf_map $tluplus_map
+
+# Preserve the RMUXes so that we can easily constrain them later
+set rmux_cells [get_cells -hier RMUX_T*sel_inst0]
+set_dont_touch $rmux_cells true
+set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true

--- a/mflowgen/common/custom-genlibdb-constraints/genlibdb-constraints.tcl
+++ b/mflowgen/common/custom-genlibdb-constraints/genlibdb-constraints.tcl
@@ -10,23 +10,10 @@
 # Authors: Alex Carsello, Teguh Hofstee
 # Date: 1/24/2020
 
-# How many tracks per side?
-set num_tracks 5
-set num_sides 4
-# Which is the first bit which controls pipeline registers
-set min_bit 0
-# One control bit ber routing track
-set num_bits [expr $num_tracks * $num_sides]
-# Name of SB where the config regs we're targeting reside
-set SB_name SB_ID0_${num_tracks}TRACKS_B*
-# name of config reg within SB
-set config_reg_name config_reg_0
-
-for {set bit $min_bit} {[expr $bit - $min_bit] < $num_bits} {incr bit} {
-    # Name of config register in netlist
-    set config_regs [get_cells -hierarchical *${SB_name}*${config_reg_name}_Register*[$bit] -filter "is_sequential==True"]
-    set config_reg_outs [get_pins -of_objects $config_regs -filter "direction==out"]
-    # Set config reg values to 1 so that all pipeline regs are activated
-    set_case_analysis 1 $config_reg_outs
-}
+# These RMUX instances have been marked dont_touch
+# in the synthesis constraints so we can more easily
+# do set_case_analysis on them here
+set rmuxes [get_cells -hier *RMUX_*_sel_inst0]
+set rmux_outputs [get_pins -of_objects $rmuxes -filter "direction==out"]
+set_case_analysis 1 $rmux_outputs
 


### PR DESCRIPTION
The genlibdb constraints broke on the PE again, so this PR introduces a new, more robust way of breaking the combinational loops in the tile array. Rather than assuming that the first 20 bits of config_reg_0 in the SB's control the pipeline registers, this approach preserves the RMUX_sel insts (which select the bits of the config register that control the pipeline registers, and uses `set_case_analysis` on those preserved RMUX insts to ensure that the pipeline registers are on.