### PR TITLE
get-step-context.sh for mflowgen

### DIFF
--- a/.buildkite/pipeline_fullchip.yml
+++ b/.buildkite/pipeline_fullchip.yml
@@ -6,6 +6,8 @@ env:
 
   # To support postroute_hold retries
   PRH    : 'eval $$GARNET_HOME/.buildkite/bin/prh.sh'
+
+  # ($FAIL|$UPLOAD): Inserts a "fail" bubble in the buildkite pipeline log
   FAIL1  : 'echo steps : [ { label : FAIL->retry1 , command : exit } ]'
   FAIL2  : 'echo steps : [ { label : FAIL->retry2 , command : exit } ]'
   UPLOAD : 'buildkite-agent pipeline upload'

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/pmtile_synth_only.yml
+pipelines/standalone_test.yml

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/standalone_test.yml
+pipelines/pmtile_synth_only.yml

--- a/.buildkite/pipelines/standalone_test.yml
+++ b/.buildkite/pipelines/standalone_test.yml
@@ -11,7 +11,7 @@ steps:
   - label: 'hold'
     commands:
       - echo "--- POSTROUTE_HOLD"
-      - 'set -x; set -o pipefail;
+      - 'set -o pipefail;
          source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
          mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
          $$GARNET_HOME/mflowgen/bin/get-step-context.sh $$GOLD \

--- a/.buildkite/pipelines/standalone_test.yml
+++ b/.buildkite/pipelines/standalone_test.yml
@@ -11,7 +11,7 @@ steps:
   - label: 'hold'
     commands:
       - echo "--- POSTROUTE_HOLD"
-      - 'set -o pipefail; \
+      - 'set -x; set -o pipefail; \
          source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
          mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
          $$GARNET_HOME/mflowgen/bin/get-step-context.sh $$GOLD \

--- a/.buildkite/pipelines/standalone_test.yml
+++ b/.buildkite/pipelines/standalone_test.yml
@@ -13,7 +13,7 @@ steps:
       - echo "--- POSTROUTE_HOLD"
       - 'set -o pipefail; \
          source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
-         mflowgen run --design $$GARNET_HOME/mflowgen/full_chip'
+         mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
          $$GARNET_HOME/mflowgen/bin/get-step-context.sh $$GOLD \
            cadence-innovus-postroute_hold'
          # ready to do: make cadence-innovus-postroute_hold

--- a/.buildkite/pipelines/standalone_test.yml
+++ b/.buildkite/pipelines/standalone_test.yml
@@ -11,7 +11,7 @@ steps:
   - label: 'hold'
     commands:
       - echo "--- POSTROUTE_HOLD"
-      - 'set -x; set -o pipefail; \
+      - 'set -x; set -o pipefail;
          source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
          mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
          $$GARNET_HOME/mflowgen/bin/get-step-context.sh $$GOLD \

--- a/.buildkite/pipelines/standalone_test.yml
+++ b/.buildkite/pipelines/standalone_test.yml
@@ -1,45 +1,21 @@
-# Run postroute_hold standalone, with two retry attempts in case of failure.
+# Build symlinks necessary to do "make postroute_hold"
+# using pre-cached collateral from dir $GOLD
 
 agents: { queue: "papers" }
 
 env:
-  BUILD     : /build/prh${BUILDKITE_BUILD_NUMBER}/full_chip
-  PHREF     : /sim/buildkite-agent/gold
-
-  # Set slack to -0.3 to make postroute_hold much faster.
-  # Default targ slack for full_chip @ 0.06 takes 6 hours atm.
-  # With hack target -0.3, should be about 2.5 hours (saves 3.5 hours)
-  MFLOWGEN_PARM_OVERRIDE_hold_target_slack : -0.3
+  BUILD : /build/prh${BUILDKITE_BUILD_NUMBER}/full_chip
+  GOLD  : /sim/buildkite-agent/gold
 
 steps:
