### PR TITLE
Change stride/range configuration register

### DIFF
--- a/global_buffer/Makefile
+++ b/global_buffer/Makefile
@@ -6,7 +6,7 @@ TB_DIR := ./sim
 TOP_MODULE := global_buffer
 
 CGRA_WIDTH := 32
-NUM_GLB_TILES := 16
+NUM_GLB_TILES := $(shell expr $(CGRA_WIDTH) / 2 )
 
 GLB_TILE_NETLIST := /sim/kongty/pnr_annotate/glb_tile.vcs.v
 GLB_TOP_NETLIST := /sim/kongty/pnr_annotate/global_buffer.vcs.v

--- a/global_buffer/global_buffer_magma.py
+++ b/global_buffer/global_buffer_magma.py
@@ -46,7 +46,7 @@ class GlobalBuffer(Generator):
         self.max_num_words_width = (self.glb_addr_width - self.bank_byte_offset
                                     + magma.bitutils.clog2(bank_data_width
                                                            // cgra_data_width))
-        self.max_stride_width = self.axi_data_width - self.max_num_words_width
+        self.max_stride_width = 10
         self.max_num_cfgs_width = self.glb_addr_width - self.bank_byte_offset
         self.queue_depth = 4
         self.loop_level = 4

--- a/global_buffer/global_buffer_magma_helper.py
+++ b/global_buffer/global_buffer_magma_helper.py
@@ -41,7 +41,7 @@ class GlobalBufferParams:
                                 - BANK_BYTE_OFFSET
                                 + m.bitutils.clog2(BANK_DATA_WIDTH
                                                    // CGRA_DATA_WIDTH))
-    MAX_STRIDE_WIDTH: int = AXI_DATA_WIDTH - MAX_NUM_WORDS_WIDTH
+    MAX_STRIDE_WIDTH: int = 10
 
     # Max number of bitstream in dma header
     MAX_NUM_CFGS_WIDTH: int = GLB_ADDR_WIDTH - BANK_BYTE_OFFSET

--- a/global_buffer/sim/glb_test.sv
+++ b/global_buffer/sim/glb_test.sv
@@ -213,7 +213,7 @@ program glb_test
         r_trans_q[r_cnt++] = new(0, addr_dic["ST_DMA_HEADER_0_NUM_WORDS"], 'd128);
         r_trans_q[r_cnt++] = new(0, addr_dic["ST_DMA_HEADER_0_VALIDATE"], 'h1);
         r_trans_q[r_cnt++] = new(0, addr_dic["LD_DMA_HEADER_0_START_ADDR"], 'h0);
-        r_trans_q[r_cnt++] = new(0, addr_dic["LD_DMA_HEADER_0_ITER_CTRL_0"], (1 << MAX_NUM_WORDS_WIDTH) + 128);
+        r_trans_q[r_cnt++] = new(0, addr_dic["LD_DMA_HEADER_0_ITER_CTRL_0"], (128 << MAX_STRIDE_WIDTH) + 1);
         r_trans_q[r_cnt++] = new(0, addr_dic["LD_DMA_HEADER_0_VALIDATE"], 'h1);
 
         s_cnt = 0;

--- a/global_buffer/systemRDL/rdl_models/glb.rdl
+++ b/global_buffer/systemRDL/rdl_models/glb.rdl
@@ -80,8 +80,8 @@ addrmap glb {
     reg iter_ctrl_r {
         name = "Iteration Control";
         desc = "Iteration control registers";
-        field {} range[<%=MAX_NUM_WORDS_WIDTH%>] = 0;
         field {} stride[<%=MAX_STRIDE_WIDTH%>] = 0;
+        field {} range[<%=MAX_NUM_WORDS_WIDTH%>] = 0;
     };
 
     reg active_ctrl_r {


### PR DESCRIPTION
This PR changes the bitwidth of `stride` and `range` registers in the global buffer tile.