### PR TITLE
Mflowgen ci

### DIFF
--- a/.buildkite/pipelines/check_tile_width.sh
+++ b/.buildkite/pipelines/check_tile_width.sh
@@ -69,22 +69,3 @@ gunzip -c $fp | awk -v max_width=${max_width} '
   }
 '
 echo ""
-
-
-##############################################################################
-# OLD
-# 
-# # Assuming a ratio of 3:1 for mem:pe widths
-# # (current TSMC build = 93u and 279u respectively);
-# # assuming a max chip width of 4800u;
-# # assuming 24 pe columns and 8 mem columns;
-# # (equal to 48 pe columns);
-# # max pe size would be 4800/48 or ... 100u
-# # max mem sixe would be 300u
-# 
-# if   [ "$which_tile" == "Tile_PE" ];      then max_width=100
-# elif [ "$which_tile" == "Tile_MemCore" ]; then max_width=300
-# else
-#     echo "ERROR must specify either 'Tile_PE' or 'Tile_Memcore'"
-#     usage; exit 13
-# fi

--- a/.buildkite/pipelines/check_tile_width.sh
+++ b/.buildkite/pipelines/check_tile_width.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/bash
+
+# Can do e.g. "$0 215" to check dir /build/gold.215
+# 
+# Also used in per-checkin CI test e.g. pmg.yml:
+#   commands:
+#   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
+#   - .buildkite/pipelines/check_pe_area.sh
+
+function usage {
+cat <<EOF
+
+Usage:
+  $0 < Tile_PE | Tile_MemCore > [ build_dir ] 
+
+Examples:
+  $0 Tile_PE          ; # Looks for tile starting in curdir
+  $0 Tile_MemCore 377 ; # Looks for tile starting in /build/gold.377
+
+EOF
+}
+if [ "$1" == "--help" ]; then usage; exit; fi
+
+# Unpack the args
+
+which_tile=$1
+[ "$which_tile" == "pe"  ] && which_tile="Tile_PE"
+[ "$which_tile" == "mem" ] && which_tile="Tile_MemCore"
+
+if [ "$2" != "" ]; then
+    cd /build/gold.$2/full_chip/*tile_array/*${which_tile}
+fi
+
+###################################################
+# Assuming a ratio of 3:1 for mem:pe widths
+# (current TSMC build = 93u and 279u respectively);
+# assuming a max chip width of 4800u;
+# assuming 24 pe columns and 8 mem columns;
+# (equal to 48 pe columns);
+# max pe size would be 4800/48 or ... 100u
+# max mem sixe would be 300u
+
+if   [ "$which_tile" == "Tile_PE" ];      then max_width=100
+elif [ "$which_tile" == "Tile_MemCore" ]; then max_width=300
+else
+    echo "ERROR must specify either 'Tile_PE' or 'Tile_Memcore'"
+    usage; exit 13
+fi
+
+cat <<EOF
+
+--- FINAL CHECK: ${which_tile} total width must be < ${max_width}u
+EOF
+
+# Designed to run from $garnet directory
+
+fp=*cadence-innovus-init/outputs/design.checkpoint/save.enc.dat/Tile_PE.fp.gz
+
+# Uncomment to test failure mode
+max_width=10
+
+# Head Box: 0.0000 0.0000 93.1500 87.5520 [ i.e. 93w and 82.5h ]
+
+echo "grep 'Head Box' $fp"
+gunzip -c $fp | awk -v max_width=$max_width '
+  /^Head Box/ {
+    print "  " $0
+    print "  Actual width = "$5
+    if ($5 > max_width) {
+      print ""
+      printf( "**ERROR TILE width %d TOO BIG, should be < %d\n", $NF, max_width);
+      print ""
+      printf("+++ FAIL TILE width %d TOO BIG, should be < %d\n", $NF, max_width);
+      print ""
+      exit 13;
+    }
+    exit
+  }
+'
+
+

--- a/.buildkite/pipelines/check_tile_width.sh
+++ b/.buildkite/pipelines/check_tile_width.sh
@@ -47,8 +47,7 @@ else
     echo "ERROR must specify either 'Tile_PE' or 'Tile_Memcore'"
     usage; exit 13
 fi
-
-max_width=10; # Uncomment this line to test failure mode
+# max_width=10; # Uncomment this line to test failure mode
 
 cat <<EOF
 

--- a/.buildkite/pipelines/check_tile_width.sh
+++ b/.buildkite/pipelines/check_tile_width.sh
@@ -12,55 +12,39 @@ function usage {
 cat <<EOF
 
 Usage:
-  $0 < Tile_PE | Tile_MemCore > [ build_dir ] 
+  $0 < Tile_PE | Tile_MemCore > <max_width> [ build_dir ] 
 
 Examples:
-  $0 Tile_PE                      ; # Looks for tile starting in curdir
-  $0 Tile_MemCore /build/gold.377 ; # Looks for tile starting in /build/gold.377
+  $0 Tile_PE 100                      ; # Look for tile starting in curdir
+  $0 Tile_MemCore 300 /build/gold.377 ; # Look for tile starting in /build/gold.377
 
 EOF
 }
 if [ "$1" == "--help" ]; then usage; exit; fi
 
 # Unpack the args
+which_tile=$1; max_width=$2; dir=$3
 
-which_tile=$1
+# Can use 'pe' or 'mem' shorthand
 [ "$which_tile" == "pe"  ] && which_tile="Tile_PE"
 [ "$which_tile" == "mem" ] && which_tile="Tile_MemCore"
 
-# Search dir defaults to curdir [and all its subdirs]
-[ "$2" == "" ] && dir="*" || dir="$2"
-
-
-###################################################
-# Assuming a ratio of 3:1 for mem:pe widths
-# (current TSMC build = 93u and 279u respectively);
-# assuming a max chip width of 4800u;
-# assuming 24 pe columns and 8 mem columns;
-# (equal to 48 pe columns);
-# max pe size would be 4800/48 or ... 100u
-# max mem sixe would be 300u
-
-if   [ "$which_tile" == "Tile_PE" ];      then max_width=100
-elif [ "$which_tile" == "Tile_MemCore" ]; then max_width=300
-else
-    echo "ERROR must specify either 'Tile_PE' or 'Tile_Memcore'"
-    usage; exit 13
-fi
-# max_width=10; # Uncomment this line to test failure mode
+# Search-dir defaults to curdir [and all its subdirs]
+[ "$dir" == "" ] && dir="*"
 
 cat <<EOF
 
 --- FINAL CHECK: ${which_tile} total width must be < ${max_width}u
 EOF
 
-# fp=*cadence-innovus-init/outputs/design.checkpoint/save.enc.dat/Tile_PE.fp.gz
-# E.g.
-# fp="/build/gold.377/full_chip/19-tile_array/17-Tile_PE/17-cadence-innovus-init/checkpoints/.../Tile_PE.fp.gz"
+# Find floorplan doc and divide in two lines for printing e.g.
 # line1="/build/gold.377/full_chip/19-tile_array/17-Tile_PE/"
 # line2="17-cadence-innovus-init/checkpoints/.../Tile_PE.fp.gz"
-
 fp=`find $dir -name ${which_tile}.fp.gz | head -1`
+if ! [ "$fp" ]; then 
+    echo "ERROR cannot find design file '${which_tile}.fp.gz' underneath dir '$dir'"
+    usage; exit 13
+fi
 line1=`echo $fp | sed 's|^\(.*/\)[0-9]*[-][^0-9]*$|\1|'`
 line2=`echo $fp | sed 's|^.*/\([0-9]*[-][^0-9]*$\)|\1|'`
 line2=`echo $line2 | sed 's|\w*/design.checkpoint/save.enc.dat|...|'`
