### PR TITLE
Parameterize pipeline depth to control timing

### DIFF
--- a/global_buffer/Makefile
+++ b/global_buffer/Makefile
@@ -22,7 +22,7 @@ SDF_LOG ?= sdf_logs
 GLB_TOP_SDF ?= gls/glb.sdf
 GLB_TILE_SDF ?= gls/glb_tile.sdf
 
-RUN_ARGS ?= +TEST=3
+RUN_ARGS ?= +TEST=test1
 RUN_ARGS += +DEBUG
 
 RUN_LOG ?= run.log

--- a/global_buffer/design/glb_bank_ctrl.py
+++ b/global_buffer/design/glb_bank_ctrl.py
@@ -45,8 +45,8 @@ class GlbBankCtrl(Generator):
         self.if_sram_cfg_s = self.interface(
             self.bank_cfg_ifc.slave, f"if_sram_cfg_s", is_port=True)
 
-        # TODO: This should not be hard-fixed
-        self.bank_ctrl_pipeline_depth = 3
+        self.bank_ctrl_pipeline_depth = self._params.glb_bank_memory_pipeline_depth + \
+            self._params.sram_gen_pipeline_depth + self._params.sram_gen_output_pipeline_depth + 1
 
         # local variables
         self.sram_cfg_rd_data_r = self.var(

--- a/global_buffer/design/glb_bank_memory.py
+++ b/global_buffer/design/glb_bank_memory.py
@@ -19,10 +19,6 @@ class GlbBankMemory(Generator):
             "data_in_bit_sel", self._params.bank_data_width)
         self.data_out = self.output("data_out", self._params.bank_data_width)
 
-        # TODO: This should be parameter
-        self.glb_bank_memory_pipeline_depth = 1
-        self.sram_gen_latency = 2
-
         # local variables
         self.sram_wen = self.var("sram_wen", 1)
         self.sram_wen_d = self.var("sram_wen_d", 1)
