### PR TITLE
PD: Modified GLB placement

### DIFF
--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -29,15 +29,13 @@ proc add_core_fiducials {} {
   set y 4008
   set cols [expr 42 - 2]; # 42 columns, this is how we do it :(
 
-  #   # Put dtcd between four bumps and as close to UR corner as it can get
-  #   set ::env(DTCD_X) 3840; set ::env(DTCD_Y) 3840
-  #
-  # Hm all the congestion is on the left side of the GLB. And this
-  # DTCD cell is below the top edge of the GLB, so if DTCD is near UR
-  # corner, that blocks GLB from moving further to the right.  How
-  # about we put DTCD symmetrically across on the LEFT side so GLB can
-  # move to the right when/if we want to alleviate congestion?
-  # FIXME these numbers should probably be a function of die size etc.
+  # Previously had DTCD on right side of GLB at (3840,3840). But all
+  # the congestion appears to be on the left side of the GLB. The DTCD
+  # cell was preventing us from moving the GLB rightward to alleviate
+  # the congestion. So now we hvae put DTCD symmetrically across on
+  # the LEFT side so GLB can move to the right when/if we want to
+  # alleviate congestion?
+  # FIXME the below numbers should probably be a function of die size etc.
   set ::env(DTCD_X) 1055; set ::env(DTCD_Y) 3840
 
   # Place!

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -27,9 +27,20 @@ proc add_core_fiducials {} {
   set x [snap_to_grid  700.00 0.09 99.99]
   # Put icovl array between bump rows near top of die
   set y 4008
-  # Put dtcd between four bumps and as close to UR corner as it can get
-  set ::env(DTCD_X) 3840; set ::env(DTCD_Y) 3840
   set cols [expr 42 - 2]; # 42 columns, this is how we do it :(
+
+  #   # Put dtcd between four bumps and as close to UR corner as it can get
+  #   set ::env(DTCD_X) 3840; set ::env(DTCD_Y) 3840
+  #
+  # Hm all the congestion is on the left side of the GLB. And this
+  # DTCD cell is below the top edge of the GLB, so if DTCD is near UR
+  # corner, that blocks GLB from moving further to the right.  How
+  # about we put DTCD symmetrically across on the LEFT side so GLB can
+  # move to the right when/if we want to alleviate congestion?
+  # FIXME these numbers should probably be a function of die size etc.
+  set ::env(DTCD_X) 1055; set ::env(DTCD_Y) 3840
+
+  # Place!
   gen_fiducial_set $x $y cc true $cols
 
   puts "--- @file_info end ICOVL"

--- a/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
+++ b/mflowgen/common/init-fullchip/outputs/alignment-cells.tcl
@@ -32,9 +32,9 @@ proc add_core_fiducials {} {
   # Previously had DTCD on right side of GLB at (3840,3840). But all
   # the congestion appears to be on the left side of the GLB. The DTCD
   # cell was preventing us from moving the GLB rightward to alleviate
-  # the congestion. So now we hvae put DTCD symmetrically across on
-  # the LEFT side so GLB can move to the right when/if we want to
-  # alleviate congestion?
+  # the congestion. So now we hvae put DTCD symmetrically across on the
+  # LEFT side so GLB can move to the right whenever and however much we like.
+  #
   # FIXME the below numbers should probably be a function of die size etc.
   set ::env(DTCD_X) 1055; set ::env(DTCD_Y) 3840
 

--- a/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
+++ b/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
@@ -20,7 +20,7 @@ if { ! $::env(soc_only) } {
   # squeezes up against a row of alignment cells, so I'm moving the
   # GLB down a bit to open it up.
   # Tried moving down 15u, that wasn't enough, now increased to 45u.
-  # (Note ic2glb_y_dist is in units of 'vert_pitches', so 45u ~ 
+  # (Note ic2glb_y_dist is in units of 'vert_pitches', and 45u ~ 78 vp's.)
   # FIXME later should express this as a function of alignment-cell location.
   set ic2glb_y_dist [expr $ic2glb_y_dist - 78]
 

--- a/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
+++ b/mflowgen/full_chip/custom-init/outputs/place-macros.tcl
@@ -15,6 +15,15 @@ if { ! $::env(soc_only) } {
   set ic2glb_y_dist 330
   set ic2glc_y_dist 600
 
+  ##############################################################################
+  # Lots of congestion at top left corner of GLB, where the top
+  # squeezes up against a row of alignment cells, so I'm moving the
+  # GLB down a bit to open it up.
+  # Tried moving down 15u, that wasn't enough, now increased to 45u.
+  # (Note ic2glb_y_dist is in units of 'vert_pitches', so 45u ~ 
+  # FIXME later should express this as a function of alignment-cell location.
+  set ic2glb_y_dist [expr $ic2glb_y_dist - 78]
+
   # power mesh vars
   set M3_route_pitchX [dbGet [dbGetLayerByZ 3].pitchX]    
   set M3_str_pitch [expr 10 * $M3_route_pitchX]
@@ -62,7 +71,6 @@ if { ! $::env(soc_only) } {
     -pgnetonly \
     -box [expr $ic_x_loc + (8*$horiz_pitch)] $ic_y_loc [expr $ic_urx - (8*$horiz_pitch)] $ic_ury
   
-
   # GLB placement prep
   set glb [get_cells -hier -filter {ref_lib_cell_name==global_buffer}]
   set glb_name [get_property $glb hierarchical_name]
@@ -72,50 +80,17 @@ if { ! $::env(soc_only) } {
   set glb_y_loc [snap_to_grid [expr $ic_y_loc + $ic_height + ($vert_pitch * $ic2glb_y_dist)] $pmesh_bot_pitch]
   set glb_x_loc [snap_to_grid [expr ([dbGet top.fPlan.box_sizex] - $glb_width)/2.] $pmesh_top_pitch]
   
-  # Prevent GLB / alignment-cell overlap
-  proc avoid_alignment_cells { glb_x_loc glb_width pmesh_top_pitch } {
-
-    # Find left edge of alignment cell
-    set blockage [ lindex [ get_db route_blockages ifid_dtcd_feol_cc_42_bigblockgf ] 1 ]
-    set rects [ get_db $blockage .rects ]; # e.g. {3822.5 3822.5 3862.588 3862.588}
-    set llx [lindex [lindex $rects 0] 0];  # e.g. 3822.5
-    set alignment_cell_left_edge $llx;     # e.g. 3822.5
-    echo "Left edge of alignment halo = $alignment_cell_left_edge"
-
-    # Find right edge of glb, including some amount of margin for
-    # space between glb and alignment cell. Arbitrarily chose
-    # pmesh-top-pitch for the margin; TODO/FIXME: think about what the
-    # right number should be
-
-    set glb_margin $pmesh_top_pitch; 
-    set glb_right_edge [expr $glb_x_loc + $glb_width + $glb_margin]
-    echo "Right edge of global buffer = $glb_right_edge"
-
-    # If overlap exists, try and fix it.
-    if { $glb_right_edge > $alignment_cell_left_edge } {
-      echo "WARNING global buffer overlaps alignment cell";
-      set nshifts     0
-      set nshifts_max 10
-      while { $glb_right_edge > $alignment_cell_left_edge } {
-        echo "...Shifting global buffer left $pmesh_top_pitch microns";
-        set glb_x_loc [snap_to_grid [expr $glb_x_loc - $pmesh_top_pitch] $pmesh_top_pitch]
-        set glb_right_edge [expr $glb_x_loc + $glb_width + $glb_margin]
-
-        set nshifts [expr $nshifts + 1]
-        if { $nshifts >= $nshifts_max } {
-            echo "ERROR: Shifted global buffer left $nshifts times, still overlaps alignment cell"
-            echo exit 13
-        }
-      }
-      set gap [expr  $glb_margin + $alignment_cell_left_edge - $glb_right_edge]
-      echo "Now right edge of global buffer = $glb_right_edge"
-      echo "Gap between glb and align cell = $gap" 
-    }
-    return $glb_x_loc
-  }
-  set glb_x_loc [avoid_alignment_cells $glb_x_loc $glb_width $pmesh_top_pitch]
-
-  # GLB placement
+  ##############################################################################
+  # Lots of congestion to the left of GLB where there are SRAMs and such.
+  # But nothing on the right side of the GLB really.
+  # So I moved the lone lower-alignment-cell from right side of GLB to
+  # left side (see alignment-cells.tcl), giving us room to move GLB to
+  # the right, away from the congested area.
+  # Currently adding ~ 300u (3300 horiz pitches), probably more than needed.
+  set glb_x_loc [ expr $glb_x_loc + (3300 * $horiz_pitch) ]
+  set glb_x_loc [ snap_to_grid $glb_x_loc $pmesh_bot_pitch ]
+  
+  # Place GLB
   placeinstance $glb_name $glb_x_loc $glb_y_loc -fixed
   addHaloToBlock [expr $horiz_pitch * 3] $vert_pitch [expr $horiz_pitch * 3] $vert_pitch $glb_name -snapToSite
   
@@ -148,6 +123,7 @@ if { ! $::env(soc_only) } {
     -pgnetonly \
     -box [expr $glb_x_loc + (8*$horiz_pitch)] $glb_y_loc [expr $glb_urx - (8*$horiz_pitch)] $glb_ury
   
+  # Place GLB controller
   set glc [get_cells -hier -filter {ref_lib_cell_name==global_controller}]
   set glc_name [get_property $glc hierarchical_name]
   set glc_width [dbGet [dbGet -p top.insts.name $glc_name -i 0].cell.size_x]
@@ -188,6 +164,13 @@ set sram_spacing_x_odd 0
 # Set spacing between pinned sides of SRAMs to some 
 # reasonable number of pitches
 set sram_spacing_x_even [expr 200 * $horiz_pitch]
+
+# Lots of congestion around the SRAMs. Keep getting routing errors in
+# this area. So let's add some space to help it out.
+set sram_spacing_y      [expr 100 * $vert_pitch]
+set sram_spacing_x_odd  [expr 400 * $horiz_pitch]
+set sram_spacing_x_even [expr 400 * $horiz_pitch]
+
 # Parameter for how many SRAMs to stack vertically
 set bank_height 4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ coreir>=2.0.123  # should be first so we get the latest version
 -e git+https://github.com/StanfordAHA/lake#egg=lake-aha
 -e git+https://github.com/phanrahan/magma.git#egg=magma-lang
 -e git+https://github.com/phanrahan/mantle.git#egg=mantle
--e git+git://github.com/jack-melchert/peak_generator#egg=peak_gen
--e git+git://github.com/rdaly525/MetaMapper#egg=metamapper
+-e git+https://github.com/jack-melchert/peak_generator#egg=peak_gen
+-e git+https://github.com/rdaly525/MetaMapper#egg=metamapper
 ordered_set
 cosa
 -e git+https://github.com/leonardt/fault.git#egg=fault


### PR DESCRIPTION
The GLB seems to have gotten bigger recently, impacting the design in ways that broke the TSMC build.

In particular, I noticed three problems
* GLB started overlapping with an alignment cell on its right side;
* lots of congestion at top left corner of GLB, where wires have to squeeze in between the top of the GLB and the bottom of the alignment-cell row above it;
* lots of congestion in and around the SRAM cells between the GLC and the GLB.

To fix the routing and overlap problems, I moved the GLB down and to the right. To allow more room for the rightward move, I took out the lower alignment cell that it was overlapping put in a position symmetrically opposite, i.e. it is now on the left side of the GLB instead of the right side.

The second thing I did was to space out the SRAMs a bit more.

I didn't do a lot of experimentation to find out the best placements for everything, as my primary goal was to get a working master branch. After this is approved, I plan to see whether I can do some tweaking to make it better.

Complete build using this branch can be seen here (or not, if you don't have TSMC clearance you'll just have to take my word for it 
* https://buildkite.com/tapeout-aha/fullchip/builds/374

If you're bored and want something to do during break, please have a look, otherwise I have no problem waiting until after break is over.