@@ -68,15 +52,18 @@ echo ""
 printf "  Found design\n    %s\n      %s\n" $line1 $line2
 echo ""
 
+# Look in $fp for tile box (llx lly urx ury)
 # Head Box: 0.0000 0.0000 93.1500 87.5520 [ i.e. 93w and 82.5h ]
-gunzip -c $fp | awk -v max_width=$max_width '
+gunzip -c $fp | awk -v max_width=${max_width} '
   /^Head Box/ {
-    print "  " $0 " => width = " $5
-    if ($5 > max_width) {
+    width=$5
+#     print "  " $0 " :: width=" width
+    printf("  `%s` :: width=%s\n", $0, width)
+    if (width > max_width) {
       print ""
-      printf( "**ERROR TILE width %d TOO BIG, should be < %d\n", $NF, max_width);
+      printf( "**ERROR TILE width %du TOO BIG, should be < %du\n", width, max_width);
       print ""
-      printf("+++ FAIL TILE width %d TOO BIG, should be < %d\n", $NF, max_width);
+      printf("+++ FAIL TILE width %du TOO BIG, should be < %du\n", width, max_width);
       print ""
       exit 13;
     }
@@ -85,3 +72,20 @@ gunzip -c $fp | awk -v max_width=$max_width '
 '
 
 
+##############################################################################
+# OLD
+# 
+# # Assuming a ratio of 3:1 for mem:pe widths
+# # (current TSMC build = 93u and 279u respectively);
+# # assuming a max chip width of 4800u;
+# # assuming 24 pe columns and 8 mem columns;
+# # (equal to 48 pe columns);
+# # max pe size would be 4800/48 or ... 100u
+# # max mem sixe would be 300u
+# 
+# if   [ "$which_tile" == "Tile_PE" ];      then max_width=100
+# elif [ "$which_tile" == "Tile_MemCore" ]; then max_width=300
+# else
+#     echo "ERROR must specify either 'Tile_PE' or 'Tile_Memcore'"
+#     usage; exit 13
+# fi

--- a/.buildkite/pipelines/check_tile_width.sh
+++ b/.buildkite/pipelines/check_tile_width.sh
@@ -6,7 +6,7 @@
 # Also used in per-checkin CI test e.g. pmg.yml:
 #   commands:
 #   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
-#   - .buildkite/pipelines/check_pe_area.sh Tile_PE .
+#   - .buildkite/pipelines/check_pe_area.sh Tile_PE --max 110
 
 function usage {
 cat <<EOF
@@ -15,8 +15,8 @@ Usage:
   $0 < Tile_PE | Tile_MemCore > --max <max_width> [ build_dir ] 
 
 Examples:
-  $0 Tile_PE 100                      ; # Look for tile starting in curdir
-  $0 Tile_MemCore 300 /build/gold.377 ; # Look for tile starting in /build/gold.377
+  $0 Tile_PE --max 100                      ; # Look for tile starting in curdir
+  $0 Tile_MemCore --max 300 /build/gold.377 ; # Look for tile starting in /build/gold.377
 
 EOF
 }

--- a/.buildkite/pipelines/check_tile_width.sh
+++ b/.buildkite/pipelines/check_tile_width.sh
@@ -34,23 +34,16 @@ which_tile=$1; max_width=$2; dir=$3
 
 cat <<EOF
 
---- FINAL CHECK: ${which_tile} total width must be < ${max_width}u
++++ FINAL CHECK: ${which_tile} total width must be < ${max_width}u
 EOF
 
-# Find floorplan doc and divide in two lines for printing e.g.
-# line1="/build/gold.377/full_chip/19-tile_array/17-Tile_PE/"
-# line2="17-cadence-innovus-init/checkpoints/.../Tile_PE.fp.gz"
+# Find floorplan doc
 fp=`find $dir -name ${which_tile}.fp.gz | head -1`
 if ! [ "$fp" ]; then 
-    echo "ERROR cannot find design file '${which_tile}.fp.gz' underneath dir '$dir'"
+    echo "ERROR cannot find floorplan '${which_tile}.fp.gz' underneath dir '$dir'"
     usage; exit 13
 fi
-line1=`echo $fp | sed 's|^\(.*/\)[0-9]*[-][^0-9]*$|\1|'`
-line2=`echo $fp | sed 's|^.*/\([0-9]*[-][^0-9]*$\)|\1|'`
-line2=`echo $line2 | sed 's|\w*/design.checkpoint/save.enc.dat|...|'`
-echo ""
-printf "  Found design\n    %s\n      %s\n" $line1 $line2
-echo ""
+printf "  Looking at width in floorplan '%s'\n"
 
 # Look in $fp for tile box (llx lly urx ury)
 # Head Box: 0.0000 0.0000 93.1500 87.5520 [ i.e. 93w and 82.5h ]
@@ -70,6 +63,7 @@ gunzip -c $fp | awk -v max_width=${max_width} '
     exit
   }
 '
+echo ""
 
 
 ##############################################################################

--- a/.buildkite/pipelines/check_tile_width.sh
+++ b/.buildkite/pipelines/check_tile_width.sh
@@ -12,7 +12,7 @@ function usage {
 cat <<EOF
 
 Usage:
-  $0 < Tile_PE | Tile_MemCore > <max_width> [ build_dir ] 
+  $0 < Tile_PE | Tile_MemCore > --max <max_width> [ build_dir ] 
 
 Examples:
   $0 Tile_PE 100                      ; # Look for tile starting in curdir
@@ -23,11 +23,16 @@ EOF
 if [ "$1" == "--help" ]; then usage; exit; fi
 
 # Unpack the args
-which_tile=$1; max_width=$2; dir=$3
+which_tile=$1; dashdashmax=$2; max_width=$3; dir=$4
 
 # Can use 'pe' or 'mem' shorthand
 [ "$which_tile" == "pe"  ] && which_tile="Tile_PE"
 [ "$which_tile" == "mem" ] && which_tile="Tile_MemCore"
+
+if ! [ "$dashdashmax" == "--max" ]; then
+    echo 'ERROR forgot "--max" arg'
+    usage; exit 13
+fi
 
 # Search-dir defaults to curdir [and all its subdirs]
 [ "$dir" == "" ] && dir="*"

--- a/.buildkite/pipelines/pe_synth_only.yml
+++ b/.buildkite/pipelines/pe_synth_only.yml
@@ -11,6 +11,6 @@ steps:
 - label: 'PE synth 45m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_pe_area.sh
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE
 
 - wait: { continue_on_failure: true } # One step at a time + continue on failure

--- a/.buildkite/pipelines/pe_synth_only.yml
+++ b/.buildkite/pipelines/pe_synth_only.yml
@@ -11,6 +11,6 @@ steps:
 - label: 'PE synth 45m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_PE
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE 110
 
 - wait: { continue_on_failure: true } # One step at a time + continue on failure

--- a/.buildkite/pipelines/pe_synth_only.yml
+++ b/.buildkite/pipelines/pe_synth_only.yml
@@ -11,6 +11,6 @@ steps:
 - label: 'PE synth 45m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_PE 110
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 110
 
 - wait: { continue_on_failure: true } # One step at a time + continue on failure

--- a/.buildkite/pipelines/pe_tile_only.yml
+++ b/.buildkite/pipelines/pe_tile_only.yml
@@ -20,5 +20,5 @@ steps:
   - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 30G;
      set -o pipefail;
      make Tile_PE |& tee make-pe.log;
-     $$GARNET_HOME/.buildkite/pipelines/check_pe_area.sh
+     $$GARNET_HOME/.buildkite/pipelines/check_tile_width.sh Tile_PE
      '

--- a/.buildkite/pipelines/pe_tile_only.yml
+++ b/.buildkite/pipelines/pe_tile_only.yml
@@ -20,5 +20,5 @@ steps:
   - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 30G;
      set -o pipefail;
      make Tile_PE |& tee make-pe.log;
-     $$GARNET_HOME/.buildkite/pipelines/check_tile_width.sh Tile_PE
+     $$GARNET_HOME/.buildkite/pipelines/check_tile_width.sh Tile_PE 110
      '

--- a/.buildkite/pipelines/pe_tile_only.yml
+++ b/.buildkite/pipelines/pe_tile_only.yml
@@ -20,5 +20,5 @@ steps:
   - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 30G;
      set -o pipefail;
      make Tile_PE |& tee make-pe.log;
-     $$GARNET_HOME/.buildkite/pipelines/check_tile_width.sh Tile_PE 110
+     $$GARNET_HOME/.buildkite/pipelines/check_tile_width.sh Tile_PE --max 110
      '

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -39,7 +39,7 @@ steps:
 - label: 'ptile init 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
-  - .buildkite/pipelines/check_pe_area.sh
+  - cd full_chip/*tile_array/*Tile_PE; .buildkite/pipelines/check_tile_width.sh pe
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'mtile init 25m'

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -45,6 +45,7 @@ steps:
 - label: 'mtile init 25m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
+  - .buildkite/pipelines/check_tile_width.sh Tile_MemCore
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
 
 - label: 'gtile init 20m'

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -39,13 +39,13 @@ steps:
 - label: 'ptile init 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_PE
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE 110
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'mtile init 25m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_MemCore
+  - .buildkite/pipelines/check_tile_width.sh Tile_MemCore 250
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
 
 - label: 'gtile init 20m'

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -39,13 +39,13 @@ steps:
 - label: 'ptile init 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_PE 110
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 110
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'mtile init 25m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_MemCore 250
+  - .buildkite/pipelines/check_tile_width.sh Tile_MemCore --max 250
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
 
 - label: 'gtile init 20m'

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -39,7 +39,7 @@ steps:
 - label: 'ptile init 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
-  - cd full_chip/*tile_array/*Tile_PE; .buildkite/pipelines/check_tile_width.sh pe
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'mtile init 25m'

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -25,7 +25,7 @@ steps:
 - label: 'PE synth 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_pe_area.sh
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'MemCore synth 25m'

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -25,12 +25,12 @@ steps:
 - label: 'PE synth 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_PE 110
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 110
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'MemCore synth 25m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_MemCore 250
+  - .buildkite/pipelines/check_tile_width.sh Tile_MemCore --max 250
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
 

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -25,11 +25,12 @@ steps:
 - label: 'PE synth 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_PE
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE 110
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'MemCore synth 25m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps synthesis --debug
+  - .buildkite/pipelines/check_tile_width.sh Tile_MemCore 250
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
 

--- a/mflowgen/bin/buildcheck.sh
+++ b/mflowgen/bin/buildcheck.sh
@@ -204,7 +204,7 @@ if [ "$do_sizes" ]; then
       expr $f1 : '.*lef' > /dev/null && f1=$(basename `pwd`)
       printf "%-30s %s %4.0f %s %4.0f %s\n" $f1 `grep SIZE $f`
     done
-    if [ "$found_lefs == "false"]; then echo "  No lefs found"; fi
+    if [ "$found_lefs" == "false"]; then echo "  No lefs found"; fi
 fi
 
 if [ "$do_lvs" ]; then

--- a/mflowgen/bin/buildcheck.sh
+++ b/mflowgen/bin/buildcheck.sh
@@ -129,6 +129,7 @@ done
 # User can optionally leave final "/full_chip" off of the dir pathname
 cd $bd
 test -d full_chip && cd full_chip
+echo "--- $0"
 echo "Found test dir `pwd`"
 
 if [ "$do_sizes" ]; then
@@ -159,11 +160,13 @@ if [ "$do_sizes" ]; then
     #     full_chip                        11765284
 
     echo ''; echo '+++ SIZE CHECK (synthesis report)'
+
+    # Expected / prev values
     declare -A size
       size[glb_tile]=69069
       size[glb_top]=2839952
       size[global_controller]=3702
-      size[Tile_PE]=6989
+      size[Tile_PE]=8131
       size[Tile_MemCore]=20500
       size[tile_array]=29914
       size[full_chip]=11765284
@@ -178,7 +181,7 @@ if [ "$do_sizes" ]; then
       # echo $area $f1
       for key in "${!size[@]}"; do
           expr $f1 : ".*${key}$" > /dev/null \
-          && msg=$(printf " (should be ? %8.0f ?)" ${size[$key]})
+          && msg=$(printf " (prev was ? %8.0f ?)" ${size[$key]})
       done
       printf "%-30s %8.0f$msg\n" $f1 $area
     done
@@ -191,6 +194,7 @@ if [ "$do_sizes" ]; then
     # 17-tile_array/17-Tile_PE       SIZE  102 BY   88 ;
     # 17-tile_array                  SIZE 4749 BY 1632 ;
 
+    found_lefs=false
     echo ''; echo '+++ SIZE CHECK (lef)'
     for f in `find * -name 'design.lef'`; do
       # e.g. "17-Tile_PE/24-cadence-innovus-signoff/outputs/design.lef" => "17-Tile_PE"
@@ -200,6 +204,7 @@ if [ "$do_sizes" ]; then
       expr $f1 : '.*lef' > /dev/null && f1=$(basename `pwd`)
       printf "%-30s %s %4.0f %s %4.0f %s\n" $f1 `grep SIZE $f`
     done
+    if [ "$found_lefs == "false"]; then echo "  No lefs found"; fi
 fi
 
 if [ "$do_lvs" ]; then
@@ -226,7 +231,7 @@ if [ "$do_runtimes" ]; then
     ########################################################################
     # Status check e.g.
     # 
-    # +++ CURRENT STATUS (runtimes)
+    # +++ RUNTIMES
     # --------------------------------------------------------------------------------
     # 9-rtl                               --         26 min  6 sec 
     # 14-glb_top                          --    1 hr 18 min 35 sec  <-- in progress
@@ -241,7 +246,7 @@ if [ "$do_runtimes" ]; then
         get_runtimes="/sim/buildkite-agent/mflowgen.master/mflowgen/scripts/mflowgen-runtimes"
     fi
     $get_runtimes |& egrep -v '^(Total|echo|runtimes)' \
-        | grep -vi warning | sed '1d; s/Runtimes/+++ CURRENT STATUS (runtimes)/'
+        | grep -vi warning | sed '1d; s/Runtimes/+++ RUNTIMES/'
 fi
 
 ########################################################################

--- a/mflowgen/test/test_module.sh
+++ b/mflowgen/test/test_module.sh
@@ -401,7 +401,7 @@ egrep '^make: .* Error 1' make*.log && exit 13 || echo 'Did not fail. Right?'
 ########################################################################
 echo '+++ SUMMARY of what we did'
 logs=`/bin/ls -t make*.log`
-cat -n $logs | grep 'mkdir.*output' | sed 's/.output.*//' | sed 's/mkdir -p/  make/' \
+cat -n $logs | grep '^mkdir.*output' | sed 's/.output.*//' | sed 's/mkdir -p/  make/' \
     >> tmp.summary \
     || PASS
 cat tmp.summary \


### PR DESCRIPTION
This is a follow-on to previous pull https://github.com/StanfordAHA/garnet/pull/869 .

It updates the tile-size check to look at tile *widths*, and not total area, to see if the tile is going to fit or not.

The new `check_tile_width.sh` script is designed to be used in CI pipelines as a standalone test that runs as part of building either a pe or mem tile. Max tile width is provided as a parameter to the script, making it easy for the designer to update, on the rare occasion when/if tile sizes are allowed to change dramatically.

