### PR TITLE
Mflowgen CI

### DIFF
--- a/.buildkite/pipelines/check_pe_area.sh
+++ b/.buildkite/pipelines/check_pe_area.sh
@@ -19,14 +19,13 @@ echo $pe_dir
 
 # "echo" to unglob why not
 resdir=`echo $pe_dir/*synthesis/results_syn`
-egrep ^Tile_PE $resdir/final_area.rpt | awk '
+egrep ^Tile_PE $resdir/final_area.rpt | awk -v max_area=8500 '
 { printf("Total area: %d\n", $NF);
-  max_area=8500
-  if ($NF > $max_area) {
+  if ($NF > max_area) {
     print ""
     print  "**ERROR '$resdir/final_area.rpt'"
-    printf("**ERROR TILE area %d TOO BIG, should be < %d\n", $NF, $max_area);
-    printf("+++ FAIL TILE area %d TOO BIG, should be < %d\n", $NF, $max_area);
+    printf("**ERROR TILE area %d TOO BIG, should be < %d\n", $NF, max_area);
+    printf("+++ FAIL TILE area %d TOO BIG, should be < %d\n", $NF, max_area);
     print ""; exit 13; }}
 '
 

--- a/.buildkite/pipelines/check_pe_area.sh
+++ b/.buildkite/pipelines/check_pe_area.sh
@@ -21,11 +21,12 @@ echo $pe_dir
 resdir=`echo $pe_dir/*synthesis/results_syn`
 egrep ^Tile_PE $resdir/final_area.rpt | awk '
 { printf("Total area: %d\n", $NF);
-  if ($NF > 7500) {
+  max_area=8500
+  if ($NF > $max_area) {
     print ""
     print  "**ERROR '$resdir/final_area.rpt'"
-    printf("**ERROR TILE area %d TOO BIG, should be < 7500\n", $NF);
-    printf("+++ FAIL TILE area %d TOO BIG, should be < 7500\n", $NF);
+    printf("**ERROR TILE area %d TOO BIG, should be < %d\n", $NF, $max_area);
+    printf("+++ FAIL TILE area %d TOO BIG, should be < %d\n", $NF, $max_area);
     print ""; exit 13; }}
 '
 

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -58,11 +58,6 @@ def construct():
     'strip_path'        : 'testbench/dut'
     }
 
-  # steveri 2101: Hoping this is temporary.
-  # But for now, 1.1ns pe tile is too big and full-chip CI test FAILS
-  if (os.getenv('USER') == "buildkite-agent"):
-      parameters['clock_period'] = 4.0; # 4ns = 250 MHz
-
   # User-level option to change clock frequency
   # E.g. 'export clock_period_PE="4.0"' to target 250MHz
   # Optionally could restrict to bk only: if (os.getenv('USER') == "buildkite-agent")


### PR DESCRIPTION
Since new capability has been added to the PE, its area has increased. This PR increases the max pe area for the CI checks.

For a better check since we're now running through floorplanning, we can directly check the widths of the PE and memory tiles, multiply the pe width by 24 and memory by 8, and ensure that's less than the chip width. Then we can perform a similar check for the height. @steveri what do you think about that? If you agree with that approach, do you have some time to look into that?

I've also removed the code that reduced the PE clock frequency for CI, since it shouldn't be necessary with the constraint updates that were introduced recently.