### PR TITLE
gfmerge: adopting files from gf-conversion branch that do not yet exist in master

### DIFF
--- a/mflowgen/common/gen_sram_macro_old/configure.yml
+++ b/mflowgen/common/gen_sram_macro_old/configure.yml
@@ -1,0 +1,29 @@
+name: gen_sram_macro
+
+commands:
+  - bash gen_srams.sh
+
+inputs:
+  - adk
+
+outputs:
+  - sram.v
+  - sram-pwr.v
+  - sram.lef
+  - sram_tt.lib
+  - sram_ff.lib
+  - sram_tt.db  # Need this back for power on ptpx
+  - sram.gds
+  - sram.spi
+
+parameters:
+  num_words: 2048
+  word_size: 64
+  mux_size: 8
+  corner: "tt0p8v25c"
+  bc_corner: "ffg0p88v125c"
+  partial_write: False
+
+postconditions:
+   # Sanity check to see if we at least got one sram
+   - assert File( 'outputs/sram_tt.lib' )

--- a/mflowgen/common/gen_sram_macro_old/lib2db/Makefile
+++ b/mflowgen/common/gen_sram_macro_old/lib2db/Makefile
@@ -1,0 +1,20 @@
+#=========================================================================
+# Makefile
+#=========================================================================
+# Generate db from a lib file (using Synopsys DC)
+#
+# Author : Christopher Torng
+# Date   : November 11, 2019
+#
+
+all:
+	rm -rf build
+	mkdir -p build
+	cd build && dc_shell-xg-t -64bit -output_log_file build.log -f ../generate_db.tcl | tee build.log
+	ln -sf build/foo.db
+
+clean:
+	rm -rf build foo.db
+
+
+

--- a/mflowgen/common/gen_sram_macro_old/lib2db/generate_db.tcl
+++ b/mflowgen/common/gen_sram_macro_old/lib2db/generate_db.tcl
@@ -1,0 +1,24 @@
+#=========================================================================
+# generate_db.tcl
+#=========================================================================
+# Generate db from a lib file (using Synopsys DC)
+#
+# For the library name, look at the top of the .lib file:
+#
+#     library (NangateOpenCellLibrary) (...)
+#
+# Author : Christopher Torng
+# Date   : November 11, 2019
+#
+
+set sram_lib_name "ts1n16ffcllsblvtc$::env(num_words)x$::env(word_size)m$::env(mux_size)s"
+if {$::env(partial_write)} {
+  set sram_lib_name "${sram_lib_name}w"
+}
+set sram_lib_name "${sram_lib_name}_$::env(corner)"
+enable_write_lib_mode
+read_lib ../../outputs/sram_tt.lib
+write_lib -format db $sram_lib_name -output ../../outputs/sram_tt.db
+
+exit
+

--- a/mflowgen/common/gf-mentor-calibre-drc-mas/configure.yml
+++ b/mflowgen/common/gf-mentor-calibre-drc-mas/configure.yml
@@ -1,0 +1,55 @@
+#=========================================================================
+# Constraints
+#=========================================================================
+# Author : Alex Carsello
+# Date   : Nov 1, 2019
+#
+
+name: gf-mentor-calibre-drc-mas
+
+#-------------------------------------------------------------------------
+# Inputs and Outputs
+#-------------------------------------------------------------------------
+
+inputs:
+  - design_merged.gds
+  - adk
+
+outputs:
+  - drc.summary
+
+#-------------------------------------------------------------------------
+# Commands
+#-------------------------------------------------------------------------
+
+commands:
+  - /bin/csh inputs/adk/run-drc-mas.csh
+  - mkdir -p outputs && cd outputs
+  - ln -sf ../rdb_out/MAS_SUMMARY_out.txt drc.summary
+#  - ln -sf ../rdb/drc-pm-results/drc-pm-results_PM_ALL.rdb drc.results
+
+#-------------------------------------------------------------------------
+# Parameters
+#-------------------------------------------------------------------------
+
+parameters:
+  design_name: undefined
+
+#-------------------------------------------------------------------------
+# Debug
+#-------------------------------------------------------------------------
+
+debug:
+  - calibredrv -m inputs/design_merged.gds \
+               -l inputs/adk/calibre.layerprops \
+               -rve -drc outputs/drc.results
+
+#-------------------------------------------------------------------------
+# Assertions
+#-------------------------------------------------------------------------
+
+preconditions:
+
+  - assert Tool( 'calibre' )
+  - assert File( 'inputs/adk' )
+  - assert File( 'inputs/design_merged.gds' )

