### PR TITLE
Pd tie cells

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -161,7 +161,7 @@ def construct():
   if pwr_aware:
       synth.extend_inputs(['designer-interface.tcl', 'upf_Tile_MemCore.tcl', 'mem-constraints.tcl', 'mem-constraints-2.tcl', 'dc-dont-use-constraints.tcl'])
       init.extend_inputs(['check-clamp-logic-structure.tcl', 'upf_Tile_MemCore.tcl', 'mem-load-upf.tcl', 'dont-touch-constraints.tcl', 'pd-mem-floorplan.tcl', 'mem-add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'mem-power-switches-setup.tcl', 'add-power-switches.tcl'])
-      place.extend_inputs(['check-clamp-logic-structure.tcl', 'place-dont-use-constraints.tcl'])
+      place.extend_inputs(['check-clamp-logic-structure.tcl', 'place-dont-use-constraints.tcl', 'add-aon-tie-cells.tcl'])
       power.extend_inputs(['pd-globalnetconnect.tcl'] )
       cts.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'])
       postcts_hold.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
@@ -402,7 +402,7 @@ def construct():
       order.append('check-clamp-logic-structure.tcl')
       init.update_params( { 'order': order } )
 
-   # power node
+      # power node
       order = power.get_param('order')
       order.insert( 0, 'pd-globalnetconnect.tcl' ) # add here
       order.remove('globalnetconnect.tcl')
@@ -411,6 +411,7 @@ def construct():
       # place node
       order = place.get_param('order')
       read_idx = order.index( 'main.tcl' ) # find main.tcl
+      order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
       order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
       order.append('check-clamp-logic-structure.tcl')
       place.update_params( { 'order': order } )

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -165,8 +165,8 @@ def construct():
   if pwr_aware:
       synth.extend_inputs(['designer-interface.tcl', 'upf_Tile_PE.tcl', 'pe-constraints.tcl', 'pe-constraints-2.tcl', 'dc-dont-use-constraints.tcl'])
       init.extend_inputs(['upf_Tile_PE.tcl', 'pe-load-upf.tcl', 'dont-touch-constraints.tcl', 'pd-pe-floorplan.tcl', 'pe-add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'pe-power-switches-setup.tcl', 'add-power-switches.tcl', 'check-clamp-logic-structure.tcl'])
-      place.extend_inputs(['place-dont-use-constraints.tcl', 'check-clamp-logic-structure.tcl'])
       power.extend_inputs(['pd-globalnetconnect.tcl'] )
+      place.extend_inputs(['place-dont-use-constraints.tcl', 'check-clamp-logic-structure.tcl', 'add-aon-tie-cells.tcl'])
       cts.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
       postcts_hold.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
       route.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
@@ -419,6 +419,7 @@ def construct():
       # place node
       order = place.get_param('order')
       read_idx = order.index( 'main.tcl' ) # find main.tcl
+      order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
       order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
       order.append('check-clamp-logic-structure.tcl')
       place.update_params( { 'order': order } )

--- a/mflowgen/common/power-domains/configure.yml
+++ b/mflowgen/common/power-domains/configure.yml
@@ -33,6 +33,5 @@ outputs:
   - check-clamp-logic-structure.tcl
   - upf_Tile_MemCore.tcl
   - upf_Tile_PE.tcl
-
-
+  - add-aon-tie-cells.tcl
  

--- a/mflowgen/common/power-domains/outputs/add-aon-tie-cells.tcl
+++ b/mflowgen/common/power-domains/outputs/add-aon-tie-cells.tcl
@@ -1,0 +1,11 @@
+setVar spgAddTieForNonDefPDFTerms 1
+setTieHiLoMode -cell $ADK_TIE_CELLS
+foreach cell $ADK_TIE_CELLS {
+   setDontUse $cell false
+}
+addTieHiLo -powerDomain AON -matchingPDs true
+
+foreach cell $ADK_TIE_CELLS {
+   setDontUse $cell true
+}
+


### PR DESCRIPTION
Adds a separate set of commands to add tie cells to the AON domain of the pe and mem tiles when power domains are turned on. We didn't need these before because DC added the tie cells in synthesis. Genus won't do it in the same way, so we'll add them in Innovus instead.

If we don't add the tie cells to the AON domain, the hi/lo outputs of each tile are connected directly to VDD and VSS, which causes an antenna DRC violation.