### PR TITLE
Fix reqs url

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coreir>=2.0.123  # should be first so we get the latest version
--e git://github.com/StanfordAHA/gemstone.git#egg=gemstone
+-e git+https://github.com/StanfordAHA/gemstone.git#egg=gemstone
 -e git://github.com/StanfordAHA/canal.git#egg=canal
 -e git://github.com/phanrahan/peak.git#egg=peak
 -e git://github.com/StanfordAHA/lassen.git#egg=lassen

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coreir>=2.0.123  # should be first so we get the latest version
 -e git+https://github.com/StanfordAHA/lassen.git#egg=lassen
 -e git+https://github.com/Kuree/karst.git#egg=karst
 -e git+https://github.com/joyliu37/BufferMapping#egg=buffer_mapping
--e git+git://github.com/pyhdi/pyverilog.git#egg=pyverilog
+-e git+https://github.com/pyhdi/pyverilog.git#egg=pyverilog
 -e git+https://github.com/StanfordAHA/lake#egg=lake-aha
 -e git+https://github.com/phanrahan/magma.git#egg=magma-lang
 -e git+https://github.com/phanrahan/mantle.git#egg=mantle
@@ -13,6 +13,6 @@ ordered_set
 cosa
 -e git+https://github.com/leonardt/fault.git#egg=fault
 hwtypes
--e git+git://github.com/Kuree/archipelago.git#egg=archipelago
+-e git+https://github.com/Kuree/archipelago.git#egg=archipelago
 systemrdl-compiler
 peakrdl-html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
 coreir>=2.0.123  # should be first so we get the latest version
 -e git+https://github.com/StanfordAHA/gemstone.git#egg=gemstone
--e git://github.com/StanfordAHA/canal.git#egg=canal
--e git://github.com/phanrahan/peak.git#egg=peak
--e git://github.com/StanfordAHA/lassen.git#egg=lassen
--e git://github.com/Kuree/karst.git#egg=karst
--e git://github.com/joyliu37/BufferMapping#egg=buffer_mapping
+-e git+https://github.com/StanfordAHA/canal.git#egg=canal
+-e git+https://github.com/phanrahan/peak.git#egg=peak
+-e git+https://github.com/StanfordAHA/lassen.git#egg=lassen
+-e git+https://github.com/Kuree/karst.git#egg=karst
+-e git+https://github.com/joyliu37/BufferMapping#egg=buffer_mapping
 -e git+git://github.com/pyhdi/pyverilog.git#egg=pyverilog
 -e git+https://github.com/StanfordAHA/lake#egg=lake-aha
--e git://github.com/phanrahan/magma.git#egg=magma-lang
--e git://github.com/phanrahan/mantle.git#egg=mantle
+-e git+https://github.com/phanrahan/magma.git#egg=magma-lang
+-e git+https://github.com/phanrahan/mantle.git#egg=mantle
 ordered_set
 cosa
--e git://github.com/leonardt/fault.git#egg=fault
+-e git+https://github.com/leonardt/fault.git#egg=fault
 hwtypes
 -e git+git://github.com/Kuree/archipelago.git#egg=archipelago
 systemrdl-compiler


### PR DESCRIPTION
As per git [blog](https://github.blog/2021-09-01-improving-git-protocol-security-github/), as of today Github is no longer accepting unencrypted Git protocol, even on clones. Updated requirements.txt to comply.