### PR TITLE
Switch all stdview adk views to view-standard

### DIFF
--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -21,7 +21,7 @@ def construct():
   #-----------------------------------------------------------------------
 
   adk_name = 'tsmc16'
-  adk_view = 'stdview'
+  adk_view = 'view-standard'
 
   if which("calibre") is not None:
       drc_rule_deck = 'calibre-drc-chip.rule'

--- a/mflowgen/glb_top/construct.py
+++ b/mflowgen/glb_top/construct.py
@@ -21,7 +21,7 @@ def construct():
   #-----------------------------------------------------------------------
 
   adk_name = 'tsmc16'
-  adk_view = 'stdview'
+  adk_view = 'view-standard'
 
   parameters = {
     'construct_path' : __file__,

--- a/mflowgen/icovl/construct.py
+++ b/mflowgen/icovl/construct.py
@@ -17,7 +17,7 @@ def construct():
   #-----------------------------------------------------------------------
 
   adk_name = 'tsmc16'
-  adk_view = 'stdview'
+  adk_view = 'view-standard'
 
   parameters = {
     'construct_path'    : __file__,
@@ -32,7 +32,7 @@ def construct():
     #
     # drc
     # drc_rule_deck: /sim/steveri/runsets/ruleset_icovl # NO GOOD instead do:
-    # cd ../adks/tsmc16-adk/stdview; ln -s /sim/steveri/runsets/ruleset_icovl
+    # cd ../adks/tsmc16-adk/view-standard; ln -s /sim/steveri/runsets/ruleset_icovl
     'drc_rule_deck'     : 'ruleset_icovl',
   }
 

--- a/mflowgen/pad_frame/construct.py
+++ b/mflowgen/pad_frame/construct.py
@@ -17,7 +17,7 @@ def construct():
   #-----------------------------------------------------------------------
 
   adk_name = 'tsmc16'
-  adk_view = 'stdview'
+  adk_view = 'view-standard'
 
   parameters = {
     'construct_path'    : __file__,

--- a/mflowgen/regressions/tile-pe-clock-gate/construct.py
+++ b/mflowgen/regressions/tile-pe-clock-gate/construct.py
@@ -20,7 +20,7 @@ def construct():
   #-----------------------------------------------------------------------
 
   adk_name = 'tsmc16'
-  adk_view = 'stdview'
+  adk_view = 'view-standard'
 
   parameters = {
     'construct_path'    : __file__,

--- a/mflowgen/soc/construct.py
+++ b/mflowgen/soc/construct.py
@@ -21,7 +21,7 @@ def construct():
   #-----------------------------------------------------------------------
 
   adk_name = 'tsmc16'
-  adk_view = 'stdview'
+  adk_view = 'view-standard'
 
   parameters = {
     'construct_path'    : __file__,


### PR DESCRIPTION
I've finally updated the tsmc16 adk to be consistent with the mflowgen convention of calling the default adk view "view-standard" instead of "stdview", so this PR just changes all the flows using stdview to view-standard. For this PR to work, you'll need the latest version of the adk.