### PR TITLE
Pipeline globals at top of tile array

### DIFF
--- a/passes/interconnect_port_pass/interconnect_port_pass.py
+++ b/passes/interconnect_port_pass/interconnect_port_pass.py
@@ -98,6 +98,8 @@ def wire_core_flush_pass(interconnect: Interconnect):
         # add the flush signal to global signals
         interconnect.globals = list(interconnect.globals) + [interconnect.ports.flush.qualified_name()]
         for tile in interconnect.tile_circuits.values():
+            # If we have flushes in other tiles, we'll add a flush input to all tiles
+            # so pass-through routing of flush signal works
             if "flush" not in tile.ports:
-                continue
+                tile.add_ports(flush=magma.In(TBit))
             interconnect.wire(interconnect.ports.flush, tile.ports.flush)

--- a/passes/pipeline_global_pass/pipeline_global_pass.py
+++ b/passes/pipeline_global_pass/pipeline_global_pass.py
@@ -65,7 +65,7 @@ def pipeline_global_signals(interconnect: Interconnect, interval):
         tile = interconnect.tile_circuits[(x, y)]
         tile_core = tile.core
         # We only want to do this on PE and memory tiles
-        if tile_core is None or "config" not in tile_core.ports or y == 0:
+        if tile_core is None or "config" not in tile_core.ports:
             continue
         else:
             if interval != 0 and y % interval == 0 and ((x, y+1) in interconnect.tile_circuits):

--- a/passes/pipeline_global_pass/pipeline_global_pass.py
+++ b/passes/pipeline_global_pass/pipeline_global_pass.py
@@ -82,7 +82,7 @@ def pipeline_global_signals(interconnect: Interconnect, interval):
 
                 # if it has flush
                 if has_flush:
-                    interconnect.remove_wire(tile.ports.flush, tile_below.ports.flush)
+                    interconnect.remove_wire(tile.ports.flush_out, tile_below.ports.flush)
                     interconnect.wire(tile.ports.flush_out, pipe_stage.ports.flush)
                     interconnect.wire(pipe_stage.ports.flush_out, tile_below.ports.flush)
             


### PR DESCRIPTION
Doing this because these signals are now a critical path since the application data is pipelined in the IO tiles.