### PR TITLE
Add workaround for wildcard for docker cmd

### DIFF
--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -145,8 +145,11 @@ else
       if [ $glb_only == True ]; then
         docker cp $container_name:/aha/garnet/global_buffer/header ../outputs/header
       elif [ $interconnect_only == False ]; then
-        docker cp $container_name:/aha/garnet/global_buffer/header ../outputs/header
-        docker cp $container_name:/aha/garnet/global_controller/header/* ../outputs/header/
+        docker cp $container_name:/aha/garnet/global_buffer/header ../glb_header
+        docker cp $container_name:/aha/garnet/global_controller/header ../glc_header
+        mkdir ../outputs/header
+        cp -r ../glb_header/* ../outputs/header/
+        cp -r ../glc_header/* ../outputs/header/
       fi
       # Kill the container
       docker kill $container_name

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -65,9 +65,9 @@ def construct():
     'flatten_effort'    : 0,
     'topographical'     : True,
     # RTL Generation
-    'array_width'       : 32,
-    'array_height'      : 16,
-    'num_glb_tiles'     : 16,
+    'array_width'       : 4,
+    'array_height'      : 4,
+    'num_glb_tiles'     : 2,
     'interconnect_only' : False,
     # glb tile memory size (unit: KB)
     # 'glb_tile_mem_size' : 64,  #  64x16 => 1M global buffer


### PR DESCRIPTION
As `docker cp` does not support wildcard, this PR adds a workaround for that.
