### PR TITLE
Change halide input/output file extension from raw to pgm

### DIFF
--- a/tests/test_app/kernel.sv
+++ b/tests/test_app/kernel.sv
@@ -210,7 +210,14 @@ endfunction
 function data_array_t Kernel::parse_input_data(int idx);
     data_array_t result = new[input_size[idx]];
     int fp = $fopen(input_filenames[idx], "rb");
+    int name_len = input_filenames[idx].len();
     assert_(fp != 0, "Unable to read input file");
+    if (input_filenames[idx].substr(name_len-3, name_len-1) == "pgm") begin
+        // just skip the first three lines
+        for (int i = 0; i < 3; i++) begin
+             $fscanf(fp, "%*[^\n]\n");
+        end
+    end
     for (int i = 0; i < input_size[idx]; i++) begin
         byte unsigned value;
         int code;
@@ -225,7 +232,14 @@ endfunction
 function data_array_t Kernel::parse_gold_data(int idx);
     data_array_t result = new[output_size[idx]];
     int fp = $fopen(output_filenames[idx], "rb");
+    int name_len = output_filenames[idx].len();
     assert_(fp != 0, "Unable to read output file");
+    if (output_filenames[idx].substr(name_len-3, name_len-1) == "pgm") begin
+        // just skip the first three lines
+        for (int i = 0; i < 3; i++) begin
+             $fscanf(fp, "%*[^\n]\n");
+        end
+    end
     for (int i = 0; i < output_size[idx]; i++) begin
         byte unsigned value;
         int code;

--- a/tests/test_app/kernel.sv
+++ b/tests/test_app/kernel.sv
@@ -181,7 +181,8 @@ function Kernel::new(string app_dir);
         output_filenames[i] = get_output_filename(kernel_info, i);
         output_size[i] = get_output_size(place_info, i);
         gold_data[i] = parse_gold_data(i);
-        output_data[i] = new[output_size[i]];
+	// convert 8bit size to 16bit size
+        output_data[i] = new[(output_size[i]>>1)];
     end
 
     bs_size = get_bs_size(bs_info);
@@ -208,45 +209,55 @@ function bitstream_t Kernel::parse_bitstream();
 endfunction
 
 function data_array_t Kernel::parse_input_data(int idx);
-    data_array_t result = new[input_size[idx]];
+    int num_pixel = (input_size[idx] >> 1); // Pixel is 2byte (16bit) size
+    data_array_t result = new[num_pixel];
     int fp = $fopen(input_filenames[idx], "rb");
     int name_len = input_filenames[idx].len();
+    string tmp;
+    int code;
     assert_(fp != 0, "Unable to read input file");
     if (input_filenames[idx].substr(name_len-3, name_len-1) == "pgm") begin
         // just skip the first three lines
         for (int i = 0; i < 3; i++) begin
-             $fscanf(fp, "%*[^\n]\n");
+             $fgets(tmp, fp);
         end
     end
-    for (int i = 0; i < input_size[idx]; i++) begin
-        byte unsigned value;
-        int code;
-        code = $fread(value, fp);
-        assert_(code == 1, $sformatf("Unable to read input data"));
-        result[i] = value;
-    end
+    code = $fread(result, fp);
+    assert_(code == input_size[idx], $sformatf("Unable to read input data"));
+    // for (int i = 0; i < input_size[idx]; i++) begin
+    //     byte unsigned value;
+    //     int code;
+    //     code = $fread(value, fp);
+    //     assert_(code == 1, $sformatf("Unable to read input data"));
+    //     result[i] = value;
+    // end
     $fclose(fp);
     return result;
 endfunction
 
 function data_array_t Kernel::parse_gold_data(int idx);
-    data_array_t result = new[output_size[idx]];
+    int num_pixel = (output_size[idx] >> 1); // Pixel is 2byte (16bit) size
+    data_array_t result = new[num_pixel];
     int fp = $fopen(output_filenames[idx], "rb");
     int name_len = output_filenames[idx].len();
+    string tmp;
+    int code;
     assert_(fp != 0, "Unable to read output file");
     if (output_filenames[idx].substr(name_len-3, name_len-1) == "pgm") begin
         // just skip the first three lines
         for (int i = 0; i < 3; i++) begin
-             $fscanf(fp, "%*[^\n]\n");
+             $fgets(tmp, fp);
         end
     end
-    for (int i = 0; i < output_size[idx]; i++) begin
-        byte unsigned value;
-        int code;
-        code = $fread(value, fp);
-        assert_(code == 1, $sformatf("Unable to read output data"));
-        result[i] = value;
-    end
+    code = $fread(result, fp);
+    assert_(code == output_size[idx], $sformatf("Unable to read output data"));
+    // for (int i = 0; i < output_size[idx]; i++) begin
+    //     byte unsigned value;
+    //     int code;
+    //     code = $fread(value, fp);
+    //     assert_(code == 1, $sformatf("Unable to read output data"));
+    //     result[i] = value;
+    // end
     $fclose(fp);
     return result;
 endfunction

--- a/tests/test_app/kernel.sv
+++ b/tests/test_app/kernel.sv
@@ -224,13 +224,6 @@ function data_array_t Kernel::parse_input_data(int idx);
     end
     code = $fread(result, fp);
     assert_(code == input_size[idx], $sformatf("Unable to read input data"));
