### PR TITLE
Fullchip drc tweaks/fixes

### DIFF
--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -26,9 +26,11 @@ def construct():
   if which("calibre") is not None:
       drc_rule_deck = 'calibre-drc-chip.rule' 
       antenna_drc_rule_deck = 'calibre-drc-antenna.rule'
+      power_drc_rule_deck = 'calibre-drc-block.rule'
   else:
       drc_rule_deck = 'pegasus-drc-chip.rule' 
       antenna_drc_rule_deck = 'pegasus-drc-antenna.rule'
+      power_drc_rule_deck = 'pegasus-drc-block.rule'
 
   parameters = {
     'construct_path'    : __file__,
@@ -76,6 +78,7 @@ def construct():
     # DRC rule deck
     'drc_rule_deck'         : drc_rule_deck,
     'antenna_drc_rule_deck' : antenna_drc_rule_deck,
+    'power_drc_rule_deck'   : power_drc_rule_deck,
     'nthreads'              : 16
   }
 
@@ -471,6 +474,9 @@ def construct():
 
   # Antenna DRC node needs to use antenna rule deck
   antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'] } )
+
+  # Power DRC node should use block level rule deck to improve runtimes and not report false errors
+  power_drc.update_params( {'drc_rule_deck': parameters['power_drc_rule_deck'] } )
 
   return g
 

--- a/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
+++ b/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
@@ -176,10 +176,11 @@ foreach_in_collection sram $srams {
   set ury [dbGet [dbGet -p top.insts.name $sram_name].box_ury]
   set tb_margin $vert_pitch
   set lr_margin [expr $horiz_pitch * 3]
-  addHaloToBlock [expr $horiz_pitch * 3] $vert_pitch [expr $horiz_pitch * 3] $vert_pitch $sram_name -snapToSite
+  addHaloToBlock $lr_margin $tb_margin $lr_margin $tb_margin $sram_name -snapToSite
+  # Make routing blockage smaller than halo so that endcaps are not obstructed by M1 blockage
   createRouteBlk \
     -inst $sram_name \
-    -box [expr $llx - $lr_margin] [expr $lly - $tb_margin] [expr $urx + $lr_margin] [expr $ury + $tb_margin] \
+    -box [expr $llx - (0.8 * $lr_margin)] [expr $lly - (0.8 * $tb_margin)] [expr $urx + (0.8 * $lr_margin)] [expr $ury + (0.8 * $tb_margin)] \
     -layer [list 1 3] \
     -pgnetonly
   set row [expr $row + 1]


### PR DESCRIPTION
More drc tweaks and fixes for the full_chip flow:

1. Ensures that post-power drc check uses block level rule deck, not full_chip
2. tightens blockages around srams to ensure that M1 blockage does not prevent endcap placement (this was causing many drc violations).