### PR TITLE
Flock

### DIFF
--- a/mflowgen/bin/setup-buildkite-flock.sh
+++ b/mflowgen/bin/setup-buildkite-flock.sh
@@ -1,26 +1,52 @@
 ##############################################################################
-# LOCK so that no two script instances can run at the same time.
-# In particular, do not want e.g. competing 'git clone' or
-# 'pip install' ops trying to access the same directory etc.
+# Initiate a LOCK region where no other script can run until lock is released,
+# either by script EXIT (see trap below) or by explicitly doing 'flock -u 9'
+# 
+# Script will wait up to an hour before giving up.
+# 
+# EXAMPLE
+#    # Initiate a lock
+#    source $0
+#
+#    # Do something that should only be done one at a time, e.g. might not
+#    # want two processes trying to clone the same repo at the same time.
+#    git clone REPO
+#
+#    # Release the lock when done
+#    flock -u 9
 
-echo "--- LOCK"
-function flockdate { date +'%m/%d %H:%M'; }  # E.g. "05/11 17:34"
 LOCK=/tmp/setup-buildkite.lock
+
+# E.g. "05/11 17:34 41033 your name here"
+function flockmsg  {
+    pnum=$$; msg="$1";
+    echo `date +'%m/%d %H:%M'` $pnum "$msg"; 
+}
+
+function flockwait {
+    msg="WARNING waited $1 minutes, could not get lock from `cat $LOCK`"
+    flock -w 600 9 || flockmsg "$msg"
+}
+
+date; flockmsg "I am process $$ and I want lock '$LOCK'"
+
 exec 9>> $LOCK
-date; echo `flockdate` $$ "I am process $$ and I want lock '$LOCK'"
+
 if ! flock -n 9; then
-    echo `flockdate` $$ "Waiting for process `cat $LOCK` to release the lock..."
-    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 10 minutes, could not get lock from `cat $LOCK`"
-    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 20 minutes, could not get lock from `cat $LOCK`"
-    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 30 minutes, could not get lock from `cat $LOCK`"
-    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 40 minutes, could not get lock from `cat $LOCK`"
-    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 50 minutes, could not get lock from `cat $LOCK`"
+    # echo `flockdate` $$ "Waiting for process `cat $LOCK` to release the lock..."
+    flockmsg "Waiting for process `cat $LOCK` to release the lock..."
+    flockwait 10
+    flockwait 20
+    flockwait 30
+    flockwait 40
+    flockwait 50
     if ! flock -w 600 9; then
-        echo `flockdate` $$ "ERROR waited 60 minutes, could not get lock from `cat $LOCK`"
+        flockmsg "ERROR waited 60 minutes, could not get lock from `cat $LOCK`"
+        echo "Might want to delete the lock file '$LOCK'"
         return 13 || exit 13
     fi
 fi
-date; echo -n "Lock acquired! Prev owner was "; cat $LOCK
+date; flockmsg "Lock acquired! Prev owner was " `cat $LOCK`
 echo $$ > $LOCK; # Record who has the lock (i.e. me)
 
 # Failsafe: Release lock on exit (if not before).  Note, because this

