### PR TITLE
Fix spef name for post-synth power

### DIFF
--- a/mflowgen/common/synopsys-ptpx-synth/configure.yml
+++ b/mflowgen/common/synopsys-ptpx-synth/configure.yml
@@ -17,7 +17,7 @@ inputs:
   - adk
   - design.v
   - design.sdc
-  - design.spef.gz
+  - design.spef
   - run.saif
 
 outputs:

--- a/mflowgen/common/synopsys-ptpx-synth/designer-interface.tcl
+++ b/mflowgen/common/synopsys-ptpx-synth/designer-interface.tcl
@@ -36,7 +36,7 @@ foreach bc_lib $corner_libs {
 set ptpx_gl_netlist         inputs/design.v
 
 set ptpx_sdc                inputs/design.sdc
-set ptpx_spef               inputs/design.spef.gz
+set ptpx_spef               inputs/design.spef
 set ptpx_saif               inputs/run.saif
 
 # The strip path must be defined!


### PR DESCRIPTION
Synthesis outputs a `design.spef`, not `design.spef.gz`.