### PR TITLE
GLS fails silently during mem tile build

### DIFF
--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/pmtile_synth_only.yml
+pipelines/pe_tile_only.yml

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/mem_tile_only.yml
+pipelines/pe_tile_only.yml

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/pe_tile_only.yml
+pipelines/pmtile_synth_only.yml

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/pe_tile_only.yml
+pipelines/mem_tile_only.yml

--- a/.buildkite/pipelines/mem_tile_only.yml
+++ b/.buildkite/pipelines/mem_tile_only.yml
@@ -2,11 +2,12 @@ agents: { jobsize: "hours" }
 
 env:
   GOLD: /build/mem_tile_only.${BUILDKITE_BUILD_NUMBER}
+  OVERRIDE_MFLOWGEN_BRANCH: silent_fail
 
 steps:
 
 ##############################################################################
-# INDIVIDUAL TILE RUNS - PE tile only
+# INDIVIDUAL TILE RUNS - Mem tile only
 
 - label: 'setup'
   commands:

--- a/.buildkite/pipelines/mem_tile_only.yml
+++ b/.buildkite/pipelines/mem_tile_only.yml
@@ -1,7 +1,7 @@
 agents: { jobsize: "hours" }
 
 env:
-  GOLD: /build/bdgtc-memtile.${BUILDKITE_BUILD_NUMBER}
+  GOLD: /build/mem_tile_only.${BUILDKITE_BUILD_NUMBER}
 
 steps:
 

--- a/.buildkite/pipelines/pe_tile_only.yml
+++ b/.buildkite/pipelines/pe_tile_only.yml
@@ -2,6 +2,7 @@ agents: { jobsize: "hours" }
 
 env:
   GOLD: /build/pe_tile_only.${BUILDKITE_BUILD_NUMBER}
+  OVERRIDE_MFLOWGEN_BRANCH: silent_fail
 
 steps:
 

--- a/.buildkite/pipelines/pe_tile_only.yml
+++ b/.buildkite/pipelines/pe_tile_only.yml
@@ -1,7 +1,7 @@
 agents: { jobsize: "hours" }
 
 env:
-  GOLD: /build/bdgtc-pe.${BUILDKITE_BUILD_NUMBER}
+  GOLD: /build/pe_tile_only.${BUILDKITE_BUILD_NUMBER}
 
 steps:
 

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e;    # FAIL if any individual command fails
+
 mflowgen run --design $GARNET_HOME/mflowgen/Tile_MemCore/
 make cadence-genus-genlib
 if command -v calibre &> /dev/null

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -12,7 +12,7 @@ else
 fi
 
 # 6/11/2021 Deleting this line, hopefully temporarily, so as not to break master.
-# See https://github.com/StanfordAHA/garnet/issues/791
+# See https://github.com/StanfordAHA/garnet/issues/791 .
 # make pwr-aware-gls
 
 mkdir -p outputs

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -11,7 +11,9 @@ else
     make cadence-pegasus-lvs
 fi
 
-make pwr-aware-gls
+# 6/11/2021 Deleting this line, hopefully temporarily, so as not to break master.
+# See https://github.com/StanfordAHA/garnet/issues/791
+# make pwr-aware-gls
 
 mkdir -p outputs
 cp -L *cadence-genus-genlib/outputs/design.lib outputs/Tile_MemCore_tt.lib

--- a/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
+++ b/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e;    # FAIL if any individual command fails
+
 mflowgen run --design $GARNET_HOME/mflowgen/Tile_PE/
 make cadence-genus-genlib
 if command -v calibre &> /dev/null


### PR DESCRIPTION
Also see:
* garnet issue https://github.com/StanfordAHA/garnet/issues/791
* mflowgen pull https://github.com/mflowgen/mflowgen/pull/109

The final gate-level sim step for mem tile construction has been failing for months in our weekly CI builds. However, the error status is lost during the build, so no one ever notices that anything is wrong.

This merge, plus a corresponding change in the mflowgen repo, should fix that. In the mflowgen repo, we add a `set -o pipefail` to the GLS command sequence, e.g. it used to do something like
```
  # BAD sequence does not trigger error-1 when mflowgen-run fails
  mflowgen-run 2>&1 | tee mflowgen-run.log || exit 1
```
This sequence never reaches the `exit 1` command because, although the `mflowgen-run` command in the first half of the pipeline might fail, the `tee` command in the second half of the pipeline always succeeds, so the pipeline overall never fails.

The corrected sequence below fails if any pipestage fails, as was originally intended:
```
  # GOOD sequence triggers error-1 when mflowgen-run fails
  set -o pipefail && mflowgen-run 2>&1 | tee mflowgen-run.log || exit 1
```
So that's what we're doing in the mflowgen repo (see pull https://github.com/mflowgen/mflowgen/pull/109). Here in the garnet repo, meanwhile, `mflowgen-run` in the tile-build steps called a bash script that did something like
```
  # BAD sequence succeeds overall, even if the make command fails
  < command 1 >
  make pwr-aware-gls
  < command 2 >
  < command 3 >
```
The error for this status depends only on the error status of the final command executed, so as long as `<command 3>` succeeds, no error is flagged. To fix this, we add a `set -e` which tells the script to fail immediately when/if any individual command fails
```
  # GOOD sequence fails as soon as the make command fails
  set -e
  < command 1 >
  make pwr-aware-gls
  < command 2 >
  < command 3 >
```
So the final sequence is something like this:
* Mem tile's `mflowgen-run` script calls the gls step `make pwr-aware-gls`.
* `make pwr-aware-gls` does `set -o pipefail && mflowgen-run 2>&1 | tee mflowgen-run.log || exit 1` resulting in error status 1.
* Mem tile's `mflowgen-run` script fails immediately because of `set -e`.

TESTING:
* Without the fix, mem tile build fails silently (i.e. build reports "passed" even though log says "failed"): https://buildkite.com/tapeout-aha/mflowgen/builds/4006
* With one of the two fixes in place, still failes silently: https://buildkite.com/tapeout-aha/mflowgen/builds/4007
* With both fixes in place, mem tile fails explicitly, as it should: https://buildkite.com/tapeout-aha/mflowgen/builds/4008

Meanwhile: because GLS is still failing, this fix would break master if we kept the "make pwr-aware-gls" command, so I commented that out. I'll make a new branch `gls_broken` that we can use to try and debug that problem separately...


