### PR TITLE
Fullchip LVS fixes

### DIFF
--- a/mflowgen/common/init-fullchip/outputs/io-fillers.tcl
+++ b/mflowgen/common/init-fullchip/outputs/io-fillers.tcl
@@ -41,6 +41,9 @@
 
     set_db [get_db nets esd] .skip_routing true
     set_db [get_db nets esd] .dont_touch true
+    
+    set_db [get_db nets rte*] .skip_routing true
+    set_db [get_db nets rte*] .dont_touch true
 
     # end of "rte_madness.tcl"
     ########################################################################

--- a/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
+++ b/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
@@ -168,8 +168,8 @@ foreach_in_collection sram $srams {
   } else {
     placeinstance $sram_name $x_loc $y_loc -fixed
   }
-  # Create M3 pg net blockage to prevent DRC from interaction
-  # with M5 stripes
+  # Create M1,M3 pg net blockage to prevent DRC from interaction
+  # with M5 stripes or pgnet short with sram pins
   set llx [dbGet [dbGet -p top.insts.name $sram_name].box_llx]
   set lly [dbGet [dbGet -p top.insts.name $sram_name].box_lly]
   set urx [dbGet [dbGet -p top.insts.name $sram_name].box_urx]
@@ -180,7 +180,7 @@ foreach_in_collection sram $srams {
   createRouteBlk \
     -inst $sram_name \
     -box [expr $llx - $lr_margin] [expr $lly - $tb_margin] [expr $urx + $lr_margin] [expr $ury + $tb_margin] \
-    -layer 3 \
+    -layer [list 1 3] \
     -pgnetonly
   set row [expr $row + 1]
   set y_loc [expr $y_loc + $sram_height + $sram_spacing_y]


### PR DESCRIPTION
Introduces 2 changes necessary to make fullchip pass LVS in Calibre.

1. set rte nets to skip_routing. When we used dc, this would've broken the flow because dc used the net name "rte" for a wide variety of tie_hi and tie_lo nets unrelated to rte. This isn't the case with Genus, so setting this prevents Innovus from trying to route from the core area into the pad ring to connect rte nets.

2. Create M1 power net blockage around srams in full_chip. Some floorplan change between now and the last time LVS passed moved the SRAMs such that a VDD stripe aligned exactly with the RTSEL pin (which goes from M1 to M3). This VSS/RTSEL short caused LVS to fail.

You can see the full_chip run with LVS passing at /sim/ajcars/builds/fc-10-26 on r7arm-aha.