### PR TITLE
Rtl check unq and mux

### DIFF
--- a/.buildkite/pipelines/check_tile_width.sh
+++ b/.buildkite/pipelines/check_tile_width.sh
@@ -48,7 +48,7 @@ if ! [ "$fp" ]; then
     echo "ERROR cannot find floorplan '${which_tile}.fp.gz' underneath dir '$dir'"
     usage; exit 13
 fi
-printf "  Looking at width in floorplan '%s'\n"
+printf "  Looking at width in floorplan '%s'\n" ${which_tile}.fp.gz
 
 # Look in $fp for tile box (llx lly urx ury)
 # Head Box: 0.0000 0.0000 93.1500 87.5520 [ i.e. 93w and 82.5h ]

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -14,8 +14,8 @@
 ##############################################################################
 # Note: "echo exit 13" prevents hang at genus/innovus prompt
 env:
-#   TEST:  echo exit 13 | mflowgen/test/test_module.sh
   SETUP: source mflowgen/bin/setup-buildkite.sh
+  TEST:  echo exit 13 | mflowgen/test/test_module.sh
 
   # Env var used by test_module.sh :(
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -20,8 +20,8 @@ env:
   # Env var used by test_module.sh :(
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'
 
-  # For debugging, can keep results in a local directory
-  BUILD: --build /build/pmg${BUILDKITE_BUILD_NUMBER}
+  # Uncomment for debugging, keep results in local directory $BUILD
+  BUILD: /build/pmg${BUILDKITE_BUILD_NUMBER}
   TEST:  echo exit 13 | mflowgen/test/test_module.sh --build_dir $BUILD
 
 

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -14,9 +14,14 @@
 ##############################################################################
 # Note: "echo exit 13" prevents hang at genus/innovus prompt
 env:
-  TEST: 'echo exit 13 | mflowgen/test/test_module.sh'
-  SETUP: 'source mflowgen/bin/setup-buildkite.sh'
+  TEST:  echo exit 13 | mflowgen/test/test_module.sh
+  SETUP: source mflowgen/bin/setup-buildkite.sh
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'
+
+  # For debugging, can keep results in a local directory
+  BUILD: --build /build/pmg${BUILDKITE_BUILD_NUMBER}
+  TEST:  echo exit 13 | mflowgen/test/test_module.sh --build_dir $BUILD
+
 
 steps:
 
@@ -38,17 +43,18 @@ steps:
 
 - label: 'ptile init 20m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
+  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
   - .buildkite/pipelines/check_pe_area.sh
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
-- label: 'mtile init 25m'
-  commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
-  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
 
-- label: 'gtile init 20m'
-  commands:
-  - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
-  - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors
 
+# - label: 'mtile init 25m'
+#   commands:
+#   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
+#   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
+# 
+# - label: 'gtile init 20m'
+#   commands:
+#   - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
+#   - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -20,9 +20,10 @@ env:
   # Env var used by test_module.sh :(
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'
 
-  # Uncomment one of these as appropriate for debugging
-  # TEST:  echo exit 13 | mflowgen/test/test_module.sh
-  TEST:  echo exit 13 | mflowgen/test/test_module.sh $BUILD
+  TEST: echo exit 13 | mflowgen/test/test_module.sh
+
+  # For debugging, can do this instead:
+  # TEST: echo exit 13 | mflowgen/test/test_module.sh $BUILD
 
 
 steps:
@@ -45,19 +46,16 @@ steps:
 
 - label: 'ptile init 20m'
   commands:
-  - echo "$TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug"
-  - set -x ; $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
+  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
+  - .buildkite/pipelines/check_pe_area.sh
+  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
+- label: 'mtile init 25m'
+  commands:
+  - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
+  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
 
-#   - .buildkite/pipelines/check_pe_area.sh
-#   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
-# 
-# - label: 'mtile init 25m'
-#   commands:
-#   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
-#   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
-# 
-# - label: 'gtile init 20m'
-#   commands:
-#   - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
-#   - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors
+- label: 'gtile init 20m'
+  commands:
+  - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
+  - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -15,15 +15,13 @@
 # Note: "echo exit 13" prevents hang at genus/innovus prompt
 env:
   SETUP: source mflowgen/bin/setup-buildkite.sh
-  BUILD: --build_dir /build/pmg${BUILDKITE_BUILD_NUMBER}
 
   # Env var used by test_module.sh :(
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'
 
+  # For debugging, use $BUILD flag to build in indicated local dir
   TEST: echo exit 13 | mflowgen/test/test_module.sh
-
-  # For debugging, can do this instead:
-  # TEST: echo exit 13 | mflowgen/test/test_module.sh $BUILD
+# TEST: echo exit 13 | mflowgen/test/test_module.sh --build_dir /build/pmg${BUILDKITE_BUILD_NUMBER}
 
 
 steps:
