### PR TITLE
Temporary fix to memory leak issue and stall only part of the chip during virtualization

### DIFF
--- a/tests/test_app/environment.sv
+++ b/tests/test_app/environment.sv
@@ -30,6 +30,9 @@ class Environment;
     extern task clear_interrupt(e_glb_ctrl glb_ctrl, bit[NUM_GLB_TILES_WIDTH-1:0] tile_num);
     extern task kernel_test(Kernel kernel);
     extern task read_data(Kernel kernel);
+    extern function bit[NUM_GLB_TILES-1:0] calculate_mask(int start, int num);
+    extern task stall(bit[NUM_GLB_TILES-1:0] stall_mask);
+    extern task unstall(bit[NUM_GLB_TILES-1:0] stall_mask);
     extern task run();
 endclass
 
@@ -99,10 +102,17 @@ endtask
 
 task Environment::cgra_configure(Kernel kernel);
     Config cfg;
+    int group_start, num_groups;
+    bit[NUM_GLB_TILES-1:0] stall_mask;
+
     realtime start_time, end_time;
     $timeformat(-9, 2, " ns");
 
-    axil_drv.write(`GLC_STALL, 32'hFFFFFFFF);
+    group_start = kernel.group_start;
+    num_groups = kernel.num_groups;
+    stall_mask = calculate_mask(group_start, num_groups);
+
+    stall(stall_mask);
     start_time = $realtime;
     $display("[%s] fast configuration start at %0t", kernel.name, start_time);
     cfg = kernel.get_pcfg_start_config();
@@ -114,8 +124,33 @@ task Environment::cgra_configure(Kernel kernel);
     $display("[%s] fast configuration end at %0t", kernel.name, end_time);
     $display("[%s] It takes %0t time to do parallel configuration.", kernel.name, end_time-start_time);
 
-    // TODO: STALL only corresponding CGRA columns
-    axil_drv.write(`GLC_STALL, '0);
+    unstall(stall_mask);
+endtask
+
+function bit[NUM_GLB_TILES-1:0] Environment::calculate_mask(int start, int num);
+    calculate_mask = '0;
+    for (int i=0; i < num; i++) begin
+        calculate_mask |= ((2'b11) << ((start + i) * 2));
+    end
+endfunction
+
+task Environment::stall(bit[NUM_GLB_TILES-1:0] stall_mask);
+    bit [AXI_DATA_WIDTH-1:0] data;
+    bit [AXI_DATA_WIDTH-1:0] wr_data;
+    axil_drv.read(`GLC_STALL, data);
+    wr_data |= ((stall_mask << NUM_GLB_TILES) | stall_mask);
+    axil_drv.write(`GLC_STALL, wr_data);
+    $display("Stall GLB & CGRA with stall mask %4h", stall_mask);
+endtask
+
+
+task Environment::unstall(bit[NUM_GLB_TILES-1:0] stall_mask);
+    bit [AXI_DATA_WIDTH-1:0] data;
+    bit [AXI_DATA_WIDTH-1:0] wr_data;
+    axil_drv.read(`GLC_STALL, data);
+    wr_data &= (((~stall_mask) << NUM_GLB_TILES) | (~stall_mask));
+    axil_drv.write(`GLC_STALL, wr_data);
+    $display("Unstall GLB & CGRA with stall mask %4h", stall_mask);
 endtask
 
 task Environment::kernel_test(Kernel kernel);

--- a/tests/test_app/environment.sv
+++ b/tests/test_app/environment.sv
@@ -124,7 +124,6 @@ task Environment::cgra_configure(Kernel kernel);
     $display("[%s] fast configuration end at %0t", kernel.name, end_time);
     $display("[%s] It takes %0t time to do parallel configuration.", kernel.name, end_time-start_time);
 
-    unstall(stall_mask);
 endtask
 
 function bit[NUM_GLB_TILES-1:0] Environment::calculate_mask(int start, int num);
@@ -156,8 +155,15 @@ endtask
 task Environment::kernel_test(Kernel kernel);
     Config cfg;
     int total_output_size;
+    int group_start, num_groups;
+    bit[NUM_GLB_TILES-1:0] stall_mask;
     realtime start_time, end_time, g2f_end_time, latency;
     $timeformat(-9, 2, " ns");
+
+    group_start = kernel.group_start;
+    num_groups = kernel.num_groups;
+    stall_mask = calculate_mask(group_start, num_groups);
+    unstall(stall_mask);
 
     start_time = $realtime;
     $display("[%s] kernel start at %0t", kernel.name, start_time);
@@ -255,7 +261,7 @@ task Environment::wait_interrupt(e_glb_ctrl glb_ctrl, bit[NUM_GLB_TILES_WIDTH-1:
             end
         end
         begin
-            repeat (20_000) @(vifc_axil.cbd);
+            repeat (200_000) @(vifc_axil.cbd);
             $display("@%0t: %m ERROR: Interrupt wait timeout ", $time);
         end
     join_any

--- a/tests/test_app/kernel.sv
+++ b/tests/test_app/kernel.sv
@@ -159,10 +159,12 @@ function Kernel::new(string app_dir);
     // meta file name is design_meat.json
     meta_filename = {app_dir, "/bin/", "design_meta.json"};
     $sformat(name, "APP%0d-%0s", cnt++, app_name);
+    $display("[%s]Initilizing the APP Done", name);
 
     app_state = IDLE;
 
     kernel_info = parse_metadata(meta_filename);
+    $display("[%s] Parsing the metadata done", name);
     assert_(kernel_info != null, $sformatf("Unable to find %s", meta_filename));
 
     bitstream_filename = get_bitstream_filename(kernel_info);
@@ -172,6 +174,10 @@ function Kernel::new(string app_dir);
     num_inputs = get_num_inputs(kernel_info);
     num_outputs = get_num_outputs(kernel_info);
     num_groups = get_num_groups(kernel_info);
+
+    $display("[%s] num_inputs: %0d", name, num_inputs);
+    $display("[%s] num_outputs: %0d", name, num_outputs);
+    $display("[%s] num_groups: %0d", name, num_groups);
 
     // IO instantiate
     inputs = new[num_inputs];

--- a/tests/test_app/map.c
+++ b/tests/test_app/map.c
@@ -212,6 +212,7 @@ void update_io_tile_configuration(struct IOTileInfo *io_tile_info, struct Config
         add_config(config_info, (tile * 0x100) + GLB_TILE0_ST_DMA_HEADER_0_START_ADDR, start_addr); 
         add_config(config_info, (tile * 0x100) + GLB_TILE0_ST_DMA_HEADER_0_NUM_WORDS, size); 
         add_config(config_info, (tile * 0x100) + GLB_TILE0_ST_DMA_HEADER_0_VALIDATE, 1); 
+        printf("Output ITER CTRL - size: %0d\n", size);
     }
 }
 

--- a/tests/test_app/parser.h
+++ b/tests/test_app/parser.h
@@ -73,6 +73,8 @@ struct IOInfo {
 };
 
 struct KernelInfo {
+    int temp[100];
+
     int num_inputs;
     int num_outputs;
 

--- a/tests/test_app/parser.h
+++ b/tests/test_app/parser.h
@@ -8,7 +8,7 @@
 #define BUFFER_SIZE 1024
 #define MAX_NUM_KERNEL 16
 #define MAX_JSON_FIELDS 512
-#define MAX_CONFIG 20
+#define MAX_CONFIG 40
 #define MAX_ADDR_GEN_LOOP 5
    
 #define GET_BS_INFO(info) struct BitstreamInfo *bs_info = \
@@ -73,8 +73,6 @@ struct IOInfo {
 };
 
 struct KernelInfo {
-    int temp[100];
-
     int num_inputs;
     int num_outputs;
 


### PR DESCRIPTION
This PR includes these two
1. Add temporary fix to memory leak issue
2. When running multiple apps, only stall corresponding columns so that It does not affect other apps.