-  - label: 'setup'
-    commands:
-    - 'source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
-       mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
-       grep slack .mflowgen/*postroute_hold/mflowgen-run;
-       grep slack .mflowgen/*postroute_hold/configure.yml'
-  - wait: ~
-
-  ########################################################################
-  # postroute_hold fails sometimes, thus all this infrastructure for retry.
-  # 
-  # "prh.sh" does the following:
-  #   - if "*-postroute_hold" already done and passed, do nothing and exit 0
-  #   - else if (presumably failed) dir "*-postroute_hold" exists, rename it
-  #   - build new step postroute_hold
-  #
-  ########################################################################
-
-  # postroute_hold, retry if fail.
   - label: 'hold'
     commands:
       - echo "--- POSTROUTE_HOLD"
-      - 'set -o pipefail;
+      - 'set -o pipefail; \
          source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
-         eval $$GARNET_HOME/mflowgen/bin/get-step-context.sh $$PHREF;
-         echo "+++ BUILD STEPS";
-         make -n cadence-innovus-postroute_hold
-         |& egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make'
-
+         mflowgen run --design $$GARNET_HOME/mflowgen/full_chip'
+         $$GARNET_HOME/mflowgen/bin/get-step-context.sh $$GOLD \
+           cadence-innovus-postroute_hold'
+         # ready to do: make cadence-innovus-postroute_hold
 
 

--- a/.buildkite/pipelines/standalone_test.yml
+++ b/.buildkite/pipelines/standalone_test.yml
@@ -1,0 +1,44 @@
+# Run postroute_hold standalone, with two retry attempts in case of failure.
+
+agents: { queue: "papers" }
+
+env:
+  BUILD     : /build/prh${BUILDKITE_BUILD_NUMBER}/full_chip
+  PHREF     : /sim/buildkite-agent/gold
+
+  # Set slack to -0.3 to make postroute_hold much faster.
+  # Default targ slack for full_chip @ 0.06 takes 6 hours atm.
+  # With hack target -0.3, should be about 2.5 hours (saves 3.5 hours)
+  MFLOWGEN_PARM_OVERRIDE_hold_target_slack : -0.3
+
+steps:
+  - label: 'setup'
+    commands:
+    - 'source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
+       mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
+       grep slack .mflowgen/*postroute_hold/mflowgen-run;
+       grep slack .mflowgen/*postroute_hold/configure.yml'
+  - wait: ~
+
+  ########################################################################
+  # postroute_hold fails sometimes, thus all this infrastructure for retry.
+  # 
+  # "prh.sh" does the following:
+  #   - if "*-postroute_hold" already done and passed, do nothing and exit 0
+  #   - else if (presumably failed) dir "*-postroute_hold" exists, rename it
+  #   - build new step postroute_hold
+  #
+  ########################################################################
+
+  # postroute_hold, retry if fail.
+  - label: "hold"
+    commands:
+      - echo "--- POSTROUTE_HOLD - FIRST ATTEMPT"
+      - 'set -o pipefail;
+         source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
+         eval $$GARNET_HOME/mflowgen/bin/get-step-context.sh $$PHREF;
+         make -n cadence-innovus-postroute_hold'
+
+
+
+

--- a/.buildkite/pipelines/standalone_test.yml
+++ b/.buildkite/pipelines/standalone_test.yml
@@ -31,14 +31,14 @@ steps:
   ########################################################################
 
   # postroute_hold, retry if fail.
-  - label: "hold"
+  - label: 'hold'
     commands:
-      - echo "--- POSTROUTE_HOLD - FIRST ATTEMPT"
+      - echo "--- POSTROUTE_HOLD"
       - 'set -o pipefail;
          source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
          eval $$GARNET_HOME/mflowgen/bin/get-step-context.sh $$PHREF;
-         make -n cadence-innovus-postroute_hold'
-
+         make -n cadence-innovus-postroute_hold
+         | egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make'
 
 
 

--- a/.buildkite/pipelines/standalone_test.yml
+++ b/.buildkite/pipelines/standalone_test.yml
@@ -37,8 +37,9 @@ steps:
       - 'set -o pipefail;
          source mflowgen/bin/setup-buildkite.sh --dir $$BUILD --need_space 1G;
          eval $$GARNET_HOME/mflowgen/bin/get-step-context.sh $$PHREF;
+         echo "+++ BUILD STEPS";
          make -n cadence-innovus-postroute_hold
-         | egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make'
+         |& egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make'
 
 
 

--- a/bin/requirements_check.sh
+++ b/bin/requirements_check.sh
@@ -126,7 +126,12 @@ if [ "$module" == "Tile_MemCore" ] ; then
 fi
 
 # /tmp needs a lot of space
-tmpdir=$TMPDIR; [ "$tmpdir" ] || tmpdir=/tmp
+if ! test -d "$TMPDIR"; then
+    echo "Cannot find designated temp dir TMPDIR='$TMPDIR'"
+    echo "Setting TMPDIR=/tmp instead"
+    export TMPDIR=/tmp
+fi
+tmpdir=$TMPDIR
 avail=`df $tmpdir --output=avail | tail -1`
 avail_human=`df -H $tmpdir --output=avail | tail -1`
 avail_human=`echo $avail_human` ; # Eliminate whitespace?
@@ -141,10 +146,12 @@ G=$(( 1024 * 1024 )) ; # As reported by df in 1024-byte blocks!
 if [[ $avail -lt $(( 3 * $G )) ]]; then
     ERROR "less than 3G definitely NOT ENOUGH for full chip postroute"
     echo "Recommend you do something like 'export TMPDIR=/sim/tmp'"
+    echo ""
     exit 13
 elif [[ $avail -lt $(( 20 * $G )) ]]; then
     ERROR "less than 20G probably NOT ENOUGH for full chip postroute"
     echo "Recommend you do something like 'export TMPDIR=/sim/tmp'"
+    echo ""
     exit 13
 elif [[ $avail -lt $(( 60 * $G )) ]]; then
     echo "***WARNING less than 60G not (yet) proven to be enough"

--- a/mflowgen/bin/cleanup-buildkite.sh
+++ b/mflowgen/bin/cleanup-buildkite.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Only works for buildkite-agent, duh.
+if [ "$USER" != "buildkite-agent" ]; then
+    printf "***ERROR Cleanup only works for USER=buildkite-agent\n\n"
+    exit 13
+fi
+
 # Nondestructive script for helping to clean out /tmp after buildkite run(s)
 # Must be used interactively; echoes a bunch of commands that you then have
 # to cut'n'paste or source or something by hand ish.
@@ -28,8 +34,10 @@ echo "--- CLEANUP /SIM/TMP: found $nfiles week-old OBJECTS owned by buildkite-ag
 echo "Found $nfiles buildkite-agent files in /sim/tmp older than one week"
 if [ "$nfiles" != "0" ]; then echo "Deleting old files..."; fi
 for f in ${files[@]}; do
-    echo /bin/rm -rf $f; /bin/rm -rf $f
+    test -e $f || printf "Oops cannot locate file '$f'\n"
+    test -e $f && echo /bin/rm -rf $f && /bin/rm -rf $f
 done
+echo ""
 
 
 ########################################################################
@@ -40,8 +48,10 @@ nfiles=${#files[@]}
 echo "--- CLEANUP /TMP: found $nfiles step-alias files > 1 hour old"
 if [ "$nfiles" != "0" ]; then echo "Deleting step-alias files..."; fi
 for f in ${files[@]}; do
-    echo /bin/rm -rf $f; # /bin/rm -rf $f
+    test -e $f || printf "Oops cannot locate file '$f'\n"
+    test -e $f && echo /bin/rm -rf $f && /bin/rm -rf $f
 done
+echo ""
 
 
 ########################################################################
@@ -52,8 +62,10 @@ nfiles=${#files[@]}
 echo "--- CLEANUP /TMP: found $nfiles qrc log files > 1 day old"
 if [ "$nfiles" != "0" ]; then echo "Deleting qrc log files..."; fi
 for f in ${files[@]}; do
-    echo /bin/rm -rf $f; /bin/rm -rf $f
+    test -e $f || printf "Oops cannot locate file '$f'\n"
+    test -e $f && echo /bin/rm -rf $f && /bin/rm -rf $f
 done
+echo ""
 
 
 ########################################################################
@@ -64,7 +76,9 @@ nfiles=${#files[@]}
 echo "--- CLEANUP /TMP: found $nfiles tmp.deleteme files > 1 hour old"
 if [ "$nfiles" != "0" ]; then echo "Deleting tmp.deleteme files..."; fi
 for f in ${files[@]}; do
-    echo /bin/rm -rf $f; /bin/rm -rf $f
+    test -e $f || printf "Oops cannot locate file '$f'\n"
+    test -e $f && echo /bin/rm -rf $f && /bin/rm -rf $f
 done
+echo ""
 
 

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -39,7 +39,8 @@ echo "+++ STANDALONE TEST RIG SETUP - build symlinks to steps in $REF/full_chip"
 
 function find_dependences {
     set -x
-    # Example: 
+
+    # Example:
     #    find_dependences cadence-innovus-postroute_hold
     # 
     # Returns:
@@ -48,14 +49,14 @@ function find_dependences {
     #      cadence-innovus-flowsetup
 
     stepname="$1"
-    stepnum=$(make list | awk '$NF == "'$stepname'"{print $2; exit}')
+    stepnum=$(make list |& awk '$NF == "'$stepname'" {print $2; exit}')
     echo "FOUND $stepnum $stepname"
 
     # Note for some reason it ignores adk dependences.
     # Seems to work anyway I guess?
     deps=$(make info-$stepnum |& grep -v warning | sed 's/|//g' \
          | awk '$NF ~ /^[0-9]/ {print $NF}; /^Parameters/{exit}' \
-         | sed "/$stepname\$/,\\$d" \
+         | sed "/$stepname\$/,\$d" \
          | egrep -v 'freepdk|tsmc' \
          | sed 's/^[0-9]*[-]//')
 

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -67,7 +67,6 @@ echo "+++ STANDALONE TEST RIG SETUP - build symlinks to steps in $REF/full_chip"
 ########################################################################
 ########################################################################
 
-# Who's the chad now?
 function get_predecessors {
 
     # Example:

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -149,6 +149,8 @@ function find_dependences_awk2 {
     #   - Could do "test -e .mflowgen || ERROR"
 
     target_step=${1} ; # E.g. "rtl"
+    target_step=cadence-innovus-postroute_hold
+
     stepdir=$(/bin/ls .mflowgen | egrep "^[0-9]*-${target_step}") ; # E.g. "11-rtl"
     config_file=".mflowgen/${stepdir}/configure.yml"
 
@@ -174,9 +176,9 @@ function find_dependences_awk2 {
         f == "adk" { next }
         $1 == "step:" { print $2 }' \
     | sed 's/^[0-9]*[-]//'
-
+}
 echo ""; echo "DEPENDENCES (mega-chad awk script): "
-find_dependences_py_awk2 cadence-innovus-postroute_hold
+find_dependences_awk2 cadence-innovus-postroute_hold
 echo ""
 echo ""
 

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -2,40 +2,86 @@
 
 # Usage: $0 <refdir>
 
-# Build the necessary context to run postroute_hold step only.
-# TODO/LATER maybe want this to work for any step.
+# Using reference/cached build in <refdir>, find and link to the
+# necessary context for running a single target step in an mflowgen
+# build
 
-REF=$1
-
-# Want to link two steps from <refdir> into current (build) dir
-#     *-cadence-innovus-postroute
-#     *-cadence-innovus-flowsetup
-
-# Example usage
+# E.g. for cadence-innovus-postroute_hold we would link two steps from
+# <refdir> into current (build) dir
 # 
-#     RUNDIR=/build/run230/full_chip
+#     ln -s 23-cadence-innovus-flowsetup <refdir>/23-cadence-innovus-postroute
+#     ln -s 31-cadence-innovus-postroute <refdir>/30-cadence-innovus-postroute
+
+# Example usage: run standalone step "cadence-innovus-postroute_hold"
+# in $RUNDIR using cached information in $REFDIR":
+# 
+#     # 1. Designate a reference directory from which we will pull context.
 #     REFDIR=/build/gold
-# 
-#     # Note setup script leaves you in RUNDIR as a side effect
-#     source mflowgen/bin/setup-buildkite.sh --dir $RUNDIR
-#     mflowgen/bin/get-step-context.sh $REFDIR
+#
+#     # 2. Build the design framework
+#     mflowgen run --design $GARNET_HOME/mflowgen/full_chip
+#
+#     # 3. Build standalone context and execute target step "postroute_hold"
+#     get-step-context.sh $REFDIR cadence-innovus-postroute_hold
 #     make cadence-innovus-postroute_hold
 
-DBG=1
+REF=$1
+target_step=$2
+target_step=cadence-innovus-postroute_hold
+
+
+DBG=0
 
 echo "--- BEGIN $0 $*" | sed "s,$GARNET_HOME,\$GARNET_HOME,"
-echo "  GARNET_HOME=$GARNET_HOME"
+echo "  where GARNET_HOME=$GARNET_HOME"
 
-echo "--- PRH TEST RIG SETUP - symlink to steps in $REF/full_chip";
+echo "+++ STANDALONE TEST RIG SETUP - build symlinks to steps in $REF/full_chip";
+
+function find_dependences {
+    # Example: 
+    #    find_dependences cadence-innovus-postroute_hold
+    # 
+    # Returns:
+    #      adk
+    #      cadence-innovus-postroute
+    #      cadence-innovus-flowsetup
+
+    stepname="$1"
+    stepnum=`make list | awk '$NF == "'$step'"{print $2; exit}'`
+    echo "FOUND $stepnum $stepname"
+
+    # Note for some reason it ignores adk dependences.
+    # Seems to work anyway I guess?
+    deps=`make info-$stepnum |& grep -v warning | sed 's/|//g' \
+         | awk '$NF ~ /^[0-9]/ {print $NF}; /^Parameters/{exit}' \
+         | sed "/$step\$/,\\$d" \
+         | egrep -v 'freepdk|tsmc' \
+         | sed 's/^[0-9]*[-]//'`
+
+    echo $deps
+}
+
+# Find-dependences came up with this:
+
+set +x
+find_dependences cadence-innovus-postroute_hold
+set -x
+echo ""
+echo ""
+echo ""
+
+
+
+
 for step in cadence-innovus-postroute cadence-innovus-flowsetup; do
 
-    echo Processing step $step
+    [ "$DBG" ] && echo Processing step $step
 
     # Find name of step in local dir; bug out if exists already
     [ "$DBG" ] && (make list |& egrep ": $step\$")
     stepnum=$(make list |& egrep ": $step\$" | awk '{print $2}')
     local_step=$stepnum-$step
-    [ "$DBG" ] && echo Want local step $local_step; echo ''
+    [ "$DBG" ] && (echo "Want local step $local_step"; echo '')
     if test -e $local_step; then
         echo "Looks like '$local_step' exists already"
         echo "Doing nothing for '$local_step'"
@@ -45,7 +91,7 @@ for step in cadence-innovus-postroute cadence-innovus-flowsetup; do
     # Find name of step in ref dir
     stepnum=$(cd $REF/full_chip; make list |& egrep ": $step\$" | awk '{print $2}')
     ref_step=$REF/full_chip/$stepnum-$step
-    [ "$DBG" ] && echo Found ref step $ref_step
+    [ "$DBG" ] && echo "Found ref step $ref_step"
     if ! test -d $ref_step; then
         echo "hm look like $ref_step don't exist after all..."
         exit 13
@@ -56,14 +102,82 @@ for step in cadence-innovus-postroute cadence-innovus-flowsetup; do
     touch $ref_step/.prebuilt
 
     # Link local to ref
-    [ "$DBG" ] && echo "Ready to do: ln -s $ref_step $local_step"
+    [ "$DBG" ] && echo "ln -s $ref_step $local_step"
     ln -s $ref_step $local_step
     echo "$local_step => $ref_step"
-    echo ''
+    [ "$DBG" ] && echo ''
 
 done
+
+echo "+++ TODO LIST";
+echo "make -n cadence-innovus-postroute_hold"
+make -n cadence-innovus-postroute_hold
+|& egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make'
+
 
 # # Did we get away with it? Example of how to check:
 # echo "+++ TODO LIST"
 # function make-n-filter { egrep '^mkdir.*output' | sed 's/output.*//' | egrep -v ^Make ;}
 # make -n cadence-innovus-postroute_hold |& make-n-filter
