### PR TITLE
fix TLX pad renaming problems etc.

### DIFF
--- a/mflowgen/full_chip/constraints/cons_scripts/design_info.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/design_info.tcl
@@ -80,7 +80,7 @@ set port_names(cgra_jtag_reset_n)           "pad_CGRA_JTAG_TRSTn"
 
 set port_names(trace_data)                  "pad_TPIU_TRACE_DATA"
 set port_names(trace_swo)                   "pad_TPIU_TRACE_SWO"
-set port_names(trace_clk)                   "pad_TPIU_TRACE_CLK"
+set port_names(trace_clk)                   "pad_TPIU_TRACECLKIN"
 
 # ------------------------------------------------------------------------------
 # Define Port Names (UART)

--- a/mflowgen/full_chip/constraints/cons_scripts/io.tcl
+++ b/mflowgen/full_chip/constraints/cons_scripts/io.tcl
@@ -59,11 +59,11 @@ set_multicycle_path -setup 0 -from [get_clocks tlx_fwd_gclk] -to [get_clocks tlx
 set_multicycle_path -hold -1 -from [get_clocks tlx_fwd_gclk] -to [get_clocks tlx_fwd_strobe]
 
 # Input constraints
-set_input_delay -max [expr ${master_clk_period} * 2] -clock [get_clocks tlx_fwd_gclk] [get_ports $tlx_fwd_inputs]
-set_input_delay -min 0.0 -clock [get_clocks tlx_fwd_gclk] [get_ports $tlx_fwd_inputs]
-
-set_multicycle_path -setup -end -from [get_ports $tlx_fwd_inputs] 5
-set_multicycle_path -hold -end -from [get_ports $tlx_fwd_inputs] 4
+# set_input_delay -max [expr ${master_clk_period} * 2] -clock [get_clocks tlx_fwd_gclk] [get_ports $tlx_fwd_inputs]
+# set_input_delay -min 0.0 -clock [get_clocks tlx_fwd_gclk] [get_ports $tlx_fwd_inputs]
+# 
+# set_multicycle_path -setup -end -from [get_ports $tlx_fwd_inputs] 5
+# set_multicycle_path -hold -end -from [get_ports $tlx_fwd_inputs] 4
 
 # ------------------------------------------------------------------------------
 # TLX Reverse Channel


### PR DESCRIPTION
The most recent full-chip synthesis failed with the following error:
```
create_generated_clock -name trace_clk \
    -source [get_pins core/u_aha_platform_ctrl/u_clock_controller/u_cpu_gclk/Q] \
    [get_ports $port_names(trace_clk)]
Warning : Could not find requested search value. [SDC-208] [get_ports]
        : The 'get_ports' command  cannot find any ports named 'pad_TPIU_TRACE_CLK'
Error   : A required object parameter could not be found. [TUI-61] [parse_options]
```
I solved this first error by updating the name of the trace-clock pad in `design_info.tcl`.

Upon retrying I then got the second error, related to tlx_fwd_inputs

```
source -echo -verbose inputs/cons_scripts/io.tcl
set_input_delay -max [expr ${master_clk_period} * 2] -clock \
        [get_clocks tlx_fwd_gclk] [get_ports $tlx_fwd_inputs]
Warning : Could not find requested search value. [SDC-208] [get_ports]
        : The 'get_ports' command  cannot find any ports named 
        'pad_TLX_FWD_PAYLOAD_TREADY'
```

The offending variable $tlx_fwd_inputs refers to pads that seem to not exist anymore, even as renamed signals that I could tell (see below), so I just comment-out the code that was using the variable.

```
design_info.tcl:
  set tlx_fwd_inputs [list  $port_names(tlx_fwd_payload_ready) \
                            $port_names(tlx_fwd_flow_ready) ]
  set port_names(tlx_fwd_payload_ready)       "pad_TLX_FWD_PAYLOAD_TREADY"
  set port_names(tlx_fwd_flow_ready)          "pad_TLX_FWD_FLOW_TREADY"
```

After this second fix, synthesis was able to complete without error.

I won't be surprised at all if this is not the right and/or best fix, I'm hoping one of you guys can help me out with that. And/or we can approve these changes to get on with the build, and sort out how to do a better fix later...
