### PR TITLE
lake => lake-aha

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ coreir>=2.0.123  # should be first so we get the latest version
 -e git://github.com/Kuree/karst.git#egg=karst
 -e git://github.com/joyliu37/BufferMapping#egg=buffer_mapping
 -e git+git://github.com/pyhdi/pyverilog.git#egg=pyverilog
--e git+https://github.com/StanfordAHA/lake#egg=lake
+-e git+https://github.com/StanfordAHA/lake#egg=lake-aha
 -e git://github.com/phanrahan/magma.git#egg=magma-lang
 -e git://github.com/phanrahan/mantle.git#egg=mantle
 ordered_set


### PR DESCRIPTION
Not sure why, but full_chip build no longer works without this one-line change, such that requirements.txt specifies 'egg=lake-aha' instead of 'egg=lake'.

This is a simple change but very high priority, since we cannot do weekly builds until this is approved. Thanks! - Steve