@@ -59,3 +57,4 @@ steps:
   commands:
   - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
   - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors
+

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -15,14 +15,14 @@
 # Note: "echo exit 13" prevents hang at genus/innovus prompt
 env:
   SETUP: source mflowgen/bin/setup-buildkite.sh
-  TEST:  echo exit 13 | mflowgen/test/test_module.sh
+  BUILD: --build_dir /build/pmg${BUILDKITE_BUILD_NUMBER}
 
   # Env var used by test_module.sh :(
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'
 
-  # Uncomment for debugging, keep results in local directory $BUILD
-  BUILD: /build/pmg${BUILDKITE_BUILD_NUMBER}
-  TEST:  echo exit 13 | mflowgen/test/test_module.sh --build_dir $BUILD
+  # Uncomment one of these as appropriate for debugging
+  # TEST:  echo exit 13 | mflowgen/test/test_module.sh
+  TEST:  echo exit 13 | mflowgen/test/test_module.sh $BUILD
 
 
 steps:

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -47,11 +47,11 @@ steps:
   commands:
   - echo "$TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug"
   - set -x ; $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
-  - .buildkite/pipelines/check_pe_area.sh
-  - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 
-
+#   - .buildkite/pipelines/check_pe_area.sh
+#   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
+# 
 # - label: 'mtile init 25m'
 #   commands:
 #   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -14,8 +14,10 @@
 ##############################################################################
 # Note: "echo exit 13" prevents hang at genus/innovus prompt
 env:
-  TEST:  echo exit 13 | mflowgen/test/test_module.sh
+#   TEST:  echo exit 13 | mflowgen/test/test_module.sh
   SETUP: source mflowgen/bin/setup-buildkite.sh
+
+  # Env var used by test_module.sh :(
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'
 
   # For debugging, can keep results in a local directory
@@ -43,7 +45,8 @@ steps:
 
 - label: 'ptile init 20m'
   commands:
-  - $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
+  - echo "$TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug"
+  - set -x ; $TEST --need_space 30G full_chip tile_array Tile_PE --steps rtl --debug
   - .buildkite/pipelines/check_pe_area.sh
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -48,24 +48,19 @@ postconditions:
   - assert 'Tile_MemCore_unq' not in File( 'outputs/design.v' )
 
   # Test: If PWR_AWARE, must not have commonlib muxes! Sample output:
-  # 
-  # Traceback (most recent call last):
-  #   File "/home/steveri/tmpdir/assertion_test/assertion_test.py", line 11, in <module>
-  #     assert not re.search('MUX_SB.*common', line), errmsg1 + errmsg2
-  # AssertionError: Found unwrapped SB mux, outputs/design.v line 28359
-  # 
-  #  28359 wire [0:0] MUX_SB_T0_EAST_SB_OUT_B1$Mux5xBits1_inst0$coreir_commonlib_mux5x1_inst0_out;
   #
+  # E AssertionError: Found unwrapped SB mux, outputs/design.v line 27526
+  # E   
+  # E    27526 wire [0:0] MUX_SB_T0_EAST_SB_OUT_B1_O;
+  # E   
   - |
     import re
-    if 'PWR_AWARE=True' in ( 'mflowgen-run' ):
+    if 'PWR_AWARE=True' in File( 'mflowgen-run' ):
       lno=0
       for line in File('outputs/design.v'):
         lno=lno+1
         # if re.search('MUX_SB.*common', line):
-
-        # Uncomment to test failure mode
-        if re.search('MUX_SB', line):
+        if re.search('MUX_SB', line): # Uncomment to test failure mode
             errmsg1 = f"Found unwrapped SB mux, outputs/design.v line {lno}\n"
             errmsg2 = f"\n {lno} {line}"
             # Uncomment when ready to deploy

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -62,10 +62,11 @@ postconditions:
     import os; import re
     if os.getenv('PWR_AWARE') == 'True':
       lno=0
-        for line in File('outputs/design.v'):
+      for line in File('outputs/design.v'):
         lno=lno+1
-        # Uncomment when ready to deploy
         # if re.search('MUX_SB.*common', line):
+
+        # Uncomment to test failure mode
         if re.search('MUX_SB', line):
             errmsg1 = f"Found unwrapped SB mux, outputs/design.v line {lno}\n"
             errmsg2 = f"\n {lno} {line}"

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -47,9 +47,7 @@ postconditions:
   - assert 'Tile_PE_unq'      not in File( 'outputs/design.v' )
   - assert 'Tile_MemCore_unq' not in File( 'outputs/design.v' )
 
