### PR TITLE
Fix systemRDL systemverilog generation bug and global controller rtl step bug

### DIFF
--- a/global_buffer/Makefile
+++ b/global_buffer/Makefile
@@ -18,7 +18,7 @@ FIX_SYSTEMRDL = \
     sed -i '/pio_dec_write_data_d1 <=/d' ./systemRDL/output/glb_jrdl_decode.sv; \
     sed -i '/pio_dec_address_d1 <=/d' ./systemRDL/output/glb_jrdl_decode.sv; \
     sed -i '/endmodule/d' ./systemRDL/output/glb_jrdl_decode.sv; \
-    echo -e "always_ff @ (posedge clk) begin \n pio_dec_address_d1 <= pio_dec_address; \n pio_dec_write_data_d1 <= pio_dec_write_data; \nend \nendmodule" >> ./systemRDL/output/glb_jrdl_decode.sv
+    printf "always_ff @ (posedge clk) begin \n pio_dec_address_d1 <= pio_dec_address; \n pio_dec_write_data_d1 <= pio_dec_write_data; \nend \nendmodule" >> ./systemRDL/output/glb_jrdl_decode.sv
 
 XRUN = xrun \
 	   -64bit \

--- a/global_buffer/Makefile
+++ b/global_buffer/Makefile
@@ -14,6 +14,12 @@ SRAM_RTL := /sim/kongty/mc/ts1n16ffcllsblvtc2048x64m8sw_130a/VERILOG/ts1n16ffcll
 
 RTL_LISTS := `cat $(RTL_DIR)/global_buffer.filelist | sed -e 's/^/$(RTL_DIR)\//' | xargs readlink -f`
 
+FIX_SYSTEMRDL = \
+    sed -i '/pio_dec_write_data_d1 <=/d' ./systemRDL/output/glb_jrdl_decode.sv; \
+    sed -i '/pio_dec_address_d1 <=/d' ./systemRDL/output/glb_jrdl_decode.sv; \
+    sed -i '/endmodule/d' ./systemRDL/output/glb_jrdl_decode.sv; \
+    echo -e "always_ff @ (posedge clk) begin \n pio_dec_address_d1 <= pio_dec_address; \n pio_dec_write_data_d1 <= pio_dec_write_data; \nend \nendmodule" >> ./systemRDL/output/glb_jrdl_decode.sv
+
 XRUN = xrun \
 	   -64bit \
 	   -sv \
@@ -66,12 +72,13 @@ $(rdl_post): $(rdl_pre)
 
 rdl_gen = $(RDL_DIR)/glb_jrdl_decode.sv $(RDL_DIR)/glb_jrdl_logic.sv $(RDL_DIR)/glb_pio.sv
 $(rdl_gen): $(rdl_post)
-	java -jar ../systemRDL/Ordt.jar -parms systemRDL/ordt_params/glb.parms -systemverilog systemRDL/output/ systemRDL/rdl_models/glb.rdl.post
+	java -jar ../systemRDL/Ordt.jar -parms systemRDL/ordt_params/glb.parms -systemverilog systemRDL/output/ systemRDL/rdl_models/glb.rdl.post \
 
 $(RTL_LISTS): $(rdl_gen)
 
 .PHONY: rtl
 rtl: $(RTL_LISTS)
+	$(FIX_SYSTEMRDL)
 
 # html target generates html for systemRDL table
 .PHONY: html
@@ -84,7 +91,7 @@ html: $(rdl_post)
 sim-tile: TOP_MODULE=glb_tile
 sim-tile: TB_DIR=sim-tile
 sim-tile: DESIGNARGS += -F $(RTL_DIR)/$(TOP_MODULE).filelist -F $(TB_DIR)/tb_$(TOP_MODULE).filelist -v $(SRAM_RTL)
-sim-tile: $(RTL_LISTS)
+sim-tile: rtl
 	$(XRUN)
 
 # sim-tile-pnr
@@ -99,14 +106,14 @@ sim-tile-gl: DESIGNARGS += \
 	$(GLB_TILE_NETLIST) \
 	$(RTL_DIR)/global_buffer_param.svh \
 	-F $(TB_DIR)/tb_$(TOP_MODULE).filelist
-sim-tile-gl: $(RTL_LISTS) $(GLB_TILE_NETLIST)
+sim-tile-gl: $(GLB_TILE_NETLIST)
 	$(XRUN)
 
 # run testbench of glb with xcelium
 .PHONY: sim
 #sim: XRUNARGS+=+define+DEBUG
 sim: DESIGNARGS += -v $(SRAM_RTL) -F $(RTL_DIR)/$(TOP_MODULE).filelist -F $(TB_DIR)/tb_$(TOP_MODULE).filelist 
-sim: $(RTL_LISTS) 
+sim: rtl
 	$(XRUN)
 
 .PHONY: sim-gl

--- a/global_buffer/Makefile
+++ b/global_buffer/Makefile
@@ -72,7 +72,7 @@ $(rdl_post): $(rdl_pre)
 
 rdl_gen = $(RDL_DIR)/glb_jrdl_decode.sv $(RDL_DIR)/glb_jrdl_logic.sv $(RDL_DIR)/glb_pio.sv
 $(rdl_gen): $(rdl_post)
-	java -jar ../systemRDL/Ordt.jar -parms systemRDL/ordt_params/glb.parms -systemverilog systemRDL/output/ systemRDL/rdl_models/glb.rdl.post \
+	java -jar ../systemRDL/Ordt.jar -parms systemRDL/ordt_params/glb.parms -systemverilog systemRDL/output/ systemRDL/rdl_models/glb.rdl.post
 
 $(RTL_LISTS): $(rdl_gen)
 

