### PR TITLE
fix bug that removes non-existent wire in flush pipelining pass

### DIFF
--- a/passes/pipeline_global_pass/pipeline_global_pass.py
+++ b/passes/pipeline_global_pass/pipeline_global_pass.py
@@ -82,7 +82,7 @@ def pipeline_global_signals(interconnect: Interconnect, interval):
 
                 # if it has flush
                 if has_flush:
-                    interconnect.remove_wire(tile.ports.flush, tile_below.ports.flush)
+                    interconnect.remove_wire(tile.ports.flush_out, tile_below.ports.flush)
                     interconnect.wire(tile.ports.flush_out, pipe_stage.ports.flush)
                     interconnect.wire(pipe_stage.ports.flush_out, tile_below.ports.flush)
             


### PR DESCRIPTION
Noticed that the wrong wire was being removed here. Shouldn't actually affect the output rtl but it will get rid of a bunch of warnings.