+
+
+
+# NOTES
+
+
+exit
+########################################################################
+# To run locally on kiwi can do this:
+do_this=OFF
+if [ "$do_this" == "ON" ]; then
+
+    # 1. Set up run and ref dirs
+    T=/tmp/get-step-context; cd $T
+    REFDIR=/build/gold; RUNDIR=$T/full_chip
+
+    # 2. Set up to execute target step in $RUNDIR
+    export GARNET_HOME=/nobackup/steveri/github/garnet
+    sbk=$GARNET_HOME/mflowgen/bin/setup-buildkite.sh
+    source $sbk --dir $RUNDIR |& tee log | less
+
+    # 3. Jimmy up a fake tsmc16 library
+    (cd /tmp/steveri/mflowgen.master/adks; ln -s freepdk-45nm tsmc16)
+
+    # 4. Build the design framework
+    mflowgen run --design $GARNET_HOME/mflowgen/full_chip
+
+    ### >>> GOOD TO HERE <<< ###
+
+    # 3. Build standalone context and execute target step "postroute_hold"
+    mflowgen/bin/get-step-context.sh $REFDIR
+    make cadence-innovus-postroute_hold
+fi
+
+exit
+########################################################################
+# Buildkite on arm machine should be able to do this:
+do_this=OFF
+if [ "$do_this" == "ON" ]; then
+
+    # 1. Set up run and ref dirs
+    T=/tmp/get-step-context; cd $T
+    REFDIR=/build/gold; RUNDIR=$T/full_chip
+
+    # 2. Set up to execute target step in $RUNDIR
+    export GARNET_HOME=/sim/steveri/soc/components/cgra/garnet
+    sbk=$GARNET_HOME/mflowgen/bin/setup-buildkite.sh
+    source $sbk --dir $RUNDIR |& tee log | less
+
+    # 3. No need to jimmy up a fake tsmc16 library
+    # (cd /tmp/steveri/mflowgen.master/adks; ln -s freepdk-45nm tsmc16)
+
+    # 4. Build the design framework
+    mflowgen run --design $GARNET_HOME/mflowgen/full_chip
+
+    ### >>> GOOD TO HERE <<< ###
+
+    # 3. Build standalone context and execute target step "postroute_hold"
+    mflowgen/bin/get-step-context.sh $REFDIR
+    make cadence-innovus-postroute_hold
+fi
+

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -30,7 +30,7 @@ target_step=$2
 target_step=cadence-innovus-postroute_hold
 
 
