### PR TITLE
add ready-valid switch

### DIFF
--- a/cgra/util.py
+++ b/cgra/util.py
@@ -55,7 +55,8 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
                 port_conn_override: Dict[str,
                                          List[Tuple[SwitchBoxSide,
                                                     SwitchBoxIO]]] = None,
-                pe_fc = lassen_fc):
+                pe_fc=lassen_fc,
+                ready_valid: bool = False):
     # currently only add 16bit io cores
     bit_widths = [1, 16]
     track_length = 1
@@ -185,7 +186,8 @@ def create_cgra(width: int, height: int, io_sides: IOSide,
     interconnect = Interconnect(ics, reg_addr_width, config_data_width,
                                 tile_id_width,
                                 lift_ports=standalone,
-                                stall_signal_width=1)
+                                stall_signal_width=1,
+                                ready_valid=ready_valid)
     if hi_lo_tile_id:
         tile_id_physical(interconnect)
     if add_pd:

--- a/garnet.py
+++ b/garnet.py
@@ -54,7 +54,8 @@ class Garnet(Generator):
                  harden_flush: bool = True,
                  pipeline_config_interval: int = 8,
                  glb_params: GlobalBufferParams = GlobalBufferParams(),
-                 pe_fc=lassen_fc):
+                 pe_fc=lassen_fc,
+                 ready_valid: bool = False):
         super().__init__()
 
         # Check consistency of @standalone and @interconnect_only parameters. If
@@ -132,7 +133,8 @@ class Garnet(Generator):
                                    mem_ratio=(1, mem_ratio),
                                    tile_layout_option=tile_layout_option,
                                    standalone=standalone,
-                                   pe_fc=pe_fc)
+                                   pe_fc=pe_fc,
+                                   ready_valid=ready_valid)
 
         self.interconnect = interconnect
 
@@ -491,6 +493,7 @@ def main():
     parser.add_argument('--mem-ratio', type=int, default=4)
     parser.add_argument('--num-tracks', type=int, default=5)
     parser.add_argument('--tile-layout-option', type=int, default=0)
+    parser.add_argument("--rv", "--ready-valid", action="store_true", dest="ready_valid")
     args = parser.parse_args()
 
     if not args.interconnect_only:
@@ -527,7 +530,8 @@ def main():
                     interconnect_only=args.interconnect_only,
                     use_sim_sram=args.use_sim_sram,
                     standalone=args.standalone,
-                    pe_fc=pe_fc)
+                    pe_fc=pe_fc,
+                    ready_valid=args.ready_valid)
 
     if args.verilog:
         garnet_circ = garnet.circuit()


### PR DESCRIPTION
This will not compile properly since all the cores don't have proper ready valid interface. As a result, this is off by default.