### PR TITLE
Update output getters to work with either pegasus or calibre lvs

### DIFF
--- a/mflowgen/full_chip/glb_top/get_glb_top_outputs.sh
+++ b/mflowgen/full_chip/glb_top/get_glb_top_outputs.sh
@@ -8,6 +8,6 @@ cp -L *cadence-innovus-signoff/outputs/design.lef outputs/glb_top.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/glb_top.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/glb_top.sdf
 cp -L *cadence-innovus-signoff/outputs/design-merged.gds outputs/glb_top.gds
-cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/glb_top.lvs.v
+cp -L *-lvs/outputs/design_merged.lvs.v outputs/glb_top.lvs.v
 cp -L *glb_tile/outputs/sram.spi outputs/glb_top.sram.spi
 

--- a/mflowgen/full_chip/glb_top/get_glb_top_outputs.sh
+++ b/mflowgen/full_chip/glb_top/get_glb_top_outputs.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 mflowgen run --design $GARNET_HOME/mflowgen/glb_top/
 make cadence-genus-genlib
-make mentor-calibre-lvs
+if command -v calibre &> /dev/null
+then
+    make mentor-calibre-lvs
+else
+    make cadence-pegasus-lvs
+fi
 mkdir -p outputs
 cp -L *cadence-genus-genlib/outputs/design.lib outputs/glb_top_tt.lib
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/glb_top.lef

--- a/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
+++ b/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
@@ -2,7 +2,13 @@
 mflowgen run --design $GARNET_HOME/mflowgen/global_controller/
 make cadence-genus-genlib
 make mentor-calibre-gdsmerge
-make mentor-calibre-lvs
+if command -v calibre &> /dev/null
+then
+    make mentor-calibre-lvs
+else
+    make cadence-pegasus-lvs
+fi
+
 mkdir -p outputs
 cp -L *cadence-genus-genlib/outputs/design.lib outputs/global_controller_tt.lib
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/global_controller.lef

--- a/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
+++ b/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
@@ -9,5 +9,5 @@ cp -L *cadence-innovus-signoff/outputs/design.lef outputs/global_controller.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/global_controller.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/global_controller.sdf
 cp -L *cadence-innovus-signoff/outputs/design-merged.gds outputs/global_controller.gds
-cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/global_controller.lvs.v
+cp -L *-lvs/outputs/design_merged.lvs.v outputs/global_controller.lvs.v
 

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -10,5 +10,5 @@ cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/tile_array.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/tile_array.sdf
 cp -L *cadence-innovus-signoff/outputs/design-merged.gds outputs/tile_array.gds
 cp -L *Tile_MemCore/outputs/sram.spi outputs/tile_array.sram.spi
-cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/tile_array.lvs.v
+cp -L *-lvs/outputs/design_merged.lvs.v outputs/tile_array.lvs.v
 

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -2,7 +2,12 @@
 mflowgen run --design $GARNET_HOME/mflowgen/tile_array/
 make cadence-genus-genlib -j 2
 make mentor-calibre-gdsmerge
-make mentor-calibre-lvs
+if command -v calibre &> /dev/null
+then
+    make mentor-calibre-lvs
+else
+    make cadence-pegasus-lvs
+fi
 mkdir -p outputs
 cp -L *cadence-genus-genlib/outputs/design.lib outputs/tile_array_tt.lib
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/tile_array.lef

--- a/mflowgen/glb_top/glb_tile/get_glb_outputs.sh
+++ b/mflowgen/glb_top/glb_tile/get_glb_outputs.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 mflowgen run --design $GARNET_HOME/mflowgen/glb_tile/
 make cadence-genus-genlib
-make mentor-calibre-lvs
+if command -v calibre &> /dev/null
+then
+    make mentor-calibre-lvs
+else
+    make cadence-pegasus-lvs
+fi
+
 mkdir -p outputs
 cp -L *cadence-genus-genlib/outputs/design.lib outputs/glb_tile_tt.lib
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/glb_tile.lef

--- a/mflowgen/glb_top/glb_tile/get_glb_outputs.sh
+++ b/mflowgen/glb_top/glb_tile/get_glb_outputs.sh
@@ -6,6 +6,6 @@ mkdir -p outputs
 cp -L *cadence-genus-genlib/outputs/design.lib outputs/glb_tile_tt.lib
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/glb_tile.lef
 cp -L *cadence-innovus-signoff/outputs/design-merged.gds outputs/glb_tile.gds
-cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/glb_tile.lvs.v
+cp -L *-lvs/outputs/design_merged.lvs.v outputs/glb_tile.lvs.v
 cp -L *gen_sram_macro/outputs/sram.spi outputs/sram.spi
 

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -9,6 +9,6 @@ cp -L *cadence-innovus-signoff/outputs/design.lef outputs/Tile_MemCore.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/Tile_MemCore.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/Tile_MemCore.sdf
 cp -L *cadence-innovus-signoff/outputs/design-merged.gds outputs/Tile_MemCore.gds
-cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/Tile_MemCore.lvs.v
+cp -L *-lvs/outputs/design_merged.lvs.v outputs/Tile_MemCore.lvs.v
 cp -L *gen_sram_macro/outputs/sram.spi outputs/sram.spi
 

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 mflowgen run --design $GARNET_HOME/mflowgen/Tile_MemCore/
 make mentor-calibre-gdsmerge
-make mentor-calibre-lvs
 make cadence-genus-genlib
+if command -v calibre &> /dev/null
+then
+    make mentor-calibre-lvs
+else
+    make cadence-pegasus-lvs
+fi
+
 mkdir -p outputs
 cp -L *cadence-genus-genlib/outputs/design.lib outputs/Tile_MemCore_tt.lib
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/Tile_MemCore.lef

--- a/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
+++ b/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
@@ -9,5 +9,5 @@ cp -L *cadence-innovus-signoff/outputs/design.lef outputs/Tile_PE.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/Tile_PE.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/Tile_PE.sdf
 cp -L *cadence-innovus-signoff/outputs/design-merged.gds outputs/Tile_PE.gds
-cp -L *mentor-calibre-lvs/outputs/design_merged.lvs.v outputs/Tile_PE.lvs.v
+cp -L *-lvs/outputs/design_merged.lvs.v outputs/Tile_PE.lvs.v
 

--- a/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
+++ b/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
@@ -2,7 +2,13 @@
 mflowgen run --design $GARNET_HOME/mflowgen/Tile_PE/
 make cadence-genus-genlib
 make mentor-calibre-gdsmerge
-make mentor-calibre-lvs
+if command -v calibre &> /dev/null
+then
+    make mentor-calibre-lvs
+else
+    make cadence-pegasus-lvs
+fi
+
 mkdir -p outputs
 cp -L *cadence-genus-genlib/outputs/design.lib outputs/Tile_PE_tt.lib
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/Tile_PE.lef


### PR DESCRIPTION
This PR fixes all get_\<block\>_outputs.sh scripts so that they can copy the lvs netlist from either the pegasus lvs node or the calibre lvs node, whichever one is actually run.