-DBG=0
+DBG=
 
 echo "--- BEGIN $0 $*" | sed "s,$GARNET_HOME,\$GARNET_HOME,"
 echo "  where GARNET_HOME=$GARNET_HOME"
@@ -48,16 +48,16 @@ function find_dependences {
     #      cadence-innovus-flowsetup
 
     stepname="$1"
-    stepnum=`make list | awk '$NF == "'$step'"{print $2; exit}'`
+    stepnum=$(make list | awk '$NF == "'$stepname'"{print $2; exit}')
     echo "FOUND $stepnum $stepname"
 
     # Note for some reason it ignores adk dependences.
     # Seems to work anyway I guess?
-    deps=`make info-$stepnum |& grep -v warning | sed 's/|//g' \
+    deps=$(make info-$stepnum |& grep -v warning | sed 's/|//g' \
          | awk '$NF ~ /^[0-9]/ {print $NF}; /^Parameters/{exit}' \
-         | sed "/$step\$/,\\$d" \
+         | sed "/$stepname\$/,\\$d" \
          | egrep -v 'freepdk|tsmc' \
-         | sed 's/^[0-9]*[-]//'`
+         | sed 's/^[0-9]*[-]//')
 
     echo $deps
 }
@@ -113,7 +113,7 @@ done
 echo "+++ TODO LIST";
 echo "make -n cadence-innovus-postroute_hold"
 make -n cadence-innovus-postroute_hold \
