### PR TITLE
set inline=False for all m.compile calls that produce verilog for tap…

### DIFF
--- a/garnet.py
+++ b/garnet.py
@@ -370,7 +370,8 @@ def main():
         magma.compile("garnet", garnet_circ, output="coreir-verilog",
                       coreir_libs={"float_CW"},
                       passes = ["rungenerators", "inline_single_instances", "clock_gate"],
-                      disable_ndarray=True)
+                      disable_ndarray=True,
+                      inline=False)
         garnet.create_stub()
     if len(args.app) > 0 and len(args.input) > 0 and len(args.gold) > 0 \
             and len(args.output) > 0 and not args.virtualize:

--- a/global_buffer/global_buffer_main.py
+++ b/global_buffer/global_buffer_main.py
@@ -20,7 +20,10 @@ def main():
 
     if args.verilog:
         global_buffer_circ = global_buffer.circuit()
-        magma.compile("global_buffer", global_buffer_circ, output="coreir-verilog")
+        magma.compile("global_buffer",
+                      global_buffer_circ,
+                      output="coreir-verilog",
+                      inline=False)
 
 if __name__ == "__main__":
     main()

--- a/io_core/io_core_magma.py
+++ b/io_core/io_core_magma.py
@@ -153,4 +153,4 @@ class IOCoreValid(ConfigurableCore, IOCoreBase):
 
 if __name__ == "__main__":
     core = IOCoreValid(8, 32)
-    magma.compile("io", core.circuit())
+    magma.compile("io", core.circuit(), inline=False)

--- a/tests/test_interconnect/test_interconnect_cgra.py
+++ b/tests/test_interconnect/test_interconnect_cgra.py
@@ -38,7 +38,7 @@ def test_1x1():
     circuit = interconnect.circuit()
     with tempfile.TemporaryDirectory() as temp:
         filename = os.path.join(temp, "1x1")
-        magma.compile(filename, circuit)
+        magma.compile(filename, circuit, inline=False)
         assert os.path.isfile(filename + ".v")
 
 
@@ -113,7 +113,8 @@ def test_interconnect_point_wise(batch_size: int, dw_files, io_sides):
             shutil.copy(aoi_mux, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
-                               magma_opts={"coreir_libs": {"float_DW"}},
+                               magma_opts={"coreir_libs": {"float_DW"},
+                                           "inline": False},
                                directory=tempdir,
                                flags=["-Wno-fatal"])
 
@@ -219,7 +220,8 @@ def test_interconnect_sram(dw_files, io_sides):
             shutil.copy(aoi_mux, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
-                               magma_opts={"coreir_libs": {"float_DW"}},
+                               magma_opts={"coreir_libs": {"float_DW"},
+                                           "inline": False},
                                directory=tempdir,
                                flags=["-Wno-fatal"])
 
@@ -360,6 +362,7 @@ def test_interconnect_fifo(dw_files, io_sides, depth):
             shutil.copy(aoi_mux, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
-                               magma_opts={"coreir_libs": {"float_DW"}},
+                               magma_opts={"coreir_libs": {"float_DW"},
+                                           "inline": False},
                                directory=tempdir,
                                flags=["-Wno-fatal"])

--- a/tests/test_interconnect/test_reset.py
+++ b/tests/test_interconnect/test_reset.py
@@ -96,6 +96,7 @@ def test_interconnect_reset(batch_size: int, dw_files, io_sides):
             shutil.copy(aoi_mux, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
-                               magma_opts={"coreir_libs": {"float_DW"}},
+                               magma_opts={"coreir_libs": {"float_DW"},
+                                           "inline": False},
                                directory=tempdir,
                                flags=["-Wno-fatal"])

--- a/tests/test_interconnect/test_stall.py
+++ b/tests/test_interconnect/test_stall.py
@@ -184,6 +184,7 @@ def test_stall(dw_files, io_sides):
             shutil.copy(aoi_mux, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
-                               magma_opts={"coreir_libs": {"float_DW"}},
+                               magma_opts={"coreir_libs": {"float_DW"},
+                                           "inline": False},
                                directory=tempdir,
                                flags=["-Wno-fatal"])