--- a/mflowgen/common/gf-mentor-calibre-drcplus-pm/configure.yml
+++ b/mflowgen/common/gf-mentor-calibre-drcplus-pm/configure.yml
@@ -1,0 +1,56 @@
+#=========================================================================
+# Constraints
+#=========================================================================
+# Author : Alex Carsello
+# Date   : Nov 1, 2019
+#
+
+name: gf-mentor-calibre-drcplus-pm
+
+#-------------------------------------------------------------------------
+# Inputs and Outputs
+#-------------------------------------------------------------------------
+
+inputs:
+  - design_merged.gds
+  - adk
+
+outputs:
+  - drc.results
+  - drc.summary
+
+#-------------------------------------------------------------------------
+# Commands
+#-------------------------------------------------------------------------
+
+commands:
+  - /bin/csh inputs/adk/run-drc-pm.csh
+  - mkdir -p outputs && cd outputs
+  - ln -sf ../rdb/drc-pm-results/drc-pm-results_PM_ALL.rdb drc.results
+  - ln -sf ../rdb/drc-pm-results/drc-pm-results_PM.sum_GFsummary drc.summary
+
+#-------------------------------------------------------------------------
+# Parameters
+#-------------------------------------------------------------------------
+
+parameters:
+  design_name: undefined
+
+#-------------------------------------------------------------------------
+# Debug
+#-------------------------------------------------------------------------
+
+debug:
+  - calibredrv -m inputs/design_merged.gds \
+               -l inputs/adk/calibre.layerprops \
+               -rve -drc outputs/drc.results
+
+#-------------------------------------------------------------------------
+# Assertions
+#-------------------------------------------------------------------------
+
+preconditions:
+
+  - assert Tool( 'calibre' )
+  - assert File( 'inputs/adk' )
+  - assert File( 'inputs/design_merged.gds' )

--- a/mflowgen/common/mentor-calibre-fill-gf/configure.yml
+++ b/mflowgen/common/mentor-calibre-fill-gf/configure.yml
@@ -1,0 +1,63 @@
+#=========================================================================
+# Mentor Calibre Fill GF
+#=========================================================================
+# Author : Alex Carsello
+# Date   : April 22, 2022
+#
+
+name: mentor-calibre-fill-gf
+
+#-------------------------------------------------------------------------
+# Inputs and Outputs
+#-------------------------------------------------------------------------
+
+inputs:
+  - design.gds
+  - adk
+
+outputs:
+  - fill.gds
+
+#-------------------------------------------------------------------------
+# Commands
+#-------------------------------------------------------------------------
+
+commands:
+  # Generate the dummy fill GDS
+  - /bin/csh inputs/adk/run-fill.csh
+  - mkdir -p outputs && cd outputs
+  - ln -sf ../MERGED_OUTPUT/{design_name}_DummyMerge.gds fill.gds
+
+
+#-------------------------------------------------------------------------
+# Parameters
+#-------------------------------------------------------------------------
+
+parameters:
+  design_name: undefined
+  # Use the rule deck "inputs/adk/${fill_rule_deck}"
+  fill_rule_deck: calibre-fill.rule
+
+#-------------------------------------------------------------------------
+# Debug
+#-------------------------------------------------------------------------
+
+debug:
+  - calibredrv -m outputs/fill.gds \
+               -l inputs/adk/calibre.layerprops
+
+#-------------------------------------------------------------------------
+# Assertions
+#-------------------------------------------------------------------------
+
+preconditions:
+
+  - assert Tool( 'calibre' )
+  - assert File( 'inputs/adk' )
+  - assert File( 'inputs/design.gds' )
+
+postconditions:
+
+  - assert File( 'outputs/fill.gds' )
+
+

--- a/tests/SC7P5T_AN2X0P5_SSC14R.sv
+++ b/tests/SC7P5T_AN2X0P5_SSC14R.sv
@@ -1,0 +1,6 @@
+module SC7P5T_AN2X0P5_SSC14R ( 
+input logic  A, 
+input logic  B, 
+output logic  Z); 
+assign Z = (A & B); 
+endmodule  

--- a/tests/SC7P5T_AO22X0P5_SSC14R.sv
+++ b/tests/SC7P5T_AO22X0P5_SSC14R.sv
@@ -1,0 +1,9 @@
+module SC7P5T_AO22X0P5_SSC14R ( 
+input logic  A1,
+input logic  A2, 
+input logic  B1, 
+input logic  B2, 
+output logic  Z);  
+assign Z = ((A1 & A2) | (B1 & B2)); 
+endmodule 
+


### PR DESCRIPTION
This should be an easy one. I pulled in some files from gf12-conversion branch that did not yet exist in master. This should make no difference to the functionality of either branch, but it will cut down the number of diffs between them. I'm hoping this merge will bring the number of different files to under 100.

BEFORE: 107 different files
```
% git diff origin/master origin/gf12-conversion | egrep ^diff | wc -l
107
```

AFTER: 99 different files
```
% git diff gfmerge-low-hanging-fruit origin/gf12-conversion | egrep ^diff | wc -l
99
```
