### PR TITLE
Add false paths for config->SB data outputs in mem tile

### DIFF
--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -161,3 +161,10 @@ set_false_path -to [get_ports lo]
 set rmux_cells [get_cells -hier RMUX_T*sel_inst0]
 set_dont_touch $rmux_cells true
 set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true
+
+# False paths from config input ports to SB output ports
+set_false_path -from [get_ports config* -filter direction==in] -to [get_ports SB* -filter direction==out]
+
+# False paths from config input ports to SB registers
+set sb_reg_path SB_ID0_5TRACKS_B*_PE/REG_T*_B*/value__CE/value_reg[*]/*
+set_false_path -from [get_ports config_* -filter direction==in] -to [get_pins $sb_reg_path]

--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -166,5 +166,5 @@ set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter n
 set_false_path -from [get_ports config* -filter direction==in] -to [get_ports SB* -filter direction==out]
 
 # False paths from config input ports to SB registers
-set sb_reg_path SB_ID0_5TRACKS_B*_PE/REG_T*_B*/value__CE/value_reg[*]/*
+set sb_reg_path SB_ID0_5TRACKS_B*/REG_T*_B*/value__CE/value_reg[*]/*
 set_false_path -from [get_ports config_* -filter direction==in] -to [get_pins $sb_reg_path]


### PR DESCRIPTION
After the modifications to the mem tile flow in #719 , the mem tile hung in postroute on VDE. To prevent this, I've added some of the false paths that were added to the PE here: https://github.com/StanfordAHA/garnet/blob/1912acad4469349e549e741fdf6cfd0fa72cb88a/mflowgen/Tile_PE/constraints/constraints.tcl#L43

Basically, these constraints say that paths from a configuration input to an SB data output or SB pipeline register do not need to be optimized. After adding these constraints, the mem tile no longer hangs in postroute on VDE. I suspect we may even be able to increase the utilization target again now, but I haven't tried that out, so I won't include it in this PR.