-    // for (int i = 0; i < input_size[idx]; i++) begin
-    //     byte unsigned value;
-    //     int code;
-    //     code = $fread(value, fp);
-    //     assert_(code == 1, $sformatf("Unable to read input data"));
-    //     result[i] = value;
-    // end
     $fclose(fp);
     return result;
 endfunction
@@ -251,13 +244,6 @@ function data_array_t Kernel::parse_gold_data(int idx);
     end
     code = $fread(result, fp);
     assert_(code == output_size[idx], $sformatf("Unable to read output data"));
-    // for (int i = 0; i < output_size[idx]; i++) begin
-    //     byte unsigned value;
-    //     int code;
-    //     code = $fread(value, fp);
-    //     assert_(code == 1, $sformatf("Unable to read output data"));
-    //     result[i] = value;
-    // end
     $fclose(fp);
     return result;
 endfunction

--- a/tests/test_app/map.c
+++ b/tests/test_app/map.c
@@ -129,7 +129,8 @@ void update_io_configuration(struct IOInfo *io_info) {
     struct ConfigInfo *config_info = &io_info->config;
     int tile = io_info->tile;
     int start_addr = io_info->start_addr;
-    int size = io_info->size;
+    // convert 8bit size to 16bit size
+    int size = ((io_info->size) >> 1);
     if (io_info->io == Input) {
         update_tile_config_table(tile, 1 << 6);
         update_tile_config_table(tile, 1 << 2);

--- a/tests/test_app/parser.c
+++ b/tests/test_app/parser.c
@@ -213,10 +213,24 @@ void *parse_metadata(char *filename) {
         if (info->input_filenames[i][0] != '\0') {
             fp = fopen(info->input_filenames[i], "r");
             if (fp) {
-                fseek(fp, 0L, SEEK_END);
-                info->place_info->input_size[i] = (int) ftell(fp);
-                fclose(fp);
+                int name_len = strlen(info->input_filenames[i]);
+                if (strncmp(&info->input_filenames[i][name_len-3], "raw", strlen("raw")) == 0) {
+                    fseek(fp, 0L, SEEK_END);
+                    info->place_info->input_size[i] = (int) ftell(fp);
+                }
+                else {
+                    char c;
+                    int cnt = 0;
+                    while (cnt < 3) {
+                        c = fgetc(fp);
+                        if (c == '\n') cnt++;
+                    } 
+                    int header_size = (int) ftell(fp);
+                    fseek(fp, 0L, SEEK_END);
+                    info->place_info->input_size[i] = (int) ftell(fp) - header_size;
+                }
             }
+            fclose(fp);
         }
     }
 
@@ -225,9 +239,23 @@ void *parse_metadata(char *filename) {
         if (info->output_filenames[i][0] != '\0') {
             fp = fopen(info->output_filenames[i], "r");
             if (fp) {
-                fseek(fp, 0L, SEEK_END);
-                info->place_info->output_size[i] = (int) ftell(fp);
-                fclose(fp);
+                int name_len = strlen(info->output_filenames[i]);
+                if (strncmp(&info->output_filenames[i][name_len-3], "raw", strlen("raw")) == 0) {
+                    fseek(fp, 0L, SEEK_END);
+                    info->place_info->output_size[i] = (int) ftell(fp);
+                }
+		// pgm format
+                else {
+                    char c;
+                    int cnt = 0;
+                    while (cnt < 3) {
+                        c = fgetc(fp);
+                        if (c == '\n') cnt++;
+                    } 
+                    int header_size = (int) ftell(fp);
+                    fseek(fp, 0L, SEEK_END);
+                    info->place_info->output_size[i] = (int) ftell(fp) - header_size;
+                }
             }
         }
     }

--- a/tests/test_app/proc_driver.sv
+++ b/tests/test_app/proc_driver.sv
@@ -86,15 +86,15 @@ task ProcDriver::read_data(int start_addr, ref data_array_t data_q);
             for (int i=0; i<num_trans; i++) begin
                 wait (vif.cbd.rd_data_valid);
 
-                data_q[i*4] = vif.cbd.rd_data & 'hFF;
+                data_q[i*4] = vif.cbd.rd_data & 'hFFFF;
                 if ((i*4+1) < num_words) begin
-                    data_q[i*4+1] = (vif.cbd.rd_data & (('hFF) << 16)) >> 16;
+                    data_q[i*4+1] = (vif.cbd.rd_data & (('hFFFF) << 16)) >> 16;
                 end
                 if ((i*4+2) < num_words) begin
-                    data_q[i*4+2] = (vif.cbd.rd_data & (('hFF) << 32)) >> 32;
+                    data_q[i*4+2] = (vif.cbd.rd_data & (('hFFFF) << 32)) >> 32;
                 end
                 if ((i*4+3) < num_words) begin
-                    data_q[i*4+3] = (vif.cbd.rd_data & (('hFF) << 48)) >> 48;
+                    data_q[i*4+3] = (vif.cbd.rd_data & (('hFFFF) << 48)) >> 48;
                 end
 
                 @(vif.cbd);


### PR DESCRIPTION
This PR modifies a `glb+fabric` testbench to use `input.pgm` and `gold.pgm` instead of `.raw` files.
It also fixes buildkite fail.