### PR TITLE
Cst

### DIFF
--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -17,19 +17,15 @@ steps:
 # 
 - label: 'MemCore synth 17m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps rtl --debug
+  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
-# - label: 'PE synth 23m'
-#   commands:
-#   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
-# - wait: { continue_on_failure: true } # One step at a time + continue on failure
+- label: 'PE synth 23m'
+  commands:
+  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
+- wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 ########################################################################
 # FULL CHIP RUNS - see pipeline_fullchip.yml
 
 # For more see pipeline_notes.yml
-
-
-#   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-#   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -22,10 +22,13 @@ steps:
 
 - label: 'PE synth 23m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
+  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 ########################################################################
 # FULL CHIP RUNS - see pipeline_fullchip.yml
 
 # For more see pipeline_notes.yml
+
+
+#   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -17,7 +17,7 @@ steps:
 # 
 - label: 'MemCore synth 17m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
+  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps rtl --debug
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 # - label: 'PE synth 23m'
@@ -32,3 +32,4 @@ steps:
 
 
 #   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
+#   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -20,10 +20,10 @@ steps:
   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
-- label: 'PE synth 23m'
-  commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
+# - label: 'PE synth 23m'
+#   commands:
+#   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
+# - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 ########################################################################
 # FULL CHIP RUNS - see pipeline_fullchip.yml

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -15,14 +15,15 @@ steps:
 ##############################################################################
 # INDIVIDUAL TILE RUNS
 # 
-- label: 'MemCore synth 17m'
-  commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
+# - label: 'MemCore synth 17m'
+#   commands:
+#   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
+# - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
-- label: 'PE synth 23m'
+- label: '250MHz PE synth 11m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
+  # - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
+  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 ########################################################################

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -15,15 +15,14 @@ steps:
 ##############################################################################
 # INDIVIDUAL TILE RUNS
 # 
-# - label: 'MemCore synth 17m'
-#   commands:
-#   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
-# - wait: { continue_on_failure: true } # One step at a time + continue on failure
-
-- label: '250MHz PE synth 11m'
+- label: 'MemCore synth 17m'
   commands:
-  # - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
+  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
+- wait: { continue_on_failure: true } # One step at a time + continue on failure
+
+- label: '250MHz PE synth 12m'
+  commands:
+  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
 - wait: { continue_on_failure: true } # One step at a time + continue on failure
 
 ########################################################################

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -22,7 +22,7 @@ parameters:
 
   # Use this to try new images e.g. 'cst' for image 'stanfordaha/garnet:cst'
   # If 'which_image' not set, defaults to "latest"
-  # which_image: cst
+  which_image: cst
 
 
 postconditions:

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -22,7 +22,7 @@ parameters:
 
   # Use this to try new images e.g. 'cst' for image 'stanfordaha/garnet:cst'
   # If 'which_image' not set, defaults to "latest"
-  which_image: cst
+  # which_image: cst
 
 
 postconditions:

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -20,10 +20,17 @@ parameters:
   # If true, clone garnet locally and copy into the container
   use_local_garnet: True
 
-  # Use this to try new images e.g. 'cst' for image 'stanfordaha/garnet:cst'
-  # If 'which_image' not set, defaults to "latest"
-  # which_image: cst
-
+  # To try out a new docker image e.g. 'stanfordaha/garnet:cst'
+  # - set 'save_verilog_to_tmpdir' to "True", then build (latest) rtl
+  # - set 'which_image' to "cst", then build (cst) rtl
+  # - should see before-and-after designs in /tmp directory:
+  # 
+  #   % ls -lt /tmp/design.v.*
+  #       1745336 Feb  5 10:47 design.v.cst.deleteme13246
+  #       1785464 Feb  5 10:39 design.v.latest.deleteme9962
+  #
+  # which_image: cst              # If not set, defaults to 'latest'
+  # save_verilog_to_tmpdir: True  # If true, copies final verilog to /tmp
 
 postconditions:
   - assert File( 'outputs/design.v' )        # must exist

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -13,8 +13,17 @@ parameters:
   interconnect_only: False
   soc_only: False
   PWR_AWARE: True
+
+  # If true, use docker container for python environment
   use_container: True
+
+  # If true, clone garnet locally and copy into the container
   use_local_garnet: True
+
+  # Use this to try new images e.g. 'cst' for image 'stanfordaha/garnet:cst'
+  # If 'which_image' not set, defaults to "latest"
+  # which_image: cst
+
 
 postconditions:
   - assert File( 'outputs/design.v' )        # must exist

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -153,3 +153,6 @@ else
     cd $current_dir
   fi
 fi
+
+cp outputs/design.v /tmp/design.v.deleteme$$
+

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -93,10 +93,9 @@ else
          # (Double-quote regime)
          source /aha/bin/activate; # Set up the build environment
 
-         # Double-check the current build environment.
-         # Example: say you want to double-check ast_tools, magma, and peak
-         # This will display the version, location and latest commit hash for each.
-         # Build garnet verilog; check and double-check cst packages
+         # Example: say you want to double-check packages 'ast_tools', 'magma', and 'peak'.
+         # Uncomment the line below; This will display the version,
+         # location and latest commit hash for each.
          # echo '+++ PIPCHECK-BEFORE'; checkpip ast.t magma 'peak '; echo '--- Continue build'
          
          aha garnet $flags; # Here is where we build the verilog for the main chip

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -39,10 +39,20 @@ else
       # docker pull stanfordaha/garnet:latest
       docker pull stanfordaha/garnet:cst
 
