### PR TITLE
Add script to parse power report and dump breakdown by modules

### DIFF
--- a/mflowgen/glb_top/synopsys-ptpx-gl/configure.yml
+++ b/mflowgen/glb_top/synopsys-ptpx-gl/configure.yml
@@ -39,5 +39,5 @@ parameters:
   strip_path: top/dut
   PWR_AWARE: False
   instances: ["glb_tile_gen_0", "glb_tile_gen_1"]
-  parse_modules: ["CTS.*", "RC_CG.*", "glb_tile_cfg", "glb_core_switch", "glb_core_proc_router", "glb_core_strm_router", "glb_core_[load|store]_dma", "[pcfg_dma|pcfg_switch|pcfg_router]", "glb_bank_memory", "sram_cfg_ctrl"]
+  parse_modules: ["CTS.*", "RC_CG.*", "glb_tile_cfg", "glb_core_switch", "glb_core_proc_router", "glb_core_strm_router", "'glb_core_(load|store)_dma'", "'(pcfg_dma|pcfg_switch|pcfg_router)'", "glb_bank_memory", "sram_cfg_ctrl"]
   chkpt: False # Turn this on to save periodically during ptpx flow

--- a/mflowgen/glb_top/synopsys-ptpx-gl/configure.yml
+++ b/mflowgen/glb_top/synopsys-ptpx-gl/configure.yml
@@ -38,5 +38,5 @@ parameters:
   design_name: undefined
   strip_path: top/dut
   PWR_AWARE: False
-  batch: False
+  instances: ["glb_tile_gen_0", "glb_tile_gen_1"]
   chkpt: False # Turn this on to save periodically during ptpx flow

--- a/mflowgen/glb_top/synopsys-ptpx-gl/configure.yml
+++ b/mflowgen/glb_top/synopsys-ptpx-gl/configure.yml
@@ -39,4 +39,5 @@ parameters:
   strip_path: top/dut
   PWR_AWARE: False
   instances: ["glb_tile_gen_0", "glb_tile_gen_1"]
+  parse_modules: ["CTS.*", "RC_CG.*", "glb_tile_cfg", "glb_core_switch", "glb_core_proc_router", "glb_core_strm_router", "glb_core_[load|store]_dma", "[pcfg_dma|pcfg_switch|pcfg_router]", "glb_bank_memory", "sram_cfg_ctrl"]
   chkpt: False # Turn this on to save periodically during ptpx flow

--- a/mflowgen/glb_top/synopsys-ptpx-gl/parse_report.py
+++ b/mflowgen/glb_top/synopsys-ptpx-gl/parse_report.py
@@ -1,0 +1,34 @@
+import argparse
+import pandas as pd
+
+
+def gen_power_df(filename: str, instances: list):
+    power_columns = ['internal', 'switching', 'leakage', 'total']
+    power_df = pd.DataFrame(0.0, index=instances, columns=power_columns)
+    with open(filename, 'r') as f:
+        line_start = False
+        for line in f.readlines():
+            if line_start is True:
+                for inst in instances:
+                    if inst in line:
+                        line_list = line.split()
+                        power_df.loc[inst] += list(map(float, line_list[1:5]))
+            elif line.startswith( '---------------------' ):
+                line_start = True
+    
+    return power_df
+        
+
+def main():
+    parser = argparse.ArgumentParser(description='Power Report Parser')
+    parser.add_argument('--filename', '-f', type=str, default="")
+    parser.add_argument('--instances', '-i', nargs='+', default=[])
+    parser.add_argument('--csv', '-c', type=str, default="power_by_module.csv")
+    args = parser.parse_args()
+
+    power_df = gen_power_df(args.filename, args.instances)
+    power_df.to_csv(args.csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/mflowgen/glb_top/synopsys-ptpx-gl/parse_report.py
+++ b/mflowgen/glb_top/synopsys-ptpx-gl/parse_report.py
@@ -1,5 +1,6 @@
 import argparse
 import pandas as pd
+import re
 
 
 def gen_power_df(filename: str, instances: list):
@@ -9,10 +10,20 @@ def gen_power_df(filename: str, instances: list):
         line_start = False
         for line in f.readlines():
             if line_start is True:
+                if line.startswith( '---------------------' ):
+                    break
+                is_counted = False
+                line_list = line.split()
+                cell_name = line_list[0]
+                power_list = line_list[1:5]
                 for inst in instances:
-                    if inst in line:
-                        line_list = line.split()
-                        power_df.loc[inst] += list(map(float, line_list[1:5]))
+                    if bool(re.search(inst, cell_name)) is True:
+                        power_df.loc[inst] += list(map(float, power_list))
+                        is_counted = True
+                        break  # inst should be included in only one index
+                if is_counted is False:  # If not counted, add it to misc.
+                    line_list = line.split()
+                    power_df.loc['misc'] += list(map(float, power_list))
             elif line.startswith( '---------------------' ):
                 line_start = True
     
@@ -26,7 +37,9 @@ def main():
     parser.add_argument('--csv', '-c', type=str, default="power_by_module.csv")
     args = parser.parse_args()
 
-    power_df = gen_power_df(args.filename, args.instances)
+    if 'misc' not in args.instances:
+        instances = args.instances + ['misc']
+    power_df = gen_power_df(args.filename, instances)
     power_df.to_csv(args.csv)
 
 

--- a/mflowgen/glb_top/synopsys-ptpx-gl/ptpx.tcl
+++ b/mflowgen/glb_top/synopsys-ptpx-gl/ptpx.tcl
@@ -127,7 +127,24 @@ report_power -nosplit -hierarchy -sort_by total_power \
   > reports/${ptpx_design_name}.power.hier.rpt
 
 report_power -nosplit -hierarchy -leaf -levels 10 -sort_by total_power \
+  > reports/${ptpx_design_name}.power.leaf.rpt
+
+report_power -nosplit -cell -leaf -sort_by total_power \
   > reports/${ptpx_design_name}.power.cell.rpt
+
+# Report power summary and breakdown of sub-instances
+foreach instance [split $::env(instances) ,] {
+    current_instance "/${ptpx_design_name}/${instance}"
+
+    report_power -nosplit \
+      > reports/${instance}.power.rpt
+    
+    report_power -nosplit -hierarchy -leaf -levels 10 -sort_by total_power \
+      > reports/${instance}.power.leaf.rpt
+
+    report_power -nosplit -cell -leaf -sort_by total_power \
+      > reports/${instance}.power.cell.rpt
+}
 
 ###
 save_session chk_final

--- a/mflowgen/glb_top/synopsys-ptpx-gl/run_step.sh
+++ b/mflowgen/glb_top/synopsys-ptpx-gl/run_step.sh
@@ -4,3 +4,10 @@ mkdir -p reports logs
 pt_shell -f ptpx.tcl | tee logs/pt.log
 cp reports/${design_name}.power.hier.rpt outputs/power.hier
 cp reports/${design_name}.power.cell.rpt outputs/power.cell
+
+
+for inst in $(echo $instances | sed "s/,/ /g")
+do
+    python parse_report.py --filename reports/${inst}.power.cell.rpt --instances $(echo $parse_modules | sed "s/,/ /g") --csv reports/${inst}.csv
+done
+


### PR DESCRIPTION
This PR adds a python script to parse the power report and dump the power breakdown by blocks into `.csv` file.
There are two parameters
`instances`: (list) The top module of the breakdown.
`parse_modules`: (list) Module name of each breakdown. They follow regex.