### PR TITLE
Make Genus Faster While Increasing Clock Frequency

### DIFF
--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -51,7 +51,7 @@ set_max_transition 0.120 $design_name
 # Constrain INPUTS
 # - make this non-zero to avoid hold buffers on input-registered designs
 set i_delay [expr 0.2 * ${clock_period}]
-set_input_delay -clock ${clock_name} ${i_delay} [all_inputs]
+set_input_delay -clock ${clock_name} ${i_delay} [all_inputs -no_clocks]
 # Pass through should have no input delay
 set pt_i_delay [expr 0.8 * ${clock_period}]
 set_input_delay -clock ${clock_name} ${pt_i_delay} stall

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -27,9 +27,7 @@ def construct():
   parameters = {
     'construct_path'      : __file__,
     'design_name'         : 'Tile_MemCore',
-  # 'clock_period'        : 1.1,    # 900MHz never finishes AFAICT
-  # 'clock_period'        : 1.25,   # 800MHz requires > ten hours
-    'clock_period'        : 4.0,    # 250MHz finishes in three hours
+    'clock_period'        : 1.1,
     'adk'                 : adk_name,
     'adk_view'            : adk_view,
     # Synthesis
@@ -43,7 +41,7 @@ def construct():
     'bc_corner'           : "ffg0p88v125c",
     'partial_write'       : False,
     # Utilization target
-    'core_density_target' : 0.74,
+    'core_density_target' : 0.68,
     # RTL Generation
     'interconnect_only'   : True,
     # Power Domains

--- a/mflowgen/Tile_PE/constraints/common.tcl
+++ b/mflowgen/Tile_PE/constraints/common.tcl
@@ -56,7 +56,7 @@ remove_driving_cell reset
 # Constrain INPUTS
 # - make this non-zero to avoid hold buffers on input-registered designs
 set i_delay [expr 0.2 * ${clock_period}]
-set_input_delay -clock ${clock_name} ${i_delay} [all_inputs]
+set_input_delay -clock ${clock_name} ${i_delay} [all_inputs -no_clocks]
 # Pass through should have no input delay
 set pt_i_delay [expr 0.8 * ${clock_period}]
 set_input_delay -clock ${clock_name} ${pt_i_delay} clk_pass_through

--- a/mflowgen/Tile_PE/constraints/constraints.tcl
+++ b/mflowgen/Tile_PE/constraints/constraints.tcl
@@ -61,8 +61,10 @@ set_false_path -to [all_outputs] -through [get_pins [list $fp_add_path/*]]
 # ALU OP SCENARIOS
 ########################################################################
 
-exec python inputs/report_alu.py
-source alu_op_scenarios.tcl
+# reports timing for each op
+# but it slows down synthesis a lot, so disabling for now
+#exec python inputs/report_alu.py
+#source alu_op_scenarios.tcl
 
 ########################################################################
 source inputs/scenarios.tcl

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -44,7 +44,7 @@ def construct():
   parameters = {
     'construct_path'    : __file__,
     'design_name'       : 'Tile_PE',
-    'clock_period'      : 4,  # Change to 250 MHz to match Mem.
+    'clock_period'      : 1.1,
     'adk'               : adk_name,
     'adk_view'          : adk_view,
     # Synthesis


### PR DESCRIPTION
Lowered density of MEM, changed constraints very slightly, and decreased clock period to 1.1ns. PT Timing signoff reports 0.008 WNS, and total area of MEM tile is 16.8K. Lowering density allows entire flow up until cadence-innovus-signoff to complete in 4h10min on arm. Keeping density at 0.74 with 1.1ns clock period is an easy to way to let postroute take a _ very _ long time.

Got rid of modes in PE genus synthesis node, which was slowing down synthesis times a lot. At 4ns, Genus went down from 30min to 6min. At 1.1ns, Genus takes 19min, and entire flow up until cadence-innovus-signoff takes 4hr49min on arm. No timing violations found, and total area (with pond) is 5907. With pond at 4ns, area was 5460.

These times were tested on arm. Let me know if I should run on VDE to make sure that the runtimes are also reasonable on the cloud.