-      # run the container in the background and delete it when it exits
-      # (this will print out the name of the container to attach to)
-      container_name=$(aha docker)
-      echo "container-name: $container_name"
+
+
+
+#       # run the container in the background and delete it when it exits
+#       # (this will print out the name of the container to attach to)
+#       container_name=$(aha docker)
+#       echo "container-name: $container_name"
+
+
+
+      container_name=cst-test
+      # mount the /cad and name it, also run it as a daemon in background
+      docker run -d --name ${container_name} --rm -v /cad:/cad stanfordaha/garnet:cst bash
+
 
       if [ $use_local_garnet == True ]; then
         docker exec $container_name /bin/bash -c "rm -rf /aha/garnet"

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-START_DIR=$(pwd)
 # Hierarchical flows can accept RTL as an input from parent graph
 if [ -f ../inputs/design.v ]; then
   echo "Using RTL from parent graph"
@@ -27,7 +26,6 @@ else
 
     # Use aha docker container for all dependencies
     if [ $use_container == True ]; then
-        set -x
       # Clone AHA repo
       git clone https://github.com/StanfordAHA/aha.git
       cd aha
@@ -37,57 +35,28 @@ else
       # Prune docker images...
       yes | docker image prune -a --filter "until=6h" --filter=label='description=garnet' || true
 
-##############################################################################
-which_container=cst
-#which_container=latest
+      ##############################################################################
+      # steveri 02/2021 - Original code only supported container "latest";
+      # new code (below) allows use of any container
 
-# if [ "$which_container" == "latest" ]; then
-# 
-#    # ORIGINAL CODE
-#       # pull docker image from docker hub
-#       docker pull stanfordaha/garnet:latest
-# 
-#       # run the container in the background and delete it when it exits
-#       # (this will print out the name of the container to attach to)
-#       container_name=$(aha docker)
-#       echo "container-name: $container_name"
-# else
-# 
-#    # TEMPORARY CST-CHECK HACK
-#       # pull docker image from docker hub
-#       docker pull stanfordaha/garnet:cst
-# 
-#       # run the container in the background and delete it when it exits
-#       # (this will print out the name of the container to attach to)
-#       container_name=cst
-#       echo "container-name: $container_name"
-#       # mount the /cad and name it, also run it as a daemon in background
-#       docker run -id --name ${container_name} --rm -v /cad:/cad stanfordaha/garnet:cst bash
-# fi
-##############################################################################
+      which_container=cst
+      #which_container=latest
 
-
-
-
-# So...does this even work? No it does not!
-
-   # ORIGINAL CODE
       # pull docker image from docker hub
-      docker pull stanfordaha/garnet:cst
+      docker pull stanfordaha/garnet:${which_container}
 
-#       # run the container in the background and delete it when it exits
-#       # (this will print out the name of the container to attach to)
-#       container_name=$(aha docker)
-#       echo "container-name: $container_name"
-
-
-      container_name=cst
+      if [ "$which_container" == "latest" ]; then
+          # run the container in the background and delete it when it exits
+          # ("aha docker" will print out the name of the container to attach to)
+          container_name=$(aha docker)
+      else
+          # run the container in the background and delete it when it exits (--rm)
+          # mount /cad and name it, and run container as a daemon in background
+          container_name=${which_container}
+          docker run -id --name ${container_name} --rm -v /cad:/cad stanfordaha/garnet:cst bash
+      fi
       echo "container-name: $container_name"
-      # mount the /cad and name it, also run it as a daemon in background
-      docker run -id --name ${container_name} --rm -v /cad:/cad stanfordaha/garnet:cst bash
-
-
-
+      ##############################################################################
 
       if [ $use_local_garnet == True ]; then
         docker exec $container_name /bin/bash -c "rm -rf /aha/garnet"
@@ -100,9 +69,10 @@ which_container=cst
       # run garnet.py in container and concat all verilog outputs
       docker exec $container_name /bin/bash -c \
         '# Single-quote regime
-         echo sq
-         # Func to check python package creds
-         set -x
+
+         ###########################################################################
+         # Func to check python package creds (Added 02/2021 as part of cst vetting)
+
          function checkpip {
              # Example: checkpip ast.t "peak "
              #   ast-tools              0.0.18    /usr/local/venv_garnet/src/ast-tools
@@ -118,19 +88,15 @@ which_container=cst
              done
          }'"
          # Double-quote regime
-         echo dq
          source /aha/bin/activate
 
-         # Build garnet verilog; check to see that the right packages get used
+         # Build garnet verilog; check and double-check cst packages
          echo 'PIPCHECK1-BEFORE'; checkpip ast.t magma 'peak '
-         exit
-
-
          aha garnet $flags;
          echo 'PIPCHECK2-AFTER';  checkpip ast.t magma 'peak '
-         exit
+
          cd garnet
