### PR TITLE
RTL step silent fail

### DIFF
--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/pmtile_synth_only.yml
+pipelines/rtl_only.yml

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/rtl_only.yml
+pipelines/pmtile_synth_only.yml

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -16,16 +16,11 @@ steps:
 
 ##############################################################################
 # INDIVIDUAL TILE RUNS
+# Builds in dir e.g. mflowgen/full_chip/19-tile_array/16-Tile_MemCore
 
 - label: '250MHz PE synth 12m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_pe_area.sh
-  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
-
-- label: 'MemCore synth 17m'
-  commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
-  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
+  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
+  - pwd
+  - 'rtl_dir=mflowgen/full_chip/*-tile_array/*-Tile_PE/*-rtl;
+     test -f $$rtl_dir/outputs/design.v || echo oh no failed silently oh no'

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -21,19 +21,5 @@ steps:
 - label: '250MHz PE synth 12m'
   commands:
   - $TEST --need_space 30G full_chip --steps rtl --debug
-  - 'pwd;
-     ls full_chip;
-     ls full_chip/*-rtl;
-     rtl_dir=full_chip/*-rtl;
+  - 'rtl_dir=full_chip/*-rtl;
      grep Traceback $$rtl_dir/mflowgen-run.log && echo oh no failed silently oh no'
-
-
-#      ls full_chip;
-#      ls full_chip/*-tile_array;
-#      ls full_chip/*-tile_array/*-rtl;
-#      ls mflowgen;
-#      rtl_dir=mflowgen/full_chip/*-tile_array/*-rtl;
-#      echo rtl_dir=$$rtl_dir;
-#      ls $$rtl_dir;
-#      ls $$rtl_dir/outputs;
-#      test -f $$rtl_dir/outputs/design.v || echo oh no failed silently oh no'

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -25,12 +25,7 @@ steps:
      ls full_chip;
      ls full_chip/*-rtl;
      rtl_dir=full_chip/*-rtl;
-     echo rtl_dir=$$rtl_dir;
-     ls $$rtl_dir;
-     ls $$rtl_dir/outputs;
-     test -f $$rtl_dir/outputs/design.v || echo oh no failed silently oh no'
-
-
+     grep Traceback $$rtl_dir/mflowgen-run.log && echo oh no failed silently oh no'
 
 
 #      ls full_chip;

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -20,7 +20,10 @@ steps:
 
 - label: '250MHz PE synth 12m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
+  - $TEST --need_space 30G full_chip tile_array --steps rtl --debug
   - pwd
-  - 'rtl_dir=mflowgen/full_chip/*-tile_array/*-Tile_PE/*-rtl;
+  - 'rtl_dir=mflowgen/full_chip/*-tile_array/*-rtl;
+     echo rtl_dir=$$rtl_dir;
+     ls $$rtl_dir;
+     ls $$rtl_dir/outputs;
      test -f $$rtl_dir/outputs/design.v || echo oh no failed silently oh no'

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -20,10 +20,25 @@ steps:
 
 - label: '250MHz PE synth 12m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array --steps rtl --debug
-  - pwd
-  - 'rtl_dir=mflowgen/full_chip/*-tile_array/*-rtl;
+  - $TEST --need_space 30G full_chip --steps rtl --debug
+  - 'pwd;
+     ls full_chip;
+     ls full_chip/*-rtl;
+     rtl_dir=full_chip/*-rtl;
      echo rtl_dir=$$rtl_dir;
      ls $$rtl_dir;
      ls $$rtl_dir/outputs;
      test -f $$rtl_dir/outputs/design.v || echo oh no failed silently oh no'
+
+
+
+
+#      ls full_chip;
+#      ls full_chip/*-tile_array;
+#      ls full_chip/*-tile_array/*-rtl;
+#      ls mflowgen;
+#      rtl_dir=mflowgen/full_chip/*-tile_array/*-rtl;
+#      echo rtl_dir=$$rtl_dir;
+#      ls $$rtl_dir;
+#      ls $$rtl_dir/outputs;
+#      test -f $$rtl_dir/outputs/design.v || echo oh no failed silently oh no'

--- a/.buildkite/pipelines/rtl_only.yml
+++ b/.buildkite/pipelines/rtl_only.yml
@@ -18,7 +18,7 @@ steps:
 # INDIVIDUAL TILE RUNS
 # Builds in dir e.g. mflowgen/full_chip/19-tile_array/16-Tile_MemCore
 
-- label: '250MHz PE synth 12m'
+- label: 'FULL_CHIP RTL'
   commands:
   - $TEST --need_space 30G full_chip --steps rtl --debug
   - 'rtl_dir=full_chip/*-rtl;

--- a/.buildkite/pipelines/rtl_only.yml
+++ b/.buildkite/pipelines/rtl_only.yml
@@ -22,4 +22,7 @@ steps:
   commands:
   - $TEST --need_space 30G full_chip --steps rtl --debug
   - 'rtl_dir=full_chip/*-rtl;
-     grep Traceback $$rtl_dir/mflowgen-run.log && echo oh no failed silently oh no'
+     if grep Traceback $$rtl_dir/mflowgen-run.log;
+     then echo oh no failed silently oh no;
+     else exit 0;
+     fi'

--- a/.buildkite/pipelines/rtl_only.yml
+++ b/.buildkite/pipelines/rtl_only.yml
@@ -20,13 +20,6 @@ steps:
 
 - label: '250MHz PE synth 12m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_pe_area.sh
-  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
-
-- label: 'MemCore synth 17m'
-  commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
-  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
-- wait: { continue_on_failure: true } # One step at a time + continue on failure
+  - $TEST --need_space 30G full_chip --steps rtl --debug
+  - 'rtl_dir=full_chip/*-rtl;
+     grep Traceback $$rtl_dir/mflowgen-run.log && echo oh no failed silently oh no'

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-# DIE if any of the below commands exits with error status
-# set -e; do i need both of these?
+set -e; # DIE if any of the below commands exits with error status
 
 # Hierarchical flows can accept RTL as an input from parent graph
 if [ -f ../inputs/design.v ]; then
@@ -84,8 +82,6 @@ else
         '# Func to check python package creds (Added 02/2021 as part of cst vetting)
          # (Single-quote regime)
 
-         set -e
-
          function checkpip {
              # Example: checkpip ast.t "peak "
              #   ast-tools           0.0.30    /aha/ast_tools
@@ -103,6 +99,8 @@ else
              done
          }'"
          # (Double-quote regime)
+         set -e; # DIE if any single commands exits with error status
+
          source /aha/bin/activate; # Set up the build environment
 
          # Example: say you want to double-check packages 'ast_tools', 'magma', and 'peak'.
@@ -110,9 +108,7 @@ else
          # location and latest commit hash for each.
          # echo '+++ PIPCHECK-BEFORE'; checkpip ast.t magma 'peak '; echo '--- Continue build'
 
-         # Here is where we build the verilog for the main chip
-         echo Here is where we build the verilog for the main chip
-         aha garnet $flags
+         aha garnet $flags; # Here is where we build the verilog for the main chip
 
          # Rename output verilog, final name must be 'design.v'
          cd garnet

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# DIE is any of the below commands exits with error status
+# DIE if any of the below commands exits with error status
 set -e
 
 # Hierarchical flows can accept RTL as an input from parent graph
@@ -84,6 +84,8 @@ else
         '# Func to check python package creds (Added 02/2021 as part of cst vetting)
          # (Single-quote regime)
 
+         set -e
+
          function checkpip {
              # Example: checkpip ast.t "peak "
              #   ast-tools           0.0.30    /aha/ast_tools
@@ -108,7 +110,9 @@ else
          # location and latest commit hash for each.
          # echo '+++ PIPCHECK-BEFORE'; checkpip ast.t magma 'peak '; echo '--- Continue build'
 
-         aha garnet $flags; # Here is where we build the verilog for the main chip
+         # Here is where we build the verilog for the main chip
+         echo Here is where we build the verilog for the main chip
+         aha garnet $flags || echo FAILED
 
          # Rename output verilog, final name must be 'design.v'
          cd garnet

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -99,7 +99,7 @@ else
              done
          }'"
          # (Double-quote regime)
-         set -e; # DIE if any single commands exits with error status
+         set -e; # DIE if any single command exits with error status
 
          source /aha/bin/activate; # Set up the build environment
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# DIE is any of the below commands exits with error status
+set -e
+
 # Hierarchical flows can accept RTL as an input from parent graph
 if [ -f ../inputs/design.v ]; then
   echo "Using RTL from parent graph"

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -112,7 +112,7 @@ else
 
          # Here is where we build the verilog for the main chip
          echo Here is where we build the verilog for the main chip
-         aha garnet $flags || echo FAILED
+         aha garnet $flags
 
          # Rename output verilog, final name must be 'design.v'
          cd garnet

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # DIE if any of the below commands exits with error status
-set -e
+# set -e; do i need both of these?
 
 # Hierarchical flows can accept RTL as an input from parent graph
 if [ -f ../inputs/design.v ]; then


### PR DESCRIPTION
As described in issue 786, the RTL build step can fail silently, without alerting or halting the larger chip build.

This fixes that.

Garnet build 263 (https://buildkite.com/tapeout-aha/fullchip/builds/263) shows what happens when RTL fails without this fix in place. There was no error code at the point of failure, so the RTL step completed "successfully;" the error did not manifest until later, in the "tile_array" build step, when it was too late to easily figure out what went wrong and where.

https://buildkite.com/tapeout-aha/mflowgen/builds/3986 shows what happens when the RTL step fails using this new fix. The job immediately halts with an error code, as it should.

https://buildkite.com/tapeout-aha/mflowgen/builds/3986 shows what happened after the RTL problem was fixed (it was a stale docker image). RTL completed successfully with no error code.
