### PR TITLE
fix erroneous glb signal names

### DIFF
--- a/mflowgen/full_chip/constraints/cons_scripts/garnet_constraints.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/garnet_constraints.tcl
@@ -15,8 +15,8 @@ set_multicycle_path 9 -hold -to [get_pins -hier *global_controller*/cgra_cfg_rd_
 set_multicycle_path 10 -setup -to [get_pins -hier *global_controller*/sram_cfg_rd_data*]
 set_multicycle_path 9 -hold -to [get_pins -hier *global_controller*/sram_cfg_rd_data*]
 
-set_multicycle_path 5 -setup -through [get_pins -hier *GlobalBuffer*/*interrupt_pulse*]
-set_multicycle_path 4 -hold  -through [get_pins -hier *GlobalBuffer*/*interrupt_pulse*]
+set_multicycle_path 5 -setup -through [get_pins -hier *global_buffer*/*interrupt_pulse*]
+set_multicycle_path 4 -hold  -through [get_pins -hier *global_buffer*/*interrupt_pulse*]
 
 # Dont touch analog nets for dragonphy
 


### PR DESCRIPTION
Oops we finalized the global-buffer pull a moment too soon. `full_chip` synthesis failed with the following error message
https://buildkite.com/tapeout-aha/fullchip/builds/306#dbb9023a-7a83-4119-a943-2303dc144f39
```
set_multicycle_path 5 -setup -through [get_pins -hier *GlobalBuffer*/*interrupt_pulse*]
Warning : Could not find requested search value. [SDC-208] [get_pins]
        : The 'get_pins' command  cannot find any pins named '*GlobalBuffer*/*interrupt_pulse*'
```


This pull implements the following change
```
-set_multicycle_path 5 -setup -through [get_pins -hier *GlobalBuffer*/*interrupt_pulse*]
-set_multicycle_path 4 -hold  -through [get_pins -hier *GlobalBuffer*/*interrupt_pulse*]
+set_multicycle_path 5 -setup -through [get_pins -hier *global_buffer*/*interrupt_pulse*]
+set_multicycle_path 4 -hold  -through [get_pins -hier *global_buffer*/*interrupt_pulse*]

```

...which I am testing now (offline) and so far it seems to be working. Then, when/if this synthesis step completes successfully, I will be able to restart the previous failed test (build 318) and, with any luck, complete the build.

What I need from my reviewers: see if this change makes sense to you, and/or if you think there are similar changes that need to be made elsewhere.

Thanks!