-  # if PWR_AWARE, must not have commonlib muxes!
-  #
-  # Sample output:
+  # Test: If PWR_AWARE, must not have commonlib muxes! Sample output:
   # 
   # Traceback (most recent call last):
   #   File "/home/steveri/tmpdir/assertion_test/assertion_test.py", line 11, in <module>
@@ -59,8 +57,8 @@ postconditions:
   #  28359 wire [0:0] MUX_SB_T0_EAST_SB_OUT_B1$Mux5xBits1_inst0$coreir_commonlib_mux5x1_inst0_out;
   #
   - |
-    import os; import re
-    if os.getenv('PWR_AWARE') == 'True':
+    import re
+    if 'PWR_AWARE=True' in ( 'mflowgen-run' ):
       lno=0
       for line in File('outputs/design.v'):
         lno=lno+1

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -47,23 +47,18 @@ postconditions:
   - assert 'Tile_PE_unq'      not in File( 'outputs/design.v' )
   - assert 'Tile_MemCore_unq' not in File( 'outputs/design.v' )
 
-  # Test: If PWR_AWARE, must not have commonlib muxes! Sample output:
+  # If PWR_AWARE, must not have commonlib muxes! Sample output:
   #
   # E AssertionError: Found unwrapped SB mux, outputs/design.v line 27526
-  # E   
   # E    27526 wire [0:0] MUX_SB_T0_EAST_SB_OUT_B1_O;
-  # E   
   - |
     import re
     if 'PWR_AWARE=True' in File( 'mflowgen-run' ):
       lno=0
       for line in File('outputs/design.v'):
         lno=lno+1
-        # if re.search('MUX_SB.*common', line):
-        if re.search('MUX_SB', line): # Uncomment to test failure mode
-            errmsg1 = f"Found unwrapped SB mux, outputs/design.v line {lno}\n"
-            errmsg2 = f"\n {lno} {line}"
-            # Uncomment when ready to deploy
-            # assert not re.search('MUX_SB.*common', line), errmsg1 + errmsg2
-            assert not re.search('MUX_SB', line), errmsg1 + errmsg2
+        if re.search('MUX_SB.*common', line):
+          errmsg1 = f"Found unwrapped SB mux, outputs/design.v line {lno}\n"
+          errmsg2 = f"\n {lno} {line}"
+          assert not re.search('MUX_SB.*common', line), errmsg1 + errmsg2
 

--- a/mflowgen/common/rtl/configure.yml
+++ b/mflowgen/common/rtl/configure.yml
@@ -42,3 +42,34 @@ parameters:
 
 postconditions:
   - assert File( 'outputs/design.v' )        # must exist
+
+  # Uniquified tiles means something bad has happened
+  - assert 'Tile_PE_unq'      not in File( 'outputs/design.v' )
+  - assert 'Tile_MemCore_unq' not in File( 'outputs/design.v' )
+
+  # if PWR_AWARE, must not have commonlib muxes!
+  #
+  # Sample output:
+  # 
+  # Traceback (most recent call last):
+  #   File "/home/steveri/tmpdir/assertion_test/assertion_test.py", line 11, in <module>
+  #     assert not re.search('MUX_SB.*common', line), errmsg1 + errmsg2
+  # AssertionError: Found unwrapped SB mux, outputs/design.v line 28359
+  # 
+  #  28359 wire [0:0] MUX_SB_T0_EAST_SB_OUT_B1$Mux5xBits1_inst0$coreir_commonlib_mux5x1_inst0_out;
+  #
+  - |
+    import os; import re
+    if os.getenv('PWR_AWARE') == 'True':
+      lno=0
+        for line in File('outputs/design.v'):
+        lno=lno+1
+        # Uncomment when ready to deploy
+        # if re.search('MUX_SB.*common', line):
+        if re.search('MUX_SB', line):
+            errmsg1 = f"Found unwrapped SB mux, outputs/design.v line {lno}\n"
+            errmsg2 = f"\n {lno} {line}"
+            # Uncomment when ready to deploy
+            # assert not re.search('MUX_SB.*common', line), errmsg1 + errmsg2
+            assert not re.search('MUX_SB', line), errmsg1 + errmsg2
+


### PR DESCRIPTION
Recent generator changes caused transient problems that will be avoided in the future, when/if this pull is approved. It enforces two basic requirements of our design:

* There should be no "uniquified" PE or memory tiles, i.e. the RTL should contain exactly one each versions of `module Tile_PE` and `module Tile_MemCore` and there should be no extraneous `module Tile_PE_unq1` etc.

* If the design is power aware, all SB muxes should be "wrapped" with special muxes that understand power domains, as opposed to using "common" muxes from the standard libraries.

So, in this pull, I have added postconditions to Garnet's RTL generation step, to check for each of these conditions, so when/if things break similarly in the future, we should know immediately what broke and why.



