### PR TITLE
Update bump_type map to make consistent with package

### DIFF
--- a/mflowgen/common/init-fullchip/outputs/gen-bumps.tcl
+++ b/mflowgen/common/init-fullchip/outputs/gen-bumps.tcl
@@ -116,7 +116,7 @@ proc gen_bumps {} {
 	"osbssrr444555555666rrssbso"
 	"gsssgsssssbssssbsssssgsssg"
 	"sssgssssgssssssssgssssgsss"
-	"sgossbssssoobboosssgbssogs"
+	"sgossbgsssoobboosssgbssogs"
 	"bogsssssssggssggsssssssgob"
 	".b.sgosbsgssggssgsbsogssb."
     }


### PR DESCRIPTION
Fixes error in bump_type map that caused a normal signal to be routed to a ground bump in the taped out chip.