### PR TITLE
Tbg config ports

### DIFF
--- a/garnet.py
+++ b/garnet.py
@@ -118,6 +118,8 @@ class Garnet(Generator):
 
         # make multiple stall ports
         stall_port_pass(self.interconnect)
+        # make multiple configuration ports
+        config_port_pass(self.interconnect)
 
         if not interconnect_only:
             self.add_ports(
@@ -149,9 +151,6 @@ class Garnet(Generator):
             # Top -> Interconnect clock port connection
             self.wire(self.ports.clk_in, self.interconnect.ports.clk)
 
-            # make multiple configuration ports
-            config_port_pass(self.interconnect)
-
             glb_glc_wiring(self)
             glb_interconnect_wiring(self)
             glc_interconnect_wiring(self)
@@ -164,9 +163,9 @@ class Garnet(Generator):
             self.add_ports(
                 clk=magma.In(magma.Clock),
                 reset=magma.In(magma.AsyncReset),
-                config=magma.In(
-                    ConfigurationType(self.interconnect.config_data_width,
-                                      self.interconnect.config_data_width)),
+                config=magma.In(magma.Array[width,
+                                ConfigurationType(config_data_width,
+                                                  config_data_width)]),
                 stall=magma.In(magma.Bits[self.width * self.interconnect.stall_signal_width]),
                 read_config_data=magma.Out(magma.Bits[config_data_width])
             )
@@ -294,15 +293,17 @@ class Garnet(Generator):
         result = """
 module Interconnect (
    input  clk,
-   input [31:0] config_config_addr,
-   input [31:0] config_config_data,
-   input [0:0] config_read,
-   input [0:0] config_write,
    output [31:0] read_config_data,
    input  reset,
 """
         # add stall based on the size
         result += f"   input [{str(self.width * self.interconnect.stall_signal_width - 1)}:0] stall,\n\n"
+        # magma can't generate SV struct array, which would be the ideal solution here
+        for i in range(self.width):
+            result += f"   input [31:0] config_{i}_config_addr,\n"
+            result += f"   input [31:0] config_{i}_config_data,\n"
+            result += f"   input [0:0] config_{i}_config_read,\n"
+            result += f"   input [0:0] config_{i}_config_write,\n"
         # loop through the interfaces
         ports = []
         for port_name, port_node in self.interconnect.interface().items():

--- a/garnet.py
+++ b/garnet.py
@@ -302,8 +302,8 @@ module Interconnect (
         for i in range(self.width):
             result += f"   input [31:0] config_{i}_config_addr,\n"
             result += f"   input [31:0] config_{i}_config_data,\n"
-            result += f"   input [0:0] config_{i}_config_read,\n"
-            result += f"   input [0:0] config_{i}_config_write,\n"
+            result += f"   input [0:0] config_{i}_read,\n"
+            result += f"   input [0:0] config_{i}_write,\n"
         # loop through the interfaces
         ports = []
         for port_name, port_node in self.interconnect.interface().items():

--- a/tbg.py
+++ b/tbg.py
@@ -26,6 +26,8 @@ class BasicTester(Tester):
         self.__xmin = 0xFFFF
         self.__xmax = 0
 
+        self.__last_addr = None
+
     def __get_x(self, addr):
         x = (addr >> 8) & 0xFF
         if x > self.__xmax:
@@ -34,15 +36,31 @@ class BasicTester(Tester):
             self.__xmin = x
         return x
 
+    def __clear_last_addr(self, addr):
+        if self.__last_addr is not None:
+            last_addr = self.__last_addr
+            last_x = self.__get_x(last_addr)
+            x = self.__get_x(addr)
+            if last_x != x:
+                self.__last_addr = None
+                self.__config_write(last_addr, 0)
+                self.__config_read(last_addr, 0)
+
     def __config_write(self, addr, value):
+        self.__clear_last_addr(addr)
         x = self.__get_x(addr)
         port_name = f"config_{x}_write"
         self.poke(self._circuit.interface[port_name], value)
+        if value:
+            self.__last_addr = addr
 
     def __config_read(self, addr, value):
+        self.__clear_last_addr(addr)
         x = self.__get_x(addr)
         port_name = f"config_{x}_read"
         self.poke(self._circuit.interface[port_name], value)
+        if value:
+            self.__last_addr = addr
 
     def __config_addr(self, addr, value):
         x = self.__get_x(addr)


### PR DESCRIPTION
`--interconnect-only` now also splits config ports among columns. As a result, fabric-level RTL will be identical as the one used in the chip.

Current limitation:
- It might be a little bit messy to implement that in `fault` since there is no `fork` semantics in `fault`. TBG still configures in serial instead of parallel.