### PR TITLE
RMUX select instances name change

### DIFF
--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -156,11 +156,9 @@ set_false_path -to [get_ports lo]
 set_false_path -from [get_ports tile_id]
 
 # Preserve the RMUXes so that we can easily constrain them later
-set rmux_cells [get_cells -hier RMUX_T*sel_inst0]
-if { "$rmux_cells" != "" } {
-    set_dont_touch $rmux_cells true
-    set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true
-}
+set rmux_cells [get_cells -hier RMUX_T*sel_*]
+set_dont_touch $rmux_cells true
+set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true
 
 # False paths from config input ports to SB output ports
 set_false_path -from [get_ports config* -filter direction==in] -to [get_ports SB* -filter direction==out]

--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -157,8 +157,10 @@ set_false_path -from [get_ports tile_id]
 
 # Preserve the RMUXes so that we can easily constrain them later
 set rmux_cells [get_cells -hier RMUX_T*sel_inst0]
-set_dont_touch $rmux_cells true
-set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true
+if { "$rmux_cells" != "" } {
+    set_dont_touch $rmux_cells true
+    set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true
+}
 
 # False paths from config input ports to SB output ports
 set_false_path -from [get_ports config* -filter direction==in] -to [get_ports SB* -filter direction==out]

--- a/mflowgen/Tile_PE/constraints/common.tcl
+++ b/mflowgen/Tile_PE/constraints/common.tcl
@@ -180,8 +180,6 @@ set_false_path -through [get_cells -hier *config_reg_*] -to [get_ports read_conf
 #                   -tech2itf_map $tluplus_map
 
 # Preserve the RMUXes so that we can easily constrain them later
-set rmux_cells [get_cells -hier RMUX_T*sel_inst0]
-if { "$rmux_cells" != "" } {
-    set_dont_touch $rmux_cells true
-    set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true
-}
+set rmux_cells [get_cells -hier RMUX_T*sel_*]
+set_dont_touch $rmux_cells true
+set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true

--- a/mflowgen/Tile_PE/constraints/common.tcl
+++ b/mflowgen/Tile_PE/constraints/common.tcl
@@ -181,5 +181,7 @@ set_false_path -through [get_cells -hier *config_reg_*] -to [get_ports read_conf
 
 # Preserve the RMUXes so that we can easily constrain them later
 set rmux_cells [get_cells -hier RMUX_T*sel_inst0]
-set_dont_touch $rmux_cells true
-set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true
+if { "$rmux_cells" != "" } {
+    set_dont_touch $rmux_cells true
+    set_dont_touch [get_nets -of_objects [get_pins -of_objects $rmux_cells -filter name=~O*]] true
+}

--- a/mflowgen/common/custom-genlibdb-constraints/genlibdb-constraints.tcl
+++ b/mflowgen/common/custom-genlibdb-constraints/genlibdb-constraints.tcl
@@ -13,9 +13,7 @@
 # These RMUX instances have been marked dont_touch
 # in the synthesis constraints so we can more easily
 # do set_case_analysis on them here
-set rmuxes [get_cells -hier *RMUX_*_sel_inst0]
-if { "$rmux_cells" != "" } {
-    set rmux_outputs [get_pins -of_objects $rmuxes -filter "direction==out"]
-    set_case_analysis 1 $rmux_outputs
-}
+set rmuxes [get_cells -hier *RMUX_*_sel_*]
+set rmux_outputs [get_pins -of_objects $rmuxes -filter "direction==out"]
+set_case_analysis 1 $rmux_outputs
 

--- a/mflowgen/common/custom-genlibdb-constraints/genlibdb-constraints.tcl
+++ b/mflowgen/common/custom-genlibdb-constraints/genlibdb-constraints.tcl
@@ -14,6 +14,8 @@
 # in the synthesis constraints so we can more easily
 # do set_case_analysis on them here
 set rmuxes [get_cells -hier *RMUX_*_sel_inst0]
-set rmux_outputs [get_pins -of_objects $rmuxes -filter "direction==out"]
-set_case_analysis 1 $rmux_outputs
+if { "$rmux_cells" != "" } {
+    set rmux_outputs [get_pins -of_objects $rmuxes -filter "direction==out"]
+    set_case_analysis 1 $rmux_outputs
+}
 

--- a/mflowgen/common/synopsys-ptpx-gl/loop_break_Interconnect.tcl
+++ b/mflowgen/common/synopsys-ptpx-gl/loop_break_Interconnect.tcl
@@ -1,10 +1,8 @@
 # Loop break constraints
 foreach_in_collection tile [get_cells -hier Tile* ] {
   current_instance $tile
-  set rmuxes [get_cells -hier *RMUX_*_sel_inst0]
-  if { "$rmux_cells" != "" } {
-    set rmux_outputs [get_pins -of_objects $rmuxes -filter "direction==out"]
-    set_case_analysis 1 $rmux_outputs
-  }
+  set rmuxes [get_cells -hier *RMUX_*_sel_*]
+  set rmux_outputs [get_pins -of_objects $rmuxes -filter "direction==out"]
+  set_case_analysis 1 $rmux_outputs
   current_instance
 }

--- a/mflowgen/common/synopsys-ptpx-gl/loop_break_Interconnect.tcl
+++ b/mflowgen/common/synopsys-ptpx-gl/loop_break_Interconnect.tcl
@@ -2,7 +2,9 @@
 foreach_in_collection tile [get_cells -hier Tile* ] {
   current_instance $tile
   set rmuxes [get_cells -hier *RMUX_*_sel_inst0]
-  set rmux_outputs [get_pins -of_objects $rmuxes -filter "direction==out"]
-  set_case_analysis 1 $rmux_outputs
+  if { "$rmux_cells" != "" } {
+    set rmux_outputs [get_pins -of_objects $rmuxes -filter "direction==out"]
+    set_case_analysis 1 $rmux_outputs
+  }
   current_instance
 }


### PR DESCRIPTION
TSMC CI failed in mem-tile synthesis, with the following error
https://buildkite.com/tapeout-aha/mflowgen/builds/5733
```
set rmux_cells [get_cells -hier RMUX_T*sel_inst0]
Warning : Could not find requested search value. [SDC-208] [get_cells]
        : The 'get_cells' command  cannot find any cells named 'RMUX_T*sel_inst0'

set_dont_touch $rmux_cells true
Error   : A required object parameter could not be found. [TUI-61] [parse_options]
        : An object of type 'subdesign|instance|net|design|libcell' named '' could not be found.
```

This is supposed to fix that. For more details, see issue https://github.com/StanfordAHA/garnet/issues/900