-  |& egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make'
+  |& egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make
 
 
 # # Did we get away with it? Example of how to check:

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -82,7 +82,6 @@ function get_predecessors {
 echo ""; echo "NODE PREDS"
 get_predecessors cadence-innovus-postroute_hold
 echo ""
-echo ""
 
 
 DBG=
@@ -121,6 +120,7 @@ for step in cadence-innovus-postroute cadence-innovus-flowsetup; do
     [ "$DBG" ] && echo ''
 
 done
+echo ""
 
 echo "+++ READY TO BUILD STANDALONE $target_step"
 echo "make -n ${target_step}"

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -38,6 +38,7 @@ echo "  where GARNET_HOME=$GARNET_HOME"
 echo "+++ STANDALONE TEST RIG SETUP - build symlinks to steps in $REF/full_chip";
 
 function find_dependences {
+    set -x
     # Example: 
     #    find_dependences cadence-innovus-postroute_hold
     # 
@@ -63,9 +64,9 @@ function find_dependences {
 
 # Find-dependences came up with this:
 
-set +x
-find_dependences cadence-innovus-postroute_hold
 set -x
+find_dependences cadence-innovus-postroute_hold
+set +x
 echo ""
 echo ""
 echo ""
@@ -111,8 +112,8 @@ done
 
 echo "+++ TODO LIST";
 echo "make -n cadence-innovus-postroute_hold"
-make -n cadence-innovus-postroute_hold
-|& egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make'
+make -n cadence-innovus-postroute_hold \
+  |& egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make'
 
 
 # # Did we get away with it? Example of how to check:

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -1,50 +1,41 @@
 #!/bin/bash
 
-# Usage: $0 <refdir>
-
-# Using reference/cached build in <refdir>, find and link to the
-# necessary context for running a single target step in an mflowgen
-# build
-
-# E.g. for cadence-innovus-postroute_hold we would link two steps from
-# <refdir> into current (build) dir
+# Usage: $0 <refdir> <step>
+# 
+# Using ref/cached/gold build in <refdir>, find and link to the
+# context needed for a given target <step> node in an mflowgen build graph.
+# 
+# E.g. for cadence-innovus-postroute_hold we might link link these two
+# steps from <refdir> into current (build) dir
 # 
 #     ln -s 23-cadence-innovus-flowsetup <refdir>/23-cadence-innovus-postroute
 #     ln -s 31-cadence-innovus-postroute <refdir>/30-cadence-innovus-postroute
-
-# Example usage: run standalone step "cadence-innovus-postroute_hold"
-# in $RUNDIR using cached information in $REFDIR":
 # 
-#     # 1. Designate a reference directory from which we will pull context.
-#     REFDIR=/build/gold
-#
-#     # 2. Build the design framework
+# Example usage to e.g. run standalone step "cadence-innovus-postroute_hold"
+# in $RUNDIR using cached information in refdir "/build/gold":
+# 
+#     #1. Build the design framework
 #     mflowgen run --design $GARNET_HOME/mflowgen/full_chip
 #
-#     # 3. Build standalone context and execute target step "postroute_hold"
-#     get-step-context.sh $REFDIR cadence-innovus-postroute_hold
+#     #2. Build (link to) standalone context for the build
+#     get-step-context.sh /build/gold cadence-innovus-postroute_hold
+# 
+#     #3. Execute target step "postroute_hold"
 #     make cadence-innovus-postroute_hold
 
 REF=$1
 target_step=$2
-target_step=cadence-innovus-postroute_hold
-
-
-DBG=
+# target_step=cadence-innovus-postroute_hold
 
 echo "--- BEGIN $0 $*" | sed "s,$GARNET_HOME,\$GARNET_HOME,"
 echo "  where GARNET_HOME=$GARNET_HOME"
-
 echo "+++ STANDALONE TEST RIG SETUP - build symlinks to steps in $REF/full_chip";
 
 function find_dependences {
-    set -x
-
     # Example:
     #    find_dependences cadence-innovus-postroute_hold
     # 
     # Returns:
-    #      adk
     #      cadence-innovus-postroute
     #      cadence-innovus-flowsetup
 
@@ -66,15 +57,24 @@ function find_dependences {
 # Find-dependences came up with this:
 
 set -x
+echo -n "DEPENDENCES (virgin awk script): "
 find_dependences cadence-innovus-postroute_hold
 set +x
 echo ""
+
+########################################################################
+########################################################################
+########################################################################
+echo -n "DEPENDENCES (chad python script): "
+echo "TODO *NEXT*"
 echo ""
 echo ""
+########################################################################
+########################################################################
+########################################################################
 
 
-
-
+DBG=
 for step in cadence-innovus-postroute cadence-innovus-flowsetup; do
 
     [ "$DBG" ] && echo Processing step $step
@@ -111,23 +111,15 @@ for step in cadence-innovus-postroute cadence-innovus-flowsetup; do
 
 done
 
-echo "+++ TODO LIST";
-echo "make -n cadence-innovus-postroute_hold"
-make -n cadence-innovus-postroute_hold \
+echo "+++ READY TO BUILD STANDALONE $target_step"
+echo "make -n ${target_step}"
+make -n ${target_step} \
   |& egrep "^mkdir.*output" | sed "s/output.*//" | egrep -v ^Make
 
 
-# # Did we get away with it? Example of how to check:
-# echo "+++ TODO LIST"
-# function make-n-filter { egrep '^mkdir.*output' | sed 's/output.*//' | egrep -v ^Make ;}
-# make -n cadence-innovus-postroute_hold |& make-n-filter
-
-
-
-# NOTES
-
-
 exit
+########################################################################
+########################################################################
 ########################################################################
 # To run locally on kiwi can do this:
 do_this=OFF

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -4,23 +4,29 @@ if [ "$1" == "--help" ]; then cat <<EOF
 
 USAGE: $0 <refdir> <step>
 
-
 DESCRIPTION:
-Provides a way to (re)run an mflowgen step in a test directory
-without having to build the predecessor nodes for that step.
+Builds symbolic links to the appropriate collateral in reference dir
+<refdir> such that you can locally run mflowgen step <step>.
 
-So, assuming that
+EXAMPLE USE CASE:
+Suppose you have a design with multiple mflowgen steps.
 
-- you are in a valid mflowgen directory with a valid Makefile
-  such that "make list" gives a valid list of steps; and
+A version of the design exists in some directory "/build/chip1",
+but now you are putting together a new version "/build/chip2".
 
-- you would like to build one of these steps <step> but without
-  having to (re)build existing predecessor steps that already
-  exist in another build directory <refdir>;
+You want to reuse the existing chip1 collateral up through step
+"cadence-innovus-postroute_hold" and then rerun that step locally.
 
-This command builds linksthe necessary predecessor nodes in <refdir>
-such that you can do "make <step>" without having to rebuild them
-locally. nodes are renumbered as appropriate to account for changes in
+You can do this:
+  % cd /build/chip2
+  % get-step-context.sh /build/chip1 cadence-innovus-postroute_hold
+  % make *-cadence-innovus-postroute_hold
+
+NOTES:
+To use this command, you should be in a valid mflowgen directory with
+a Makefile such that "make list" gives a valid list of mflowgen steps.
+
+Linked nodes are renumbered as appropriate to account for changes in
 the graph between <refdir> and local dir.
 
 E.g. for <step> = 'cadence-innovus-postroute_hold' it might link
@@ -29,8 +35,8 @@ these two steps from <refdir> into current (build) dir
     ln -s ./23-cadence-innovus-flowsetup <refdir>/22-cadence-innovus-flowsetup
     ln -s ./31-cadence-innovus-postroute <refdir>/30-cadence-innovus-postroute
 
-
-EXAMPLE: to e.g. run standalone step "cadence-innovus-postroute_hold"
+REAL-WORLD EXAMPLE: 
+To e.g. run standalone step "cadence-innovus-postroute_hold"
 using cached information in refdir "/build/gold":
 
     1 Build the design framework
@@ -45,9 +51,12 @@ EOF
 exit
 fi
 
-
+if [ "$1" == "--from" ]; then shift; fi
 REF=$1
+
+if [ "$2" == "--step" ]; then shift; fi
 target_step=$2
+
 # target_step=cadence-innovus-postroute_hold
 
 echo "--- BEGIN $0 $*" | sed "s,$GARNET_HOME,\$GARNET_HOME,"

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -54,14 +54,13 @@ function find_dependences {
 
 # Find-dependences came up with this:
 
-echo -n "DEPENDENCES (virgin awk script): "
+echo ""; echo "DEPENDENCES (virgin awk script): "
 find_dependences cadence-innovus-postroute_hold
-echo ""
 
 ########################################################################
 ########################################################################
 ########################################################################
-echo -n "DEPENDENCES (chad python script): "
+echo ""; echo "DEPENDENCES (chad python script): "
 
 function find_dependences_py {
     # Find all dependent steps leading to indicated target step
@@ -87,7 +86,7 @@ function find_dependences_py {
 
     # Build and execute a python script
     # cat << ....EOF | sed 's/        //' > $pyfile
-    cat << ....EOF | sed 's/        //' | python3
+    cat << ....EOF | sed 's/        //' | python3 | sed 's/^[0-9]*[-]//'
         # 1. Read date from config yaml file
         import yaml; DBG=${DBG}
         config_file=".mflowgen/${stepdir}/configure.yml"
@@ -114,7 +113,7 @@ function find_dependences_py {
         exit()
 ....EOF
 
-#     python3 < $pyfile
+#     python3 < $pyfile | sed 's/^[0-9]*[-]//'
 #     /bin/rm ${pyfile}
     #    return $(python3 < $pyfile; /bin/rm $pyfile)
 }

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -71,9 +71,9 @@ echo "+++ STANDALONE TEST RIG SETUP - build symlinks to steps in $REF/full_chip"
 function get_predecessors {
 
     # Example:
-    #    find_dependences cadence-innovus-postroute_hold
+    #    get_predecessors cadence-innovus-postroute_hold
     # 
-    # Returns predecessor 'cadence-innovus-postroute_hold' odes:
+    # Returns predecessor 'cadence-innovus-postroute_hold' nodes:
     #      cadence-innovus-postroute
     #      cadence-innovus-flowsetup
     # 
@@ -217,107 +217,3 @@ if [ "$do_this" == "ON" ]; then
     mflowgen/bin/get-step-context.sh $REFDIR
     make cadence-innovus-postroute_hold
 fi
-
-########################################################################
-########################################################################
-########################################################################
-# OLD
-
-function find_dependences {
-    # Example:
-    #    find_dependences cadence-innovus-postroute_hold
-    # 
-    # Returns:
-    #      cadence-innovus-postroute
-    #      cadence-innovus-flowsetup
-    # 
-    # Notes:
-    #   - Ignores adk steps because it's better to redo those from scratch.
-    #   - Must run in a valid mflowgen design dir i.e. one with a '.mflowgen' subdir.
-    #   - Could do "test -e .mflowgen || ERROR"
-
-    stepname="$1"
-    stepnum=$(make list |& awk '$NF == "'$stepname'" {print $2; exit}')
-    # echo "FOUND $stepnum $stepname"
-
-    # Note for some reason it ignores adk dependences.
-    # Seems to work anyway I guess?
-    make info-$stepnum |& grep -v warning | sed 's/|//g' \
-         | awk '$NF ~ /^[0-9]/ {print $NF}; /^Parameters/{exit}' \
-         | sed "/$stepname\$/,\$d" \
-         | egrep -v 'freepdk|tsmc' \
-         | sed 's/^[0-9]*[-]//'
-}
-
-# Find-dependences came up with this:
-
-echo ""; echo "DEPENDENCES (virgin awk script): "
-find_dependences cadence-innovus-postroute_hold
-
-########################################################################
-########################################################################
-########################################################################
-echo ""; echo "DEPENDENCES (chad python script): "
-
-function find_dependences_py {
-    # Find all dependent steps leading to indicated target step
-    # 
-    # Example:
-    #    find_dependences cadence-innovus-postroute_hold
-    # 
-    # Returns the list
-    #   31-cadence-innovus-postroute
-    #   23-cadence-innovus-flowsetup
-    #
-    # Ignores adk steps because it's better to redo those from scratch.
-    # 
-    # Must run in a valid mflowgen design dir i.e. one with a '.mflowgen' subdir.
-    # Could do "test -e .mflowgen || ERROR"
-    target_step=${1}
-    # TEST: target_step="cadence-innovus-postroute_hold"
-
-    DBG=0
-    pyfile=deleteme.pyfile.$$
-    # Want e.g. stepdir = "32-cadence-innovus-postroute_hold"
-    stepdir=$(/bin/ls .mflowgen | egrep "^[0-9]*-${target_step}")
-
-    # Build and execute a python script
-    # cat << ....EOF | sed 's/        //' > $pyfile
-    cat << ....EOF | sed 's/        //' | python3 | sed 's/^[0-9]*[-]//'
-        # 1. Read date from config yaml file
-        import yaml; DBG=${DBG}
-        config_file=".mflowgen/${stepdir}/configure.yml"
-        if DBG: print(f"config file = '{config_file}'\n\n")
-        with open(config_file, 'r') as f: data = yaml.safe_load(f)
-        if DBG: print(data)
-
-        # 2. Find and print input edges; ignore adk edges
-        need_steps={}
-        ei = data['edges_i']
-        if DBG: print("Dependences found:")
-        for edge_name in ei:
-            filename = ei[edge_name][0]['f']    ; # E.g. "design.checkpoint" or "adk"
-            stepname = ei[edge_name][0]['step'] ; # E.g. "23-cadence-innovus-flowsetup"
-            # print(f"Step Found dependence {qf:30} in step '{stepname}/outputs'")
-            if DBG: print(f"STEP {stepname:30} FILE {filename:30}")
-
-            # Dunno if this is important, but I'd like to know when/if it happens...
-            assert filename == edge_name, "Edge name != filename...why?"
-
-            if filename != "adk": need_steps[stepname]=True;
-        if DBG: print("")
-        for s in need_steps: print(s)
-        exit()
-....EOF
-
-#     python3 < $pyfile | sed 's/^[0-9]*[-]//'
-#     /bin/rm ${pyfile}
-    #    return $(python3 < $pyfile; /bin/rm $pyfile)
-}
-
-
-find_dependences_py cadence-innovus-postroute_hold
-
-
-echo ""
-echo ""

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -1,27 +1,50 @@
 #!/bin/bash
 
-# Usage: $0 <refdir> <step>
-# 
-# Using ref/cached/gold build in <refdir>, find and link to the
-# context needed for a given target <step> node in an mflowgen build graph.
-# 
-# E.g. for cadence-innovus-postroute_hold we might link link these two
-# steps from <refdir> into current (build) dir
-# 
-#     ln -s 23-cadence-innovus-flowsetup <refdir>/23-cadence-innovus-postroute
-#     ln -s 31-cadence-innovus-postroute <refdir>/30-cadence-innovus-postroute
-# 
-# Example usage to e.g. run standalone step "cadence-innovus-postroute_hold"
-# in $RUNDIR using cached information in refdir "/build/gold":
-# 
-#     #1. Build the design framework
-#     mflowgen run --design $GARNET_HOME/mflowgen/full_chip
-#
-#     #2. Build (link to) standalone context for the build
-#     get-step-context.sh /build/gold cadence-innovus-postroute_hold
-# 
-#     #3. Execute target step "postroute_hold"
-#     make cadence-innovus-postroute_hold
+if [ "$1" == "--help" ]; then cat <<EOF
+
+USAGE: $0 <refdir> <step>
+
+
+DESCRIPTION:
+Provides a way to (re)run an mflowgen step in a test directory
+without having to build the predecessor nodes for that step.
+
+So, assuming that
+
+- you are in a valid mflowgen directory with a valid Makefile
+  such that "make list" gives a valid list of steps; and
+
+- you would like to build one of these steps <step> but without
+  having to (re)build existing predecessor steps that already
+  exist in another build directory <refdir>;
+
+This command builds linksthe necessary predecessor nodes in <refdir>
+such that you can do "make <step>" without having to rebuild them
+locally. nodes are renumbered as appropriate to account for changes in
+the graph between <refdir> and local dir.
+
+E.g. for <step> = 'cadence-innovus-postroute_hold' it might link
+these two steps from <refdir> into current (build) dir
+
+    ln -s ./23-cadence-innovus-flowsetup <refdir>/22-cadence-innovus-flowsetup
+    ln -s ./31-cadence-innovus-postroute <refdir>/30-cadence-innovus-postroute
+
+
+EXAMPLE: to e.g. run standalone step "cadence-innovus-postroute_hold"
+using cached information in refdir "/build/gold":
+
+    1 Build the design framework
+    mflowgen run --design $GARNET_HOME/mflowgen/full_chip
+
+    2 Build (link to) standalone context for the build
+    get-step-context.sh /build/gold cadence-innovus-postroute_hold
+
+    3 Execute target step "postroute_hold"
+    make cadence-innovus-postroute_hold
+EOF
+exit
+fi
+
 
 REF=$1
 target_step=$2

--- a/mflowgen/bin/get-step-context.sh
+++ b/mflowgen/bin/get-step-context.sh
@@ -31,115 +31,17 @@ echo "--- BEGIN $0 $*" | sed "s,$GARNET_HOME,\$GARNET_HOME,"
 echo "  where GARNET_HOME=$GARNET_HOME"
 echo "+++ STANDALONE TEST RIG SETUP - build symlinks to steps in $REF/full_chip";
 
-function find_dependences {
-    # Example:
-    #    find_dependences cadence-innovus-postroute_hold
-    # 
-    # Returns:
-    #      cadence-innovus-postroute
-    #      cadence-innovus-flowsetup
-    # 
-    # Notes:
-    #   - Ignores adk steps because it's better to redo those from scratch.
-    #   - Must run in a valid mflowgen design dir i.e. one with a '.mflowgen' subdir.
-    #   - Could do "test -e .mflowgen || ERROR"
-
-    stepname="$1"
-    stepnum=$(make list |& awk '$NF == "'$stepname'" {print $2; exit}')
-    # echo "FOUND $stepnum $stepname"
-
-    # Note for some reason it ignores adk dependences.
-    # Seems to work anyway I guess?
-    make info-$stepnum |& grep -v warning | sed 's/|//g' \
-         | awk '$NF ~ /^[0-9]/ {print $NF}; /^Parameters/{exit}' \
-         | sed "/$stepname\$/,\$d" \
-         | egrep -v 'freepdk|tsmc' \
-         | sed 's/^[0-9]*[-]//'
-}
-
-# Find-dependences came up with this:
-
-echo ""; echo "DEPENDENCES (virgin awk script): "
-find_dependences cadence-innovus-postroute_hold
-
-########################################################################
-########################################################################
-########################################################################
-echo ""; echo "DEPENDENCES (chad python script): "
-
-function find_dependences_py {
-    # Find all dependent steps leading to indicated target step
-    # 
-    # Example:
-    #    find_dependences cadence-innovus-postroute_hold
-    # 
-    # Returns the list
-    #   31-cadence-innovus-postroute
-    #   23-cadence-innovus-flowsetup
-    #
-    # Ignores adk steps because it's better to redo those from scratch.
-    # 
-    # Must run in a valid mflowgen design dir i.e. one with a '.mflowgen' subdir.
-    # Could do "test -e .mflowgen || ERROR"
-    target_step=${1}
-    # TEST: target_step="cadence-innovus-postroute_hold"
-
-    DBG=0
-    pyfile=deleteme.pyfile.$$
-    # Want e.g. stepdir = "32-cadence-innovus-postroute_hold"
-    stepdir=$(/bin/ls .mflowgen | egrep "^[0-9]*-${target_step}")
-
-    # Build and execute a python script
-    # cat << ....EOF | sed 's/        //' > $pyfile
-    cat << ....EOF | sed 's/        //' | python3 | sed 's/^[0-9]*[-]//'
-        # 1. Read date from config yaml file
-        import yaml; DBG=${DBG}
-        config_file=".mflowgen/${stepdir}/configure.yml"
-        if DBG: print(f"config file = '{config_file}'\n\n")
-        with open(config_file, 'r') as f: data = yaml.safe_load(f)
-        if DBG: print(data)
-
-        # 2. Find and print input edges; ignore adk edges
-        need_steps={}
-        ei = data['edges_i']
-        if DBG: print("Dependences found:")
-        for edge_name in ei:
-            filename = ei[edge_name][0]['f']    ; # E.g. "design.checkpoint" or "adk"
-            stepname = ei[edge_name][0]['step'] ; # E.g. "23-cadence-innovus-flowsetup"
-            # print(f"Step Found dependence {qf:30} in step '{stepname}/outputs'")
-            if DBG: print(f"STEP {stepname:30} FILE {filename:30}")
-
-            # Dunno if this is important, but I'd like to know when/if it happens...
-            assert filename == edge_name, "Edge name != filename...why?"
-
-            if filename != "adk": need_steps[stepname]=True;
-        if DBG: print("")
-        for s in need_steps: print(s)
-        exit()
-....EOF
-
-#     python3 < $pyfile | sed 's/^[0-9]*[-]//'
-#     /bin/rm ${pyfile}
-    #    return $(python3 < $pyfile; /bin/rm $pyfile)
-}
-
-
-find_dependences_py cadence-innovus-postroute_hold
-
-
-echo ""
-echo ""
 ########################################################################
 ########################################################################
 ########################################################################
 
 # Who's the chad now?
-function find_dependences_awk2 {
+function get_predecessors {
 
     # Example:
     #    find_dependences cadence-innovus-postroute_hold
     # 
-    # Returns:
+    # Returns predecessor 'cadence-innovus-postroute_hold' odes:
     #      cadence-innovus-postroute
     #      cadence-innovus-flowsetup
     # 
@@ -166,7 +68,7 @@ function find_dependences_awk2 {
     #       - f: innovus-foundation-flow
     #         step: 23-cadence-innovus-flowsetup
     # 
-    # And then use that to print this:
+    # Use that to print this (ignores adk nodes, see?)
     #     cadence-innovus-postroute
     #     cadence-innovus-flowsetup
 
@@ -177,8 +79,8 @@ function find_dependences_awk2 {
         $1 == "step:" { print $2 }' \
     | sed 's/^[0-9]*[-]//'
 }
-echo ""; echo "DEPENDENCES (mega-chad awk script): "
-find_dependences_awk2 cadence-innovus-postroute_hold
+echo ""; echo "NODE PREDS"
+get_predecessors cadence-innovus-postroute_hold
 echo ""
 echo ""
 
@@ -284,3 +186,106 @@ if [ "$do_this" == "ON" ]; then
     make cadence-innovus-postroute_hold
 fi
 
+########################################################################
+########################################################################
+########################################################################
+# OLD
+
+function find_dependences {
+    # Example:
+    #    find_dependences cadence-innovus-postroute_hold
+    # 
+    # Returns:
+    #      cadence-innovus-postroute
+    #      cadence-innovus-flowsetup
+    # 
+    # Notes:
+    #   - Ignores adk steps because it's better to redo those from scratch.
+    #   - Must run in a valid mflowgen design dir i.e. one with a '.mflowgen' subdir.
+    #   - Could do "test -e .mflowgen || ERROR"
+
+    stepname="$1"
+    stepnum=$(make list |& awk '$NF == "'$stepname'" {print $2; exit}')
+    # echo "FOUND $stepnum $stepname"
+
+    # Note for some reason it ignores adk dependences.
+    # Seems to work anyway I guess?
+    make info-$stepnum |& grep -v warning | sed 's/|//g' \
+         | awk '$NF ~ /^[0-9]/ {print $NF}; /^Parameters/{exit}' \
+         | sed "/$stepname\$/,\$d" \
+         | egrep -v 'freepdk|tsmc' \
+         | sed 's/^[0-9]*[-]//'
+}
+
+# Find-dependences came up with this:
+
+echo ""; echo "DEPENDENCES (virgin awk script): "
+find_dependences cadence-innovus-postroute_hold
+
+########################################################################
+########################################################################
+########################################################################
+echo ""; echo "DEPENDENCES (chad python script): "
+
+function find_dependences_py {
+    # Find all dependent steps leading to indicated target step
+    # 
+    # Example:
+    #    find_dependences cadence-innovus-postroute_hold
+    # 
+    # Returns the list
+    #   31-cadence-innovus-postroute
+    #   23-cadence-innovus-flowsetup
+    #
+    # Ignores adk steps because it's better to redo those from scratch.
+    # 
+    # Must run in a valid mflowgen design dir i.e. one with a '.mflowgen' subdir.
+    # Could do "test -e .mflowgen || ERROR"
+    target_step=${1}
+    # TEST: target_step="cadence-innovus-postroute_hold"
+
+    DBG=0
+    pyfile=deleteme.pyfile.$$
+    # Want e.g. stepdir = "32-cadence-innovus-postroute_hold"
+    stepdir=$(/bin/ls .mflowgen | egrep "^[0-9]*-${target_step}")
+
+    # Build and execute a python script
+    # cat << ....EOF | sed 's/        //' > $pyfile
+    cat << ....EOF | sed 's/        //' | python3 | sed 's/^[0-9]*[-]//'
+        # 1. Read date from config yaml file
+        import yaml; DBG=${DBG}
+        config_file=".mflowgen/${stepdir}/configure.yml"
+        if DBG: print(f"config file = '{config_file}'\n\n")
+        with open(config_file, 'r') as f: data = yaml.safe_load(f)
+        if DBG: print(data)
+
+        # 2. Find and print input edges; ignore adk edges
+        need_steps={}
+        ei = data['edges_i']
+        if DBG: print("Dependences found:")
+        for edge_name in ei:
+            filename = ei[edge_name][0]['f']    ; # E.g. "design.checkpoint" or "adk"
+            stepname = ei[edge_name][0]['step'] ; # E.g. "23-cadence-innovus-flowsetup"
+            # print(f"Step Found dependence {qf:30} in step '{stepname}/outputs'")
+            if DBG: print(f"STEP {stepname:30} FILE {filename:30}")
+
+            # Dunno if this is important, but I'd like to know when/if it happens...
+            assert filename == edge_name, "Edge name != filename...why?"
+
+            if filename != "adk": need_steps[stepname]=True;
+        if DBG: print("")
+        for s in need_steps: print(s)
+        exit()
+....EOF
+
+#     python3 < $pyfile | sed 's/^[0-9]*[-]//'
+#     /bin/rm ${pyfile}
+    #    return $(python3 < $pyfile; /bin/rm $pyfile)
+}
+
+
+find_dependences_py cadence-innovus-postroute_hold
+
+
+echo ""
+echo ""

--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -38,7 +38,7 @@ fi
 # SO. To keep things honest, will require '--dir'
 
 script=${BASH_SOURCE[0]}
-function usage {
+function setup_buildkite_usage {
     cat <<EOF
 Usage:
     source $script --dir < build-directory > [ OPTIONS ]
@@ -62,14 +62,14 @@ EOF
 ########################################################################
 # Args / switch processing
 
-if [ "$1" == "--help" ]; then usage; return; fi
+if [ "$1" == "--help" ]; then setup_buildkite_usage; return; fi
 
 if ! [ "$1" == "--dir" ]; then
     echo ""
     echo "**ERROR: missing required arg '--dir' i.e. might want to do something like"
     echo "$script --dir ."
     echo ""
-    usage; return 13
+    setup_buildkite_usage; return 13
 fi
 
 # Default is to use pre-built RTL from docker,
@@ -81,7 +81,7 @@ VERBOSE=false
 need_space=100G
 while [ $# -gt 0 ] ; do
     case "$1" in
-        -h|--help)    usage; return;    ;;
+        -h|--help)    setup_buildkite_usage; return;    ;;
         -v|--verbose) VERBOSE=true;  ;;
         -q|--quiet)   VERBOSE=false; ;;
         --dir)        shift; build_dir="$1"; ;;
@@ -94,7 +94,7 @@ while [ $# -gt 0 ] ; do
 
         # Any other 'dashed' arg
         -*)
-            echo "***ERROR: unrecognized arg '$1'"; usage; return 13; ;;
+            echo "***ERROR: unrecognized arg '$1'"; setup_buildkite_usage; return 13; ;;
     esac
     shift
 done

--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -69,7 +69,7 @@ if ! [ "$1" == "--dir" ]; then
     echo "**ERROR: missing required arg '--dir' i.e. might want to do something like"
     echo "$script --dir ."
     echo ""
-    setup_buildkite_usage; return 13
+    setup_buildkite_usage; return 13 || exit 13
 fi
 
 # Default is to use pre-built RTL from docker,
@@ -94,7 +94,7 @@ while [ $# -gt 0 ] ; do
 
         # Any other 'dashed' arg
         -*)
-            echo "***ERROR: unrecognized arg '$1'"; setup_buildkite_usage; return 13; ;;
+            echo "***ERROR: unrecognized arg '$1'"; setup_buildkite_usage; return 13 || exit 13; ;;
     esac
     shift
 done
@@ -270,7 +270,7 @@ if [ "$USER" == "buildkite-agent" ]; then
     venv=/usr/local/venv_garnet
     if ! test -d $venv; then
         echo "**ERROR: Cannot find pre-built environment '$venv'"
-        return 13
+        return 13 || exit 13
     fi
     echo "USING PRE-BUILT PYTHON VIRTUAL ENVIRONMENT '$venv'"
     source $venv/bin/activate
@@ -328,7 +328,7 @@ echo "--- REQUIREMENTS CHECK"; echo ""
 
 # Maybe don't need to check python libs and eggs no more...?
 # $garnet/bin/requirements_check.sh -v --debug
-$garnet/bin/requirements_check.sh -v --debug --pd_only || exit 13
+$garnet/bin/requirements_check.sh -v --debug --pd_only || return 13 || exit 13
 
 
 ########################################################################
@@ -430,11 +430,11 @@ if [ "$USER" == "buildkite-agent" ]; then
                 echo "  - Need to do a git pull on '$d'"
                 echo "  - Also see 'help adk'."
                 echo "---------------------------------------------------------"
-                exit 13
+                return 13 || exit 13
             fi
         popd
     }
-    check_adk $tsmc16 || exit 13
+    check_adk $tsmc16 || return 13 || exit 13
 
     # Copy the adk to test rig
     echo "Copying adks from '$tsmc16'"; ls -l $tsmc16; adks=$mflowgen/adks

--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -62,6 +62,8 @@ EOF
 ########################################################################
 # Args / switch processing
 
+if [ "$1" == "--help" ]; then usage; return; fi
+
 if ! [ "$1" == "--dir" ]; then
     echo ""
     echo "**ERROR: missing required arg '--dir' i.e. might want to do something like"

--- a/mflowgen/setup-garnet.sh
+++ b/mflowgen/setup-garnet.sh
@@ -10,7 +10,29 @@ module load genus/19.10.000
 module load innovus/19.10.000
 module load lc/M-2017.06-SP3 
 module load syn/P-2019.03
-module load calibre/2019.1
+
+########################################################################
+# Loading calibre/2019.1 results in loading mentor versions of binaries
+# e.g.
+#   /cad/mentor/2019.1/aoi_cal_2019.1_18.11/bin/tclsh and python3
+#
+# These binaries *do not work* on ubuntu systems. Worse, they usurp
+# the previously existing/working binaries in your path so that if
+# you try to run e.g. "python3" or "tclsh" from the command line you
+# just get the cryptic error "Invalid operating system environment".
+#
+# Because tclsh is thusly poisoned, the "module load" commands stop
+# working, among whatever other bad things might happen.
+#
+# My fix is to just skip this load if the OS is Ubuntu...
+
+tmp=`lsb_release -i | awk '{print $NF}'`
+if [ "$tmp" == "Ubuntu" ]; then
+    echo "Skipping calibre load because its binaries don't work under Ubuntu"
+else
+    echo module load calibre/2019.1
+fi
+
 module load pts/M-2017.06
 module load ext/latest
 


### PR DESCRIPTION
New mflowgen utility `get-step-context` for running a step standalone, using previously-cached predecessor steps.

### EXAMPLE USE CASE (`get-step-context --help`):

Suppose you have a design with multiple mflowgen steps. A version of the design exists in some directory `/build/chip1`, but now you are putting together a new version `/build/chip2`. You want to reuse the existing chip1 collateral up through step `cadence-innovus-postroute_hold` and then rerun that step locally.

You can use this new utility `get-step-context`:
```
  % cd /build/chip2
  % get-step-context.sh /build/chip1 cadence-innovus-postroute_hold
  % make *-cadence-innovus-postroute_hold
```

### Also included in this pull: various bug fixes unrelated to `get-step-context`
- `--help` for setup script
- check(s) to make sure `TMPDIR` exists
- tweaks to help keep `TMPDIR` clean and free of unnecessary garbage
- mflowgen install dir falls back to `/tmp` if default `/sim` dir does not exist
- problems with bad mentor binaries overriding good local commands (e.g. bad `tclsh` and `python`)