--- a/mflowgen/bin/setup-buildkite-flock.sh
+++ b/mflowgen/bin/setup-buildkite-flock.sh
@@ -1,0 +1,29 @@
+##############################################################################
+# LOCK so that no two script instances can run at the same time.
+# In particular, do not want e.g. competing 'git clone' or
+# 'pip install' ops trying to access the same directory etc.
+
+echo "--- LOCK"
+function flockdate { date +'%m/%d %H:%M'; }  # E.g. "05/11 17:34"
+LOCK=/tmp/setup-buildkite.lock
+exec 9>> $LOCK
+date; echo `flockdate` $$ "I am process $$ and I want lock '$LOCK'"
+if ! flock -n 9; then
+    echo `flockdate` $$ "Waiting for process `cat $LOCK` to release the lock..."
+    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 10 minutes, could not get lock from `cat $LOCK`"
+    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 20 minutes, could not get lock from `cat $LOCK`"
+    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 30 minutes, could not get lock from `cat $LOCK`"
+    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 40 minutes, could not get lock from `cat $LOCK`"
+    flock -w 600 9 || echo `flockdate` $$ "WARNING waited 50 minutes, could not get lock from `cat $LOCK`"
+    if ! flock -w 600 9; then
+        echo `flockdate` $$ "ERROR waited 60 minutes, could not get lock from `cat $LOCK`"
+        return 13 || exit 13
+    fi
+fi
+date; echo -n "Lock acquired! Prev owner was "; cat $LOCK
+echo $$ > $LOCK; # Record who has the lock (i.e. me)
+
+# Failsafe: Release lock on exit (if not before).  Note, because this
+# script is sourced, this trap won't kick in until calling process dies.
+trap "flock -u 9" EXIT
+

--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -388,11 +388,12 @@ if [ "$skip_mflowgen" == "true" ]; then
   ls -ld $mflowgen || return 13 || exit 13
 
 else
-  echo "--- INSTALL LATEST MFLOWGEN using branch '$mflowgen_branch'"
+  echo "--- INSTALL LATEST MFLOWGEN using branch '$mflowgen_branch'"; date
   echo "Install mflowgen in dir '$mflowgen'"
 
   # Build repo if not exists yet
   if ! test -e $mflowgen; then
+      echo "No mflowgen yet; cloning a new one"
       git clone -b $mflowgen_branch \
           -- https://github.com/mflowgen/mflowgen.git $mflowgen
   fi

--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -376,6 +376,7 @@ if [ "$mflowbranch" != "master" ]; then
     mflowgen=$mflowgen.$mflowgen_branch
 fi
 
+# Side effect: defines function 'flockmsg'
 echo "--- LOCK"; source $GARNET_HOME/mflowgen/bin/setup-buildkite-flock.sh
 
 # FIXME/TODO could have better mechanism to decide when to skip mflowgen install;
@@ -398,6 +399,7 @@ else
 fi
 
 # Check out latest version of the desired branch
+echo "PIP INSTALL $mflowgen branch $mflowgen_branch"; date
 pushd $mflowgen
   git checkout $mflowgen_branch; git pull
   TOP=$PWD; pip install -e .
@@ -415,19 +417,14 @@ fi
 # See what we got
 which mflowgen; pip list | grep mflowgen
 
-echo "--- UNLOCK "; date; echo `flockdate` $$ "Release! The lock!"; flock -u 9
-echo "--- LOCK"; source $GARNET_HOME/mflowgen/bin/setup-buildkite-flock.sh
 
 
 ########################################################################
 # GARNET-PD: Installs garnet-pd package so to enable import
 # and reuse in mflowgen graph construction
 
-echo "--- PIP INSTALL $GARNET_HOME/mflowgen"
+echo "--- PIP INSTALL $GARNET_HOME/mflowgen"; date
 pip install -e $GARNET_HOME/mflowgen
-
-echo "--- UNLOCK "; date; echo `flockdate` $$ "Release! The lock!"; flock -u 9
-echo "--- LOCK"; source $GARNET_HOME/mflowgen/bin/setup-buildkite-flock.sh
 
 ########################################################################
 # ADK
@@ -462,7 +459,7 @@ fi
 
 
 echo "--- UNLOCK "; date
-echo `flockdate` $$ "Release! The lock!"; flock -u 9
+flockmsg "Release! The lock!"; flock -u 9
 
 
 ########################################################################


### PR DESCRIPTION
Extended maximum `flock` wait so as to avoid the timeout problem we saw earlier; the lock region is as much as 2-3 minutes long, and each check-in results in three simultaneous `flock` competes, so the previous 10-minute timeout was probably too aggressive. Now, it gives warnings at ten-minute intervals before finally giving up after maximum one hour.