### PR TITLE
use archipelago master branch?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ ordered_set
 cosa
 -e git+https://github.com/leonardt/fault.git#egg=fault
 hwtypes
--e git+https://github.com/Kuree/archipelago.git@pipeline-hard-flush#egg=archipelago
+-e git+https://github.com/Kuree/archipelago.git#egg=archipelago
 systemrdl-compiler
 peakrdl-html


### PR DESCRIPTION
Master branch is broken presently! So this pull, which fixes it, should be of highest priority.

`requirements.txt` was using the wrong branch for archipelago (see file changes). It seems to have broken garnet master, possibly because of subsequent changes to the archipelago branch after merging a working version with garnet master.

Broken garnet test: https://buildkite.com/stanford-aha/garnet/builds/2148

Fixed garnet test: https://buildkite.com/stanford-aha/garnet/builds/2158
