### PR TITLE
fix rtl_docker_image param name mixup

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -53,7 +53,7 @@ def construct():
     'core_density_target' : 0.68,
     # RTL Generation
     'interconnect_only'   : True,
-    'docker_rtl_image'    : 'default', # Current default is 'stanfordaha/garnet:latest'
+    'rtl_docker_image'    : 'default', # Current default is 'stanfordaha/garnet:latest'
     # Power Domains
     'PWR_AWARE'         : pwr_aware,
     # Power analysis

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -46,7 +46,7 @@ def construct():
     'topographical'     : True,
     # RTL Generation
     'interconnect_only' : True,
-    'docker_rtl_image'  : 'default', # Current default is 'stanfordaha/garnet:latest'
+    'rtl_docker_image'  : 'default', # Current default is 'stanfordaha/garnet:latest'
     # Power Domains
     'PWR_AWARE'         : pwr_aware,
     'core_density_target': 0.63,

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -27,13 +27,13 @@ parameters:
   save_verilog_to_tmpdir: False
 
   # Current default is 'stanfordaha/garnet:latest'
-  docker_rtl_image: default
+  rtl_docker_image: default
 
   ############################################################################
   # To try out a new docker image e.g. 'stanfordaha/garnet:cst' or 'stanfordaha/garnet@sha256:1e4a0bf29f3bad8e3...'
   #   - set 'save_verilog_to_tmpdir' to "True"
-  #   - set docker_rtl_image to latest, then build (latest) rtl
-  #   - change docker_rtl_image to cst, then build (cst) rtl
+  #   - set rtl_docker_image to latest, then build (latest) rtl
+  #   - change rtl_docker_image to cst, then build (cst) rtl
   #   - should see before-and-after designs in /tmp directory:
   # 
   #   % ls -lt /tmp/design.v.*


### PR DESCRIPTION
Fixes bug from #835 that used `rtl_docker_image` param in scripts but only defined `docker_rtl_image`.