-         if [ -d \"genesis_verif\" ]; then
+         if [ -d 'genesis_verif' ]; then
            cp garnet.v genesis_verif/garnet.v
            cat genesis_verif/* >> design.v
          else
@@ -184,16 +150,3 @@ which_container=cst
     cd $current_dir
   fi
 fi
-
-echo ENDGAME
-set -x
-pwd
-current_dir=$(pwd)
-cd $START_DIR
-  # cp outputs/design.v /tmp/design.v.$$
-  # cp mflowgen-run.log /tmp/log.$$
-  pwd; ls -l outputs/design.v mflowgen-run.log
-  cp outputs/design.v /tmp/design.v.${which_container}.deleteme$$
-  cp mflowgen-run.log /tmp/cstlog.${which_container}.deleteme$$
-cd $current_dir
-set +x

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -91,27 +91,23 @@ which_container=cst
       fi
 
       # run garnet.py in container and concat all verilog outputs
-      docker exec $container_name /bin/bash -c "
-
-         set -x
-         # Func to check python package creds
+      docker exec $container_name /bin/bash -c \
+        '# Func to check python package creds
          function checkpip {
-             # Example: checkpip ast.t 'peak '
+             # Example: checkpip ast.t "peak "
              #   ast-tools              0.0.18    /usr/local/venv_garnet/src/ast-tools
              #   ee46bd4    Merged master into fork
              #   ---             
-             set -x
-             for p in \"$@\"; do
-                 echo .$p.
-                 if ! pip list -v |& egrep \"$p\";
-                 then echo \"Cannot find package '$p'\"; continue; fi
-                 src_dir=$(pip list -v |& grep $p | awk '{print $NF}')
-                 echo -n $(cd $src_dir; git log | head -1 | awk '{print substr($2,1,6)}' )
-                 (cd $src_dir; git log | egrep '^ ' | head -1)
-                 echo '---'
+             for p in "$@"; do
+                 if ! pip list -v |& egrep "$p";
+                 then echo "Cannot find package \"$p\""; continue; fi
+                 src_dir=$(pip list -v |& grep $p | awk "{print \$NF}")
+                 echo -n $(cd $src_dir; git log | head -1 | awk "{print substr(\$2,1,6)}" )
+                 (cd $src_dir; git log | egrep "^ " | head -1)
+                 echo "---"
              done
-         }
-         source /aha/bin/activate
+         }'\
+        "source /aha/bin/activate
 
          # Build garnet verilog; check to see that the right packages get used
          echo 'PIPCHECK1-BEFORE'; checkpip ast.t magma 'peak '

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -93,6 +93,7 @@ which_container=cst
       # run garnet.py in container and concat all verilog outputs
       docker exec $container_name /bin/bash -c \
         '# Func to check python package creds
+        set -x
          function checkpip {
              # Example: checkpip ast.t "peak "
              #   ast-tools              0.0.18    /usr/local/venv_garnet/src/ast-tools
@@ -116,7 +117,7 @@ which_container=cst
 
          aha garnet $flags;
          echo 'PIPCHECK2-AFTER';  checkpip ast.t magma 'peak '
-
+         exit
          cd garnet
          if [ -d \"genesis_verif\" ]; then
            cp garnet.v genesis_verif/garnet.v

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -64,22 +64,22 @@ else
          echo PIP PIP HOORAY BEGIN ----------------
          pip list -v | egrep 'ast|peak|magma'
          echo PIP PIP HOORAY MIDDLE ----------------
-         echo ast_tools check; (cd /aha/ast_tools; git log | head) || echo FAIL
-         echo magma     check; (cd /aha/magma;     git log | head) || echo FAIL
-         echo peak      check; (cd /aha/peak;      git log | head) || echo FAIL
+         echo ast_tools check; (cd /aha/ast_tools; git log | head -6) || echo FAIL
+         echo magma     check; (cd /aha/magma;     git log | head -6) || echo FAIL
+         echo peak      check; (cd /aha/peak;      git log | head -6) || echo FAIL
          echo PIP PIP HOORAY END --------------------
 
-pip install -U --exists-action s -e git://github.com/phanrahan/magma.git@cst#egg=magma-lang
-pip install -U --exists-action s -e git://github.com/cdonovan/peak.git@cst#egg=peak
 pip install -U --exists-action s -e git://github.com/leonardt/ast_tools.git@cst#egg=ast_tools
+pip install -U --exists-action s -e git://github.com/phanrahan/magma.git@cst#egg=magma-lang
+pip install -U --exists-action s -e git://github.com/cdonovick/peak.git@cst#egg=peak
 
 
          echo PIP PIP HOORAY BEGIN2 ----------------
          pip list -v | egrep 'ast|peak|magma'
          echo PIP PIP HOORAY MIDDLE2 ----------------
-         echo ast_tools check; (cd /aha/src/ast-tools; git log | head) || echo FAIL
-         echo magma     check; (cd /aha/src/magma;     git log | head) || echo FAIL
-         echo peak      check; (cd /aha/peak;          git log | head) || echo FAIL
+         echo ast_tools check; (cd /aha/src/ast-tools; git log | head -6) || echo FAIL
+         echo magma     check; (cd /aha/src/magma-lang;git log | head -6) || echo FAIL
+         echo peak      check; (cd /aha/peak;          git log | head -6) || echo FAIL
          echo PIP PIP HOORAY END2 --------------------
 
          aha garnet $flags;
@@ -88,9 +88,9 @@ pip install -U --exists-action s -e git://github.com/leonardt/ast_tools.git@cst#
          echo PIP PIP HOORAY BEGIN3 ----------------
          pip list -v | egrep 'ast|peak|magma'
          echo PIP PIP HOORAY MIDDLE3 ----------------
-         echo ast_tools check; (cd /aha/src/ast-tools; git log | head) || echo FAIL
-         echo magma     check; (cd /aha/src/magma;     git log | head) || echo FAIL
-         echo peak      check; (cd /aha/peak;          git log | head) || echo FAIL
+         echo ast_tools check; (cd /aha/src/ast-tools; git log | head -6) || echo FAIL
+         echo magma     check; (cd /aha/src/magma-lang;git log | head -6) || echo FAIL
+         echo peak      check; (cd /aha/peak;          git log | head -6) || echo FAIL
          echo PIP PIP HOORAY END3 --------------------
 
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -39,8 +39,9 @@ else
 
 
 ##############################################################################
-#which_container=latest
-which_container=cst
+#which_container=cst
+which_container=latest
+
 if [ "$which_container" == "latest" ]; then
 
    # ORIGINAL CODE

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -38,8 +38,8 @@ else
 
 
 ##############################################################################
-# which_container=latest
-which_container=cst
+#which_container=cst
+which_container=latest
 if [ "$which_container" == "latest" ]; then
 
    # ORIGINAL CODE

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -79,7 +79,7 @@ pip install -U --exists-action s -e git://github.com/cdonovick/peak.git@cst#egg=
          echo PIP PIP HOORAY MIDDLE2 ----------------
          echo ast_tools check; (cd /aha/src/ast-tools; git log | head -6) || echo FAIL
          echo magma     check; (cd /aha/src/magma-lang;git log | head -6) || echo FAIL
-         echo peak      check; (cd /aha/peak;          git log | head -6) || echo FAIL
+         echo peak      check; (cd /aha/src/peak;      git log | head -6) || echo FAIL
          echo PIP PIP HOORAY END2 --------------------
 
          aha garnet $flags;
@@ -90,7 +90,7 @@ pip install -U --exists-action s -e git://github.com/cdonovick/peak.git@cst#egg=
          echo PIP PIP HOORAY MIDDLE3 ----------------
          echo ast_tools check; (cd /aha/src/ast-tools; git log | head -6) || echo FAIL
          echo magma     check; (cd /aha/src/magma-lang;git log | head -6) || echo FAIL
-         echo peak      check; (cd /aha/peak;          git log | head -6) || echo FAIL
+         echo peak      check; (cd /aha/src/peak;      git log | head -6) || echo FAIL
          echo PIP PIP HOORAY END3 --------------------
 
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -62,11 +62,11 @@ else
 
 
          echo PIP PIP HOORAY BEGIN ----------------
-         pip list -v
+         pip list -v | egrep 'ast|peak|magma'
          echo PIP PIP HOORAY MIDDLE ----------------
-         echo peak      check; (cd /aha/peak;      git log | head) || echo FAIL
-         echo magma     check; (cd /aha/magma;     git log | head) || echo FAIL
          echo ast_tools check; (cd /aha/ast_tools; git log | head) || echo FAIL
+         echo magma     check; (cd /aha/magma;     git log | head) || echo FAIL
+         echo peak      check; (cd /aha/peak;      git log | head) || echo FAIL
          echo PIP PIP HOORAY END --------------------
 
 pip install -U --exists-action s -e git://github.com/phanrahan/magma.git@cst#egg=magma-lang
@@ -75,22 +75,22 @@ pip install -U --exists-action s -e git://github.com/leonardt/ast_tools.git@cst#
 
 
          echo PIP PIP HOORAY BEGIN2 ----------------
-         pip list -v
+         pip list -v | egrep 'ast|peak|magma'
          echo PIP PIP HOORAY MIDDLE2 ----------------
-         echo peak      check; (cd /aha/peak;      git log | head) || echo FAIL
-         echo magma     check; (cd /aha/magma;     git log | head) || echo FAIL
-         echo ast_tools check; (cd /aha/ast_tools; git log | head) || echo FAIL
+         echo ast_tools check; (cd /aha/src/ast-tools; git log | head) || echo FAIL
+         echo magma     check; (cd /aha/src/magma;     git log | head) || echo FAIL
+         echo peak      check; (cd /aha/peak;          git log | head) || echo FAIL
          echo PIP PIP HOORAY END2 --------------------
 
          aha garnet $flags;
 
 
          echo PIP PIP HOORAY BEGIN3 ----------------
-         pip list -v
+         pip list -v | egrep 'ast|peak|magma'
          echo PIP PIP HOORAY MIDDLE3 ----------------
-         echo peak      check; (cd /aha/peak;      git log | head) || echo FAIL
-         echo magma     check; (cd /aha/magma;     git log | head) || echo FAIL
-         echo ast_tools check; (cd /aha/ast_tools; git log | head) || echo FAIL
+         echo ast_tools check; (cd /aha/src/ast-tools; git log | head) || echo FAIL
+         echo magma     check; (cd /aha/src/magma;     git log | head) || echo FAIL
+         echo peak      check; (cd /aha/peak;          git log | head) || echo FAIL
          echo PIP PIP HOORAY END3 --------------------
 
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -48,6 +48,12 @@ else
       # pull docker image from docker hub
       docker pull stanfordaha/garnet:${which_image}
 
+      # Display ID info for image e.g.
+      #     RepoTags    [stanfordaha/garnet:latest]
+      #     RepoDigests [stanfordaha/garnet@sha256:e43c853b4068992...]
+      docker inspect --format='RepoTags    {{.RepoTags}}'    stanfordaha/garnet:${which_image}
+      docker inspect --format='RepoDigests {{.RepoDigests}}' stanfordaha/garnet:${which_image}
+
       if [ "$which_image" == "latest" ]; then
           # run the container in the background and delete it when it exits
           # ("aha docker" will print out the name of the container to attach to)

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -27,7 +27,7 @@ else
     # Use aha docker container for all dependencies
     if [ $use_container == True ]; then
       # Clone AHA repo
-      git clone https://github.com/StanfordAHA/aha.git
+      git clone -b cst https://github.com/StanfordAHA/aha.git
       cd aha
       # install the aha wrapper script
       pip install -e .
@@ -54,6 +54,15 @@ else
       # run garnet.py in container and concat all verilog outputs
       docker exec $container_name /bin/bash -c \
         "source /aha/bin/activate && aha garnet $flags;
+
+         echo PIP PIP HOORAY BEGIN ----------------
+         pip list -v
+         echo PIP PIP HOORAY MIDDLE ----------------
+         echo peak      check; (cd /aha/peak;      git log | head) || echo FAIL
+         echo magma     check; (cd /aha/magma;     git log | head) || echo FAIL
+         echo ast_tools check; (cd /aha/ast_tools; git log | head) || echo FAIL
+         echo PIP PIP HOORAY END --------------------
+
          cd garnet
          if [ -d "genesis_verif" ]; then
            cp garnet.v genesis_verif/garnet.v

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -27,7 +27,7 @@ else
     # Use aha docker container for all dependencies
     if [ $use_container == True ]; then
       # Clone AHA repo
-      git clone -b cst https://github.com/StanfordAHA/aha.git
+      git clone https://github.com/StanfordAHA/aha.git
       cd aha
       # install the aha wrapper script
       pip install -e .
@@ -36,7 +36,8 @@ else
       yes | docker image prune -a --filter "until=6h" --filter=label='description=garnet' || true
 
       # pull docker image from docker hub
-      docker pull stanfordaha/garnet:latest
+      # docker pull stanfordaha/garnet:latest
+      docker pull stanfordaha/garnet:cst
 
       # run the container in the background and delete it when it exits
       # (this will print out the name of the container to attach to)
@@ -58,9 +59,6 @@ else
          # source /aha/bin/activate && aha garnet $flags;
          source /aha/bin/activate
 
-
-
-
          echo PIP PIP HOORAY BEGIN ----------------
          pip list -v | egrep 'ast|peak|magma'
          echo PIP PIP HOORAY MIDDLE ----------------
@@ -69,31 +67,19 @@ else
          echo peak      check; (cd /aha/peak;      git log | head -6) || echo FAIL
          echo PIP PIP HOORAY END --------------------
 
-pip install -U --exists-action s -e git://github.com/leonardt/ast_tools.git@cst#egg=ast_tools
-pip install -U --exists-action s -e git://github.com/phanrahan/magma.git@cst#egg=magma-lang
-pip install -U --exists-action s -e git://github.com/cdonovick/peak.git@cst#egg=peak
+# pip install -U --exists-action s -e git://github.com/leonardt/ast_tools.git@cst#egg=ast_tools
+# pip install -U --exists-action s -e git://github.com/phanrahan/magma.git@cst#egg=magma-lang
+# pip install -U --exists-action s -e git://github.com/cdonovick/peak.git@cst#egg=peak
 
+         aha garnet $flags;
 
          echo PIP PIP HOORAY BEGIN2 ----------------
          pip list -v | egrep 'ast|peak|magma'
          echo PIP PIP HOORAY MIDDLE2 ----------------
-         echo ast_tools check; (cd /aha/src/ast-tools; git log | head -6) || echo FAIL
-         echo magma     check; (cd /aha/src/magma-lang;git log | head -6) || echo FAIL
-         echo peak      check; (cd /aha/src/peak;      git log | head -6) || echo FAIL
+         echo ast_tools check; (cd /aha/ast_tools; git log | head -6) || echo FAIL
+         echo magma     check; (cd /aha/magma;     git log | head -6) || echo FAIL
+         echo peak      check; (cd /aha/peak;      git log | head -6) || echo FAIL
          echo PIP PIP HOORAY END2 --------------------
-
-         aha garnet $flags;
-
-
-         echo PIP PIP HOORAY BEGIN3 ----------------
-         pip list -v | egrep 'ast|peak|magma'
-         echo PIP PIP HOORAY MIDDLE3 ----------------
-         echo ast_tools check; (cd /aha/src/ast-tools; git log | head -6) || echo FAIL
-         echo magma     check; (cd /aha/src/magma-lang;git log | head -6) || echo FAIL
-         echo peak      check; (cd /aha/src/peak;      git log | head -6) || echo FAIL
-         echo PIP PIP HOORAY END3 --------------------
-
-
 
          cd garnet
          if [ -d "genesis_verif" ]; then

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -96,9 +96,9 @@ else
          source /aha/bin/activate
 
          # Build garnet verilog; check and double-check cst packages
-         echo 'PIPCHECK1-BEFORE'; checkpip ast.t magma 'peak '
+         echo '+++ PIPCHECK1-BEFORE'; checkpip ast.t magma 'peak '; echo '--- Continue build'
          aha garnet $flags;
-         echo 'PIPCHECK2-AFTER';  checkpip ast.t magma 'peak '
+         echo '+++ PIPCHECK2-AFTER';  checkpip ast.t magma 'peak '; echo '--- Continue build'
 
          cd garnet
          if [ -d 'genesis_verif' ]; then

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -160,6 +160,13 @@ fi
   fi
 fi
 
-cp outputs/design.v /tmp/design.v.${which_container}.deleteme$$
-cp mflowgen-run.log /tmp/cstlog.${which_container}.deleteme$$
-
+current_dir=$(pwd)
+cd $START_DIR
+  # cp outputs/design.v /tmp/design.v.$$
+  # cp mflowgen-run.log /tmp/log.$$
+  pwd; ls -l outputs/design.v mflowgen-run.log
+  set -x
+  cp outputs/design.v /tmp/design.v.${which_container}.deleteme$$
+  cp mflowgen-run.log /tmp/cstlog.${which_container}.deleteme$$
+  set +x
+cd $current_dir

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -76,9 +76,11 @@ else
 
          function checkpip {
              # Example: checkpip ast.t "peak "
-             #   ast-tools              0.0.18    /usr/local/venv_garnet/src/ast-tools
-             #   ee46bd4    Merged master into fork
-             #   ---             
+             #   ast-tools           0.0.30    /aha/ast_tools
+             #   6b779e    Merge pull request #70 from leonardt/arg-fix
+             #   ---
+             #   peak                0.0.1     /aha/peak
+             #   fa4635    Move to libcst
              for p in "$@"; do
                  if ! pip list -v |& egrep "$p";
                  then echo "Cannot find package \"$p\""; continue; fi

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -38,16 +38,21 @@ else
 
 
 ##############################################################################
-# ORIGINAL CODE
-#       # pull docker image from docker hub
-#       docker pull stanfordaha/garnet:latest
-# 
-#       # run the container in the background and delete it when it exits
-#       # (this will print out the name of the container to attach to)
-#       container_name=$(aha docker)
-#       echo "container-name: $container_name"
+# which_container=latest
+which_container=cst
+if [ "$which_container" == "latest" ]; then
 
-# TEMPORARY CST-CHECK HACK
+   # ORIGINAL CODE
+      # pull docker image from docker hub
+      docker pull stanfordaha/garnet:latest
+
+      # run the container in the background and delete it when it exits
+      # (this will print out the name of the container to attach to)
+      container_name=$(aha docker)
+      echo "container-name: $container_name"
+else
+
+   # TEMPORARY CST-CHECK HACK
       # pull docker image from docker hub
       docker pull stanfordaha/garnet:cst
 
@@ -57,6 +62,7 @@ else
       echo "container-name: $container_name"
       # mount the /cad and name it, also run it as a daemon in background
       docker run -id --name ${container_name} --rm -v /cad:/cad stanfordaha/garnet:cst bash
+fi
 ##############################################################################
 
 
@@ -154,5 +160,6 @@ else
   fi
 fi
 
-cp outputs/design.v /tmp/design.v.deleteme$$
+cp outputs/design.v /tmp/design.v.${which_container}.deleteme$$
+cp mflowgen-run.log /tmp/cstlog.${which_container}.deleteme$$
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -38,8 +38,8 @@ else
 
 
 ##############################################################################
-#which_container=cst
-which_container=latest
+#which_container=latest
+which_container=cst
 if [ "$which_container" == "latest" ]; then
 
    # ORIGINAL CODE

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -99,7 +99,9 @@ which_container=cst
              #   ast-tools              0.0.18    /usr/local/venv_garnet/src/ast-tools
              #   ee46bd4    Merged master into fork
              #   ---             
-             for p in \"$@\"; do 
+             set -x
+             for p in \"$@\"; do
+                 echo .$p.
                  if ! pip list -v |& egrep \"$p\";
                  then echo \"Cannot find package '$p'\"; continue; fi
                  src_dir=$(pip list -v |& grep $p | awk '{print $NF}')
@@ -112,6 +114,9 @@ which_container=cst
 
          # Build garnet verilog; check to see that the right packages get used
          echo 'PIPCHECK1-BEFORE'; checkpip ast.t magma 'peak '
+         exit
+
+
          aha garnet $flags;
          echo 'PIPCHECK2-AFTER';  checkpip ast.t magma 'peak '
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+START_DIR=$(pwd)
 # Hierarchical flows can accept RTL as an input from parent graph
 if [ -f ../inputs/design.v ]; then
   echo "Using RTL from parent graph"
@@ -160,13 +161,15 @@ fi
   fi
 fi
 
+echo ENDGAME
+set -x
+pwd
 current_dir=$(pwd)
 cd $START_DIR
   # cp outputs/design.v /tmp/design.v.$$
   # cp mflowgen-run.log /tmp/log.$$
   pwd; ls -l outputs/design.v mflowgen-run.log
-  set -x
   cp outputs/design.v /tmp/design.v.${which_container}.deleteme$$
   cp mflowgen-run.log /tmp/cstlog.${which_container}.deleteme$$
-  set +x
 cd $current_dir
+set +x

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -53,7 +53,13 @@ else
 
       # run garnet.py in container and concat all verilog outputs
       docker exec $container_name /bin/bash -c \
-        "source /aha/bin/activate && aha garnet $flags;
+        "
+
+         # source /aha/bin/activate && aha garnet $flags;
+         source /aha/bin/activate
+
+
+
 
          echo PIP PIP HOORAY BEGIN ----------------
          pip list -v
@@ -62,6 +68,32 @@ else
          echo magma     check; (cd /aha/magma;     git log | head) || echo FAIL
          echo ast_tools check; (cd /aha/ast_tools; git log | head) || echo FAIL
          echo PIP PIP HOORAY END --------------------
+
+pip install -U --exists-action s -e git://github.com/phanrahan/magma.git@cst#egg=magma-lang
+pip install -U --exists-action s -e git://github.com/cdonovan/peak.git@cst#egg=peak
+pip install -U --exists-action s -e git://github.com/leonardt/ast_tools.git@cst#egg=ast_tools
+
+
+         echo PIP PIP HOORAY BEGIN2 ----------------
+         pip list -v
+         echo PIP PIP HOORAY MIDDLE2 ----------------
+         echo peak      check; (cd /aha/peak;      git log | head) || echo FAIL
+         echo magma     check; (cd /aha/magma;     git log | head) || echo FAIL
+         echo ast_tools check; (cd /aha/ast_tools; git log | head) || echo FAIL
+         echo PIP PIP HOORAY END2 --------------------
+
+         aha garnet $flags;
+
+
+         echo PIP PIP HOORAY BEGIN3 ----------------
+         pip list -v
+         echo PIP PIP HOORAY MIDDLE3 ----------------
+         echo peak      check; (cd /aha/peak;      git log | head) || echo FAIL
+         echo magma     check; (cd /aha/magma;     git log | head) || echo FAIL
+         echo ast_tools check; (cd /aha/ast_tools; git log | head) || echo FAIL
+         echo PIP PIP HOORAY END3 --------------------
+
+
 
          cd garnet
          if [ -d "genesis_verif" ]; then

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -99,8 +99,10 @@ which_container=cst
 
       # run garnet.py in container and concat all verilog outputs
       docker exec $container_name /bin/bash -c \
-        '# Func to check python package creds
-        set -x
+        '# Single-quote regime
+         echo sq
+         # Func to check python package creds
+         set -x
          function checkpip {
              # Example: checkpip ast.t "peak "
              #   ast-tools              0.0.18    /usr/local/venv_garnet/src/ast-tools
@@ -114,8 +116,10 @@ which_container=cst
                  (cd $src_dir; git log | egrep "^ " | head -1)
                  echo "---"
              done
-         }'\
-        "source /aha/bin/activate
+         }'"
+         # Double-quote regime
+         echo dq
+         source /aha/bin/activate
 
          # Build garnet verilog; check to see that the right packages get used
          echo 'PIPCHECK1-BEFORE'; checkpip ast.t magma 'peak '

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -35,23 +35,31 @@ else
       # Prune docker images...
       yes | docker image prune -a --filter "until=6h" --filter=label='description=garnet' || true
 
-      # pull docker image from docker hub
-      # docker pull stanfordaha/garnet:latest
-      docker pull stanfordaha/garnet:cst
 
 
-
-
+##############################################################################
+# ORIGINAL CODE
+#       # pull docker image from docker hub
+#       docker pull stanfordaha/garnet:latest
+# 
 #       # run the container in the background and delete it when it exits
 #       # (this will print out the name of the container to attach to)
 #       container_name=$(aha docker)
 #       echo "container-name: $container_name"
 
+# TEMPORARY CST-CHECK HACK
+      # pull docker image from docker hub
+      docker pull stanfordaha/garnet:cst
 
-
-      container_name=cst-test
+      # run the container in the background and delete it when it exits
+      # (this will print out the name of the container to attach to)
+      container_name=cst
+      echo "container-name: $container_name"
       # mount the /cad and name it, also run it as a daemon in background
-      docker run -d --name ${container_name} --rm -v /cad:/cad stanfordaha/garnet:cst bash
+      docker run -id --name ${container_name} --rm -v /cad:/cad stanfordaha/garnet:cst bash
+##############################################################################
+
+
 
 
       if [ $use_local_garnet == True ]; then
@@ -65,31 +73,31 @@ else
       # run garnet.py in container and concat all verilog outputs
       docker exec $container_name /bin/bash -c \
         "
-
          # source /aha/bin/activate && aha garnet $flags;
          source /aha/bin/activate
 
-         echo PIP PIP HOORAY BEGIN ----------------
-         pip list -v | egrep 'ast|peak|magma'
-         echo PIP PIP HOORAY MIDDLE ----------------
-         echo ast_tools check; (cd /aha/ast_tools; git log | head -6) || echo FAIL
-         echo magma     check; (cd /aha/magma;     git log | head -6) || echo FAIL
-         echo peak      check; (cd /aha/peak;      git log | head -6) || echo FAIL
-         echo PIP PIP HOORAY END --------------------
+         echo PIPCHECK BEGIN ----------------
+         pip list -v |& egrep 'ast.t|peak|magma'
+         echo ----------------
+         echo ast_tools check; (cd /aha/ast_tools; git log | grep . | head -6); echo "---"
+         echo magma     check; (cd /aha/magma;     git log | grep . | head -6); echo "---"
+         echo peak      check; (cd /aha/peak;      git log | grep . | head -6); echo "---"
+         echo PIPCHECK END --------------------
 
-# pip install -U --exists-action s -e git://github.com/leonardt/ast_tools.git@cst#egg=ast_tools
-# pip install -U --exists-action s -e git://github.com/phanrahan/magma.git@cst#egg=magma-lang
-# pip install -U --exists-action s -e git://github.com/cdonovick/peak.git@cst#egg=peak
+# alias piu='pip install -U --exists-action s -e'
+# piu git://github.com/leonardt/ast_tools.git@cst#egg=ast_tools
+# piu git://github.com/phanrahan/magma.git@cst#egg=magma-lang
+# piu git://github.com/cdonovick/peak.git@cst#egg=peak
 
          aha garnet $flags;
 
-         echo PIP PIP HOORAY BEGIN2 ----------------
-         pip list -v | egrep 'ast|peak|magma'
-         echo PIP PIP HOORAY MIDDLE2 ----------------
-         echo ast_tools check; (cd /aha/ast_tools; git log | head -6) || echo FAIL
-         echo magma     check; (cd /aha/magma;     git log | head -6) || echo FAIL
-         echo peak      check; (cd /aha/peak;      git log | head -6) || echo FAIL
-         echo PIP PIP HOORAY END2 --------------------
+         echo PIPCHECK BEGIN2 ----------------
+         pip list -v |& egrep 'ast.t|peak|magma'
+         echo ----------------
+         echo ast_tools check; (cd /aha/ast_tools; git log | grep . | head -6); echo "---"
+         echo magma     check; (cd /aha/magma;     git log | grep . | head -6); echo "---"
+         echo peak      check; (cd /aha/peak;      git log | grep . | head -6); echo "---"
+         echo PIPCHECK END2 --------------------
 
          cd garnet
          if [ -d "genesis_verif" ]; then

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -27,6 +27,7 @@ else
 
     # Use aha docker container for all dependencies
     if [ $use_container == True ]; then
+        set -x
       # Clone AHA repo
       git clone https://github.com/StanfordAHA/aha.git
       cd aha
@@ -68,16 +69,22 @@ which_container=cst
 
 
 
-# So...does this even work?
+# So...does this even work? No it does not!
 
    # ORIGINAL CODE
       # pull docker image from docker hub
       docker pull stanfordaha/garnet:cst
 
-      # run the container in the background and delete it when it exits
-      # (this will print out the name of the container to attach to)
-      container_name=$(aha docker)
+#       # run the container in the background and delete it when it exits
+#       # (this will print out the name of the container to attach to)
+#       container_name=$(aha docker)
+#       echo "container-name: $container_name"
+
+
+      container_name=cst
       echo "container-name: $container_name"
+      # mount the /cad and name it, also run it as a daemon in background
+      docker run -id --name ${container_name} --rm -v /cad:/cad stanfordaha/garnet:cst bash
 
 
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -93,6 +93,7 @@ which_container=cst
       # run garnet.py in container and concat all verilog outputs
       docker exec $container_name /bin/bash -c "
 
+         set -x
          # Func to check python package creds
          function checkpip {
              # Example: checkpip ast.t 'peak '


### PR DESCRIPTION
These changes are designed to make it easier for me to test out new docker images, e.g. the recent request from Caleb to approve new image `stanfordaha/garnet:cst` (https://github.com/StanfordAHA/aha/pull/1099).

You'll see instructions for how to use these new changes embedded in `common/rtl/configure.yml` comments:
```
  # To try out a new docker image e.g. 'stanfordaha/garnet:cst'
  # - set 'save_verilog_to_tmpdir' to "True", then build (latest) rtl
  # - set 'which_image' to "cst", then build (cst) rtl
  # - should see before-and-after designs in /tmp directory:
  # 
  #   % ls -lt /tmp/design.v.*
  #       1745336 Feb  5 10:47 design.v.cst.deleteme13246
  #       1785464 Feb  5 10:39 design.v.latest.deleteme9962
```

The new code is turned off by default, so no real changes to master will occur as a result of this merge, it just enables a new/simpler mechanism for trying out new docker images when/if desired.


