### PR TITLE
Pd dont touch refactor

### DIFF
--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -148,6 +148,8 @@ if $::env(PWR_AWARE) {
     source inputs/dc-dont-use-constraints.tcl
     # source inputs/mem-constraints-2.tcl
     set_dont_touch [get_cells -hierarchical *u_mux_logic*]
+    # Prevent buffers in paths from SB input ports
+    set_dont_touch_network [get_ports *SB* -filter "direction==in"]
 }
 
 # Tile ID false paths

--- a/mflowgen/Tile_MemCore/constraints/common.tcl
+++ b/mflowgen/Tile_MemCore/constraints/common.tcl
@@ -149,7 +149,7 @@ if $::env(PWR_AWARE) {
     # source inputs/mem-constraints-2.tcl
     set_dont_touch [get_cells -hierarchical *u_mux_logic*]
     # Prevent buffers in paths from SB input ports
-    set_dont_touch_network [get_ports *SB* -filter "direction==in"]
+    set_dont_touch_network [get_ports *SB* -filter "direction==in"] -no_propagate
 }
 
 # Tile ID false paths

--- a/mflowgen/Tile_PE/constraints/common.tcl
+++ b/mflowgen/Tile_PE/constraints/common.tcl
@@ -164,7 +164,7 @@ if $::env(PWR_AWARE) {
     # source inputs/pe-constraints-2.tcl
     set_dont_touch [get_cells -hierarchical *u_mux_logic*]
     # Prevent buffers in paths from SB input ports
-    set_dont_touch_network [get_ports *SB* -filter "direction==in"]
+    set_dont_touch_network [get_ports *SB* -filter "direction==in"] -no_propagate
 } 
 
 # False paths

--- a/mflowgen/Tile_PE/constraints/common.tcl
+++ b/mflowgen/Tile_PE/constraints/common.tcl
@@ -163,6 +163,8 @@ if $::env(PWR_AWARE) {
     source inputs/dc-dont-use-constraints.tcl
     # source inputs/pe-constraints-2.tcl
     set_dont_touch [get_cells -hierarchical *u_mux_logic*]
+    # Prevent buffers in paths from SB input ports
+    set_dont_touch_network [get_ports *SB* -filter "direction==in"]
 } 
 
 # False paths

--- a/mflowgen/Tile_PE/constraints/constraints.tcl
+++ b/mflowgen/Tile_PE/constraints/constraints.tcl
@@ -64,9 +64,6 @@ set_false_path -from [get_ports config_* -filter direction==in] -to [get_pins [l
 # Paths from config input ports to the register file in Pond 
 set pond_path PondCore_inst0/PondTop_W_inst0/PondTop/memory_0/data_array_reg*
 
-# Prevent buffers in paths from SB input ports
-set_dont_touch [get_nets -of_objects [get_ports *SB* -filter "direction==in"]]
-
 # set_false_path -from [get_ports config_* -filter direction==in] -to [get_pins [list $pond_path/*]] -through [get_pins [list $pe_path/* ]]
 # Set multicycle path from config ports to the register file passing through the ALU
 # These are false paths and the above false path constraint can be applied but use MCP for conservative constraints


### PR DESCRIPTION
Rewrite of the constraint added in #908 

Highlights:
-adds the constraint the mem tile in addition to PE
-only applies constraint when using power domains (not needed otherwise)
-uses `set_dont_touch_network` because I found that the previous version of the constraint didn't always work.