### PR TITLE
Pass header files as inputs to rtl node of sub-graphs 

### DIFF
--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -6,6 +6,10 @@ if [ -f ../inputs/design.v ]; then
   echo "Using RTL from parent graph"
   mkdir -p outputs
   (cd outputs; ln -s ../../inputs/design.v)
+  if [ -d ../inputs/header ]; then
+    echo "Using header from parent graph"
+    (cd outputs; ln -s ../../inputs/header)
+  fi
 else
   if [ $soc_only = True ]; then
     echo "soc_only set to true. Garnet not included"

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -267,6 +267,10 @@ def construct():
 
   power.extend_outputs( ["design-merged.gds"] )
 
+  if parameters['interconnect_only'] is False:
+    rtl.extend_outputs( ['header'] )
+    rtl.extend_postconditions( ["assert File( 'outputs/header' ) "] )
+
   #-----------------------------------------------------------------------
   # Graph -- Add nodes
   #-----------------------------------------------------------------------
@@ -474,10 +478,6 @@ def construct():
   #-----------------------------------------------------------------------
   # Parameterize
   #-----------------------------------------------------------------------
-
-  if parameters['interconnect_only'] is not True:
-    rtl.extend_outputs( ['header'] )
-    rtl.extend_postconditions( ["assert File( 'outputs/header' ) "] )
 
   # Allow user to override parms with env in a limited sort of way
   parameters = sr_override_parms( parameters )

--- a/mflowgen/full_chip/glb_top/configure.yml
+++ b/mflowgen/full_chip/glb_top/configure.yml
@@ -5,6 +5,7 @@ commands:
 
 inputs:
   - design.v
+  - header
 
 outputs:
   - glb_top_tt.lib

--- a/mflowgen/glb_tile/construct.py
+++ b/mflowgen/glb_tile/construct.py
@@ -64,7 +64,7 @@ def construct():
 
   # Custom steps
 
-  rtl          = Step( this_dir + '/rtl'                          )
+  rtl          = Step( this_dir + '/../common/rtl'                          )
   constraints  = Step( this_dir + '/constraints'                  )
   gen_sram     = Step( this_dir + '/../common/gen_sram_macro'     )
   custom_init  = Step( this_dir + '/custom-init'                  )
@@ -128,6 +128,10 @@ def construct():
 
   init.extend_inputs( custom_init.all_outputs() )
   power.extend_inputs( custom_power.all_outputs() )
+
+  # Add header files to outputs
+  rtl.extend_outputs( ['header'] )
+  rtl.extend_postconditions( ["assert File( 'outputs/header' ) "] )
 
   #-----------------------------------------------------------------------
   # Add short_fix script(s) to list of available postroute_hold scripts
@@ -260,10 +264,6 @@ def construct():
   #-----------------------------------------------------------------------
 
   rtl.update_params( { 'glb_only': True }, allow_new=True )
-
-  # Add header files to outputs
-  rtl.extend_outputs( ['header'] )
-  rtl.extend_postconditions( ["assert File( 'outputs/header' ) "] )
 
   g.update_params( parameters )
 

--- a/mflowgen/glb_top/construct.py
+++ b/mflowgen/glb_top/construct.py
@@ -35,8 +35,11 @@ def construct():
     'topographical'  : True,
     # hold target slack
     'hold_target_slack'   : 0.045,
-    'array_width' : 4,
-    'num_glb_tiles'       : 2,
+    # array_width = width of CGRA below GLB; `pin-assignments.tcl` uses
+    # these parms to set up per-cgra-column ports connecting glb tile
+    # signals in glb_top to corresponding CGRA tile columns below glb_top
+    'array_width'         : 32,
+    'num_glb_tiles'       : 16,
     # glb tile memory size (unit: KB)
     'glb_tile_mem_size' : 256
   }

--- a/mflowgen/glb_top/glb_tile/configure.yml
+++ b/mflowgen/glb_top/glb_tile/configure.yml
@@ -5,6 +5,7 @@ commands:
 
 inputs:
   - design.v
+  - header
 
 outputs:
   - glb_tile_tt.lib


### PR DESCRIPTION
This PR passes `header` folder as inputs to rtl node of sub-graphs.
`header` folder contains all `AXI` related address map information where M3 can read/wrtie.
This file will be used in SoC simulation instead of hard-fixed address of AXI registers.