### PR TITLE
System adk skip mflowgen

### DIFF
--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -42,12 +42,13 @@ steps:
   - .buildkite/pipelines/check_pe_area.sh
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
-# - label: 'mtile init 25m'
-#   commands:
-#   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
-#   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
-# 
-# - label: 'gtile init 20m'
-#   commands:
-#   - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
-#   - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors
+- label: 'mtile init 25m'
+  commands:
+  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
+  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
+
+- label: 'gtile init 20m'
+  commands:
+  - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
+  - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors
+

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -16,6 +16,7 @@
 env:
   TEST: 'echo exit 13 | mflowgen/test/test_module.sh'
   SETUP: 'source mflowgen/bin/setup-buildkite.sh'
+  TEST_MODULE_SBFLAGS: '--skip_mflowgen'
 
 steps:
 
@@ -41,13 +42,12 @@ steps:
   - .buildkite/pipelines/check_pe_area.sh
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
-- label: 'mtile init 25m'
-  commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
-  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
-
-- label: 'gtile init 20m'
-  commands:
-  - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
-  - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors
-
+# - label: 'mtile init 25m'
+#   commands:
+#   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
+#   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
+# 
+# - label: 'gtile init 20m'
+#   commands:
+#   - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
+#   - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors

--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -419,25 +419,24 @@ else
   fi
 fi
 
-  # Check out latest version of the desired branch
-  pushd $mflowgen
-    git checkout $mflowgen_branch; git pull
-    TOP=$PWD; pip install -e .
-  popd
+# Check out latest version of the desired branch
+pushd $mflowgen
+  git checkout $mflowgen_branch; git pull
+  TOP=$PWD; pip install -e .
+popd
 
-  # mflowgen might be hidden in $HOME/.local/bin
-  if ! (type mflowgen >& /dev/null); then
-      echo "***WARNING Cannot find mflowgen after install"
-      echo "   Will try adding '$HOME/.local/bin' to your path why not"
-      echo ""
-      export PATH=${PATH}:$HOME/.local/bin
-      which mflowgen
-  fi
+# mflowgen might be hidden in $HOME/.local/bin
+if ! (type mflowgen >& /dev/null); then
+    echo "***WARNING Cannot find mflowgen after install"
+    echo "   Will try adding '$HOME/.local/bin' to your path why not"
+    echo ""
+    export PATH=${PATH}:$HOME/.local/bin
+    which mflowgen
+fi
 
-  # See what we got
-  which mflowgen; pip list | grep mflowgen
+# See what we got
+which mflowgen; pip list | grep mflowgen
 
-# fi
 
 
 ########################################################################

--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -417,6 +417,7 @@ else
       git clone -b $mflowgen_branch \
           -- https://github.com/mflowgen/mflowgen.git $mflowgen
   fi
+fi
 
   # Check out latest version of the desired branch
   pushd $mflowgen
@@ -436,7 +437,7 @@ else
   # See what we got
   which mflowgen; pip list | grep mflowgen
 
-fi
+# fi
 
 
 ########################################################################


### PR DESCRIPTION
Simple fix for the --skip_mflowgen problem. The script was not doing a "pip install" for the cached mflowgen repo, so the mflowgen command defaulted to some old path that should probably be hunted down and purged, but I will do that another day.