--- a/tests/test_io_core/test_io_core_magma.py
+++ b/tests/test_io_core/test_io_core_magma.py
@@ -30,6 +30,7 @@ def test_regression():
     with tempfile.TemporaryDirectory() as tempdir:
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
+                               magma_opts={"inline": False},
                                directory=tempdir,
                                flags=["-Wno-fatal"])
 
@@ -87,5 +88,6 @@ def test_valid_generation():
     with tempfile.TemporaryDirectory() as tempdir:
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
+                               magma_opts={"inline": False},
                                directory=tempdir,
                                flags=["-Wno-fatal"])

--- a/tests/test_memory_core/test_memory_core.py
+++ b/tests/test_memory_core/test_memory_core.py
@@ -233,6 +233,7 @@ def test_multiple_output_ports():
             shutil.copy(genesis_verilog, tempdir)
         tester.compile_and_run(directory=tempdir,
                                magma_output="coreir-verilog",
+                               magma_opts={"inline": False},
                                target="verilator",
                                flags=["-Wno-fatal"])
 
@@ -412,6 +413,7 @@ def test_multiple_output_ports_conv():
             shutil.copy(genesis_verilog, tempdir)
         tester.compile_and_run(directory=tempdir,
                                magma_output="coreir-verilog",
+                               magma_opts={"inline": False},
                                target="verilator",
                                flags=["-Wno-fatal"])
 
@@ -626,6 +628,7 @@ def test_mult_ports_mult_aggs_double_buffer_conv():
             shutil.copy(genesis_verilog, tempdir)
         tester.compile_and_run(directory=tempdir,
                                magma_output="coreir-verilog",
+                               magma_opts={"inline": False},
                                target="verilator",
                                flags=["-Wno-fatal"])
 
@@ -829,6 +832,7 @@ def test_mult_ports_mult_aggs_double_buffer():
             shutil.copy(genesis_verilog, tempdir)
         tester.compile_and_run(directory=tempdir,
                                magma_output="coreir-verilog",
+                               magma_opts={"inline": False},
                                target="verilator",
                                flags=["-Wno-fatal"])
 
@@ -1030,6 +1034,7 @@ def test_multiple_input_ports_identity_stream_mult_aggs():
             shutil.copy(genesis_verilog, tempdir)
         tester.compile_and_run(directory=tempdir,
                                magma_output="coreir-verilog",
+                               magma_opts={"inline": False},
                                target="verilator",
                                flags=["-Wno-fatal"])
 
@@ -1135,7 +1140,8 @@ def basic_tb(config_path,
         target = "verilator"
         runtime_kwargs = {"magma_output": "coreir-verilog",
                           "magma_opts": {"coreir_libs": {"float_CW"},
-                                         "disable_ndarray": True},
+                                         "disable_ndarray": True,
+                                         "inline": False},
                           "directory": tempdir,
                           "flags": []}
         if xcelium is False:

--- a/tests/test_memory_core/test_pond.py
+++ b/tests/test_memory_core/test_pond.py
@@ -200,7 +200,8 @@ def test_pond_rd_wr(verilator=True):
 
         target = "verilator"
         runtime_kwargs = {"magma_output": "coreir-verilog",
-                          "magma_opts": {"coreir_libs": {"float_DW"}},
+                          "magma_opts": {"coreir_libs": {"float_DW"},
+                                         "inline": False},
                           "directory": tempdir,
                           "flags": ["-Wno-fatal"]}
         if verilator is False:
@@ -299,7 +300,8 @@ def test_pond_pe(verilator=True):
 
         target = "verilator"
         runtime_kwargs = {"magma_output": "coreir-verilog",
-                          "magma_opts": {"coreir_libs": {"float_DW"}},
+                          "magma_opts": {"coreir_libs": {"float_DW"},
+                                         "inline": False},
                           "directory": tempdir,
                           "flags": ["-Wno-fatal", "--trace"]}
         if verilator is False:

--- a/tests/test_peak_core/test_pe_config.py
+++ b/tests/test_peak_core/test_pe_config.py
@@ -72,7 +72,8 @@ def test_pe_config(dw_files):
             shutil.copy(filename, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
-                               magma_opts={"coreir_libs": {"float_DW"}},
+                               magma_opts={"coreir_libs": {"float_DW"},
+                                           "inline": False},
                                directory=tempdir,
                                flags=["-Wno-fatal"])
 
@@ -149,7 +150,8 @@ def test_pe_data_gate(op, dw_files):
                                    simulator="ncsim",
                                    magma_output="coreir-verilog",
                                    ext_srcs=ext_srcs,
-                                   magma_opts={"coreir_libs": {"float_DW"}},
+                                   magma_opts={"coreir_libs": {"float_DW"},
+                                               "inline": False},
                                    directory=tempdir,)
         else:
             for filename in dw_files:
@@ -157,6 +159,7 @@ def test_pe_data_gate(op, dw_files):
             tester.compile_and_run(target="verilator",
                                    magma_output="coreir-verilog",
                                    magma_opts={"coreir_libs": {"float_DW"},
+                                               "inline": False,
                                                "verilator_debug": True},
                                    directory=tempdir,
                                    flags=["-Wno-fatal"])

--- a/tests/test_peak_core/test_pe_stall.py
+++ b/tests/test_peak_core/test_pe_stall.py
@@ -48,6 +48,7 @@ def test_pe_stall(dw_files):
             shutil.copy(filename, tempdir)
         tester.compile_and_run(target="verilator",
                                magma_output="coreir-verilog",
-                               magma_opts={"coreir_libs": {"float_DW"}},
+                               magma_opts={"coreir_libs": {"float_DW"},
+                                           "inline": False},
                                directory=tempdir,
                                flags=["-Wno-fatal"])

--- a/tests/test_peak_core/test_peak_core_and_tile.py
+++ b/tests/test_peak_core/test_peak_core_and_tile.py
@@ -111,7 +111,8 @@ def test_peak_core_sequence(sequence, cw_files):
 
         tester.compile_and_run("verilator",
                                directory=tempdir,
-                               magma_opts={"coreir_libs": {"float_CW"}},
+                               magma_opts={"coreir_libs": {"float_CW"},
+                                           "inline": False},
                                flags=["-Wno-fatal"])
 
 
@@ -168,5 +169,6 @@ def test_peak_tile_sequence(sequence, cw_files, seed):
 
         tester.compile_and_run("verilator",
                                directory=tempdir,
-                               magma_opts={"coreir_libs": {"float_CW"}},
+                               magma_opts={"coreir_libs": {"float_CW"},
+                                           "inline": False},
                                flags=["-Wno-fatal"])

--- a/tests/test_timing/test_basic.py
+++ b/tests/test_timing/test_basic.py
@@ -29,6 +29,7 @@ def test_basic(dw_files):
     with tempfile.TemporaryDirectory() as tempdir:
         common.generate_scaffolding(tempdir)
         magma.compile(f"{tempdir}/{circuit.name}", circuit,
-                      output="coreir-verilog", coreir_libs={"float_DW"})
+                      output="coreir-verilog", coreir_libs={"float_DW"},
+                      inline=False)
         tester.compile_and_run(skip_compile=True, target="verilator",
                                directory=tempdir, flags=["-Wno-fatal"])


### PR DESCRIPTION
Setting inline=False for all calls to magma.Compile that produce verilog for tapeout in order to prevent rtl changes caused by https://github.com/phanrahan/magma/pull/873

@rsetaluri I'm not sure that I've gotten everything here, but I thing these are the main ones we have to worry about for PD. I also see magma.compile calls in some of the tests... we should update those as well, right?