### PR TITLE
remove unnecessary gdsmerge targets

### DIFF
--- a/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
+++ b/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 mflowgen run --design $GARNET_HOME/mflowgen/global_controller/
 make cadence-genus-genlib
-make mentor-calibre-gdsmerge
 if command -v calibre &> /dev/null
 then
     make mentor-calibre-lvs

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 mflowgen run --design $GARNET_HOME/mflowgen/tile_array/
 make cadence-genus-genlib -j 2
-make mentor-calibre-gdsmerge
 if command -v calibre &> /dev/null
 then
     make mentor-calibre-lvs

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 mflowgen run --design $GARNET_HOME/mflowgen/Tile_MemCore/
-make mentor-calibre-gdsmerge
 make cadence-genus-genlib
 if command -v calibre &> /dev/null
 then

--- a/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
+++ b/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 mflowgen run --design $GARNET_HOME/mflowgen/Tile_PE/
 make cadence-genus-genlib
-make mentor-calibre-gdsmerge
 if command -v calibre &> /dev/null
 then
     make mentor-calibre-lvs


### PR DESCRIPTION
Removes old, no longer valid gdsmerge targets from get_<block>_outputs scripts