### PR TITLE
Fullchip drc setup tweaks

### DIFF
--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -22,6 +22,13 @@ def construct():
 
   adk_name = 'tsmc16'
   adk_view = 'stdview'
+  
+  if which("calibre") is not None:
+      drc_rule_deck = 'calibre-drc-chip.rule' 
+      antenna_drc_rule_deck = 'calibre-drc-antenna.rule'
+  else:
+      drc_rule_deck = 'pegasus-drc-chip.rule' 
+      antenna_drc_rule_deck = 'pegasus-drc-antenna.rule'
 
   parameters = {
     'construct_path'    : __file__,
@@ -67,8 +74,8 @@ def construct():
     'TLX_FWD_DATA_LO_WIDTH' : 16,
     'TLX_REV_DATA_LO_WIDTH' : 45,
     # DRC rule deck
-    'drc_rule_deck'         : 'calibre-drc-chip.rule',
-    'antenna_drc_rule_deck' : 'calibre-drc-antenna.rule',
+    'drc_rule_deck'         : drc_rule_deck,
+    'antenna_drc_rule_deck' : antenna_drc_rule_deck,
     'nthreads'              : 16
   }
 

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -43,7 +43,7 @@ def construct():
     # Include SoC core? (use 0 for false, 1 for true)
     'include_core'      : 1,
     # Include sealring?
-    'include_sealring'  : False,
+    'include_sealring'  : True,
     # SRAM macros
     'num_words'         : 2048,
     'word_size'         : 64,


### PR DESCRIPTION
Just 2 small changes related to full_chip drcs.

1. Put the sealring back in  by default to avoid chip_boundary errors
2. Ensure that we use the right drc rule deck for the available drc checking tool.