@@ -65,7 +61,7 @@ class GlbBankMemory(Generator):
                                   self.sram_addr_d, self.sram_data_in_d, self.sram_data_in_bit_sel_d)
 
         sram_signals_pipeline = Pipeline(width=sram_signals_in.width,
-                                         depth=self.glb_bank_memory_pipeline_depth)
+                                         depth=self._params.glb_bank_memory_pipeline_depth)
         self.add_child(f"sram_signals_pipeline",
                        sram_signals_pipeline,
                        clk=self.clk,
@@ -75,7 +71,9 @@ class GlbBankMemory(Generator):
                        out_=sram_signals_out)
 
         self.sram_ren_rsp_pipeline = Pipeline(width=1,
-                                              depth=self.sram_gen_latency)
+                                              depth=(self._params.sram_gen_pipeline_depth
+                                                     + self._params.sram_gen_output_pipeline_depth
+                                                     + 1))
         self.add_child("sram_ren_rsp_pipeline",
                        self.sram_ren_rsp_pipeline,
                        clk=self.clk,
@@ -88,7 +86,8 @@ class GlbBankMemory(Generator):
         self.glb_bank_sram_gen = GlbBankSramGen(addr_width=(self._params.bank_addr_width
                                                             - self._params.bank_byte_offset),
                                                 sram_macro_width=self._params.bank_data_width,
-                                                sram_macro_depth=self._params.sram_macro_depth)
+                                                sram_macro_depth=self._params.sram_macro_depth,
+                                                _params=self._params)
         self.add_child("glb_bank_sram_gen",
                        self.glb_bank_sram_gen,
                        CLK=self.clk,

--- a/global_buffer/design/glb_core_pcfg_dma.py
+++ b/global_buffer/design/glb_core_pcfg_dma.py
@@ -32,10 +32,15 @@ class GlbCorePcfgDma(Generator):
         # localparam
         self.bank_data_byte_offset = math.ceil(
             self._params.bank_data_width / 8)
-        # TODO: For now, we assume that it takes 8 cycles to finish configuring the chip after sending the last rdrq
-        self.default_latency = 8
-        # TODO: Interrupt pulse width can be just one cycle?
-        self.interrupt_pulse_width = 4  # This is not used now.
+        self.default_latency = (self._params.glb_switch_pipeline_depth
+                                + self._params.glb_bank_memory_pipeline_depth
+                                + self._params.sram_gen_pipeline_depth
+                                + self._params.sram_gen_output_pipeline_depth
+                                + 1  # SRAM macro read latency
+                                + self._params.glb_switch_pipeline_depth
+                                + 2  # FIXME: Unnecessary delay of moving back and forth btw switch and router
+                                + 1  # dma cache register delay
+                                )
 
         # local variables
         self.is_running_r = self.var("is_running_r", 1)

--- a/global_buffer/design/glb_core_store_dma.py
+++ b/global_buffer/design/glb_core_store_dma.py
@@ -33,8 +33,8 @@ class GlbCoreStoreDma(Generator):
         self.st_dma_done_pulse = self.output("st_dma_done_pulse", 1)
 
         # localparam
-        self.default_latency = 3
-
+        self.default_latency = self._params.glb_bank_memory_pipeline_depth + \
+            self._params.sram_gen_pipeline_depth + self._params.glb_switch_pipeline_depth
         # local variables
         self.data_f2g_d1 = self.var(
             "data_f2g_d1", width=self._params.cgra_data_width)
@@ -349,7 +349,6 @@ class GlbCoreStoreDma(Generator):
         self.done_pulse_w = self.strm_done & (~self.strm_done_d1)
 
     def add_done_pulse_pipeline(self):
-        # TODO: This maximum latency should be automatically set
         maximum_latency = 2 * self._params.num_glb_tiles + self.default_latency
         latency_width = clog2(maximum_latency)
         self.done_pulse_d_arr = self.var(

--- a/global_buffer/design/global_buffer_parameter.py
+++ b/global_buffer/design/global_buffer_parameter.py
@@ -66,7 +66,11 @@ class GlobalBufferParams:
     # dma latency
     latency_width: int = 2 + math.ceil(math.log(num_glb_tiles, 2))
 
-    glb_switch_pipeline_depth: int = 4
+    # pipeline depth
+    glb_switch_pipeline_depth: int = 1  # fixed
+    glb_bank_memory_pipeline_depth: int = 1
+    sram_gen_pipeline_depth: int = 1
+    sram_gen_output_pipeline_depth: int = 1
 
 
 def gen_global_buffer_params(**kwargs):
@@ -90,7 +94,9 @@ def gen_global_buffer_params(**kwargs):
     max_stride_width = kwargs.pop('max_stride_width', 10)
     queue_depth = kwargs.pop('queue_depth', 2)
     loop_level = kwargs.pop('loop_level', 4)
-    glb_switch_pipeline_depth = kwargs.pop('glb_switch_pipeline_depth', 4)
+    glb_bank_memory_pipeline_depth = kwargs.pop('glb_bank_memory_pipeline_depth', 1)
+    sram_gen_pipeline_depth = kwargs.pop('sram_gen_pipeline_depth', 1)
+    sram_gen_output_pipeline_depth = kwargs.pop('sram_gen_output_pipeline_depth', 1)
 
     # Check if there is unused kwargs
     if kwargs:
@@ -156,7 +162,9 @@ def gen_global_buffer_params(**kwargs):
                                 queue_depth=queue_depth,
                                 loop_level=loop_level,
                                 latency_width=latency_width,
-                                glb_switch_pipeline_depth=glb_switch_pipeline_depth
+                                glb_bank_memory_pipeline_depth=glb_bank_memory_pipeline_depth,
+                                sram_gen_pipeline_depth=sram_gen_pipeline_depth,
+                                sram_gen_output_pipeline_depth=sram_gen_output_pipeline_depth
                                 )
     return params
 


### PR DESCRIPTION
This PR parameterize the `pipeline` depth in several places in `global buffer`.
By changing the parameter at the very top, we can easily control the pipeline depth.
This can be useful if we need to increase pipeline depth to meet timing during PD.