### PR TITLE
Tile false paths

### DIFF
--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -166,3 +166,8 @@ set_false_path -from [get_ports config* -filter direction==in] -to [get_ports SB
 # False paths from config input ports to SB registers
 set sb_reg_path SB_ID0_5TRACKS_B*/REG_T*_B*/value__CE/value_reg*/*
 set_false_path -from [get_ports config_* -filter direction==in] -to [get_pins $sb_reg_path]
+
+# Timing path to read_config_data output should never transition through a configuration
+# register because we assume the register's value is constant during a read. 
+set_false_path -through [get_cells -hier *config_reg_*] -to [get_ports read_config_data]
+

--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -150,9 +150,10 @@ if $::env(PWR_AWARE) {
     set_dont_touch [get_cells -hierarchical *u_mux_logic*]
 }
 
-# HI LO False path
+# Tile ID false paths
 set_false_path -to [get_ports hi]
 set_false_path -to [get_ports lo]
+set_false_path -from [get_ports tile_id]
 
 # Preserve the RMUXes so that we can easily constrain them later
 set rmux_cells [get_cells -hier RMUX_T*sel_inst0]

--- a/mflowgen/Tile_PE/constraints/common.tcl
+++ b/mflowgen/Tile_PE/constraints/common.tcl
@@ -171,6 +171,10 @@ set_false_path -to [get_ports hi]
 set_false_path -to [get_ports lo]
 set_false_path -from [get_ports tile_id]
 
+# Timing path to read_config_data output should never transition through a configuration
+# register because we assume the register's value is constant during a read. 
+set_false_path -through [get_cells -hier *config_reg_*] -to [get_ports read_config_data]
+
 #set_tlu_plus_files -max_tluplus  $tluplus_max \
 #                   -min_tluplus  $tluplus_min \
 #                   -tech2itf_map $tluplus_map

--- a/mflowgen/Tile_PE/constraints/constraints.tcl
+++ b/mflowgen/Tile_PE/constraints/constraints.tcl
@@ -49,9 +49,13 @@ set_constraint_mode default_c
 # Paths from config input ports to SB output ports
 set_false_path -from [get_ports config* -filter direction==in] -to [get_ports SB* -filter direction==out]
 
-# Paths from config input ports to SB register inputs
+# Paths from config input ports to SB data register inputs
 set sb_reg_path SB_ID0_5TRACKS_B*_PE/REG_T*_B*/I
 set_false_path -from [get_ports config_* -filter direction==in] -through [get_pins $sb_reg_path]
+# Paths from config register outputs to SB data register inputs
+set_false_path -through [get_cells -hier *config_reg_*] -through [get_pins $sb_reg_path]
+# Paths from config register outputs to SB outputs
+set_false_path -through [get_cells -hier *config_reg_*] -to [get_ports SB* -filter direction==out]
 
 # Paths from config input ports to PE registers
 set pe_path PE_inst0/WrappedPE_inst0\$PE_inst0

--- a/mflowgen/Tile_PE/constraints/constraints.tcl
+++ b/mflowgen/Tile_PE/constraints/constraints.tcl
@@ -49,8 +49,9 @@ set_constraint_mode default_c
 # Paths from config input ports to SB output ports
 set_false_path -from [get_ports config* -filter direction==in] -to [get_ports SB* -filter direction==out]
 
-# Paths from config input ports to SB registers
-set sb_reg_path SB_ID0_5TRACKS_B*_PE/REG_T*_B*/value__CE/value_reg*/*
+# Paths from config input ports to SB register inputs
+set sb_reg_path SB_ID0_5TRACKS_B*_PE/REG_T*_B*/I
+set_false_path -from [get_ports config_* -filter direction==in] -through [get_pins $sb_reg_path]
 
 # Paths from config input ports to PE registers
 set pe_path PE_inst0/WrappedPE_inst0\$PE_inst0


### PR DESCRIPTION
Sets some false paths related to configuration signals/registers in the pe and memory tiles. Innovus was unnecessarily trying to optimize these paths.