--- a/global_buffer/systemRDL/ordt_params/glb.parms
+++ b/global_buffer/systemRDL/ordt_params/glb.parms
@@ -17,5 +17,6 @@ output systemverilog {
     leaf_address_size = 12
     root_decoder_interface = parallel
     generate_child_addrmaps = true
+    use_async_resets = true
 }
 

--- a/global_controller/Makefile
+++ b/global_controller/Makefile
@@ -51,7 +51,7 @@ FIX_SYSTEMRDL = \
 	sed -i '/pio_dec_write_data_d1 <=/d' ./systemRDL/output/glc_jrdl_decode.sv; \
 	sed -i '/pio_dec_address_d1 <=/d' ./systemRDL/output/glc_jrdl_decode.sv; \
 	sed -i '/endmodule/d' ./systemRDL/output/glc_jrdl_decode.sv; \
-	echo -e "always_ff @ (posedge clk) begin \n pio_dec_address_d1 <= pio_dec_address; \n pio_dec_write_data_d1 <= pio_dec_write_data; \nend \nendmodule" >> ./systemRDL/output/glc_jrdl_decode.sv
+	printf "always_ff @ (posedge clk) begin \n pio_dec_address_d1 <= pio_dec_address; \n pio_dec_write_data_d1 <= pio_dec_write_data; \nend \nendmodule" >> ./systemRDL/output/glc_jrdl_decode.sv
 
 
 GEN_RTL_FILELIST = \

--- a/global_controller/Makefile
+++ b/global_controller/Makefile
@@ -47,14 +47,21 @@ SIMV = ./simv \
 	   -assert nopostproc \
 	   -l vcs.log
 
+FIX_SYSTEMRDL = \
+	sed -i '/pio_dec_write_data_d1 <=/d' ./systemRDL/output/glc_jrdl_decode.sv; \
+	sed -i '/pio_dec_address_d1 <=/d' ./systemRDL/output/glc_jrdl_decode.sv; \
+	sed -i '/endmodule/d' ./systemRDL/output/glc_jrdl_decode.sv; \
+	echo -e "always_ff @ (posedge clk) begin \n pio_dec_address_d1 <= pio_dec_address; \n pio_dec_write_data_d1 <= pio_dec_write_data; \nend \nendmodule" >> ./systemRDL/output/glc_jrdl_decode.sv
+
+
 GEN_RTL_FILELIST = \
-	find $(RTL_DIR) -type f -name '*.sv' > $(TOP_MODULE).filelist; \
-	find ./systemRDL/output -type f -name '*.sv' >> $(TOP_MODULE).filelist; \
+	find $(RTL_DIR) -type f -name '*.sv' | xargs realpath  > $(TOP_MODULE).filelist; \
+	find ./systemRDL/output -type f -name '*.sv' | xargs realpath  >> $(TOP_MODULE).filelist; \
 	echo "/cad/cadence/GENUS_19.10.000_lnx86/share/synth/lib/chipware/sim/verilog/CW/CW_tap.v" >> $(TOP_MODULE).filelist
 
 GEN_TB_FILELIST = \
-	find $(TB_RTL_DIR) -type f -name '*.sv' > tb_$(TOP_MODULE).filelist; \
-	find ./systemRDL/output -type f -name '*.sv' >> tb_$(TOP_MODULE).filelist; \
+	find $(TB_RTL_DIR) -type f -name '*.sv' | xargs realpath  > tb_$(TOP_MODULE).filelist; \
+	find ./systemRDL/output -type f -name '*.sv' | xargs realpath  >> tb_$(TOP_MODULE).filelist; \
 	echo "/cad/cadence/GENUS_19.10.000_lnx86/share/synth/lib/chipware/sim/verilog/CW/CW_tap.v" >> tb_$(TOP_MODULE).filelist
 
 
@@ -73,6 +80,7 @@ html: rdl
 
 rtl: rdl genesis
 	java -jar ../systemRDL/Ordt.jar -parms systemRDL/ordt_params/glc.parms -systemverilog systemRDL/output/ systemRDL/rdl_models/glc.rdl.final
+	$(FIX_SYSTEMRDL)
 	$(GEN_RTL_FILELIST)
 
 sim_genesis: $(TB_GENESIS_FILES)

--- a/global_controller/systemRDL/ordt_params/glc.parms
+++ b/global_controller/systemRDL/ordt_params/glc.parms
@@ -17,5 +17,6 @@ output systemverilog {
     leaf_address_size = 12
     root_decoder_interface = parallel
     generate_child_addrmaps = true
+    use_async_resets = true
 }
 

--- a/mflowgen/global_controller/rtl/gen_rtl.sh
+++ b/mflowgen/global_controller/rtl/gen_rtl.sh
@@ -9,6 +9,6 @@ else
 
   while read F  ; do
     echo "Reading design file: $F"
-    cat $GARNET_HOME/global_controller/$F >> outputs/design.v
+    cat $F >> outputs/design.v
   done <$GARNET_HOME/global_controller/global_controller.filelist
 fi


### PR DESCRIPTION
This PR has two major changes

1. @thenextged and I had an issue with `systemRDL`. When it generates RTL with `async_reset`, the output RTL has a syntax that tools doesn't like. This PR manually deletes the lines that cause a problem and append the correct syntax. 
2. Fix global controller mflowgen RTL step. Set `CW_tap` path correctly.