### PR TITLE
pin SoC to legacy TSMC version

### DIFF
--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -19,10 +19,13 @@ env:
   # Env var used by test_module.sh :(
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'
 
-  # For debugging, use $BUILD flag to build in indicated local dir
   TEST: echo exit 13 | mflowgen/test/test_module.sh
-# TEST: echo exit 13 | mflowgen/test/test_module.sh --build_dir /build/pmg${BUILDKITE_BUILD_NUMBER}
 
+  # For debugging, use build_dir flag to save build in indicated local dir
+  # TEST: echo exit 13 | mflowgen/test/test_module.sh --build_dir /build/pmg${BUILDKITE_BUILD_NUMBER}
+
+  # Newer dockers use lake "sparse_strawman" branch offshoots :(
+  RTL_DOCKER_IMAGE: 'stanfordaha/garnet@sha256:dd688c7b98b034dadea9f7177781c97a7a030d737ae4751a78dbb97ae8b72af4'
 
 steps:
 

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -1,31 +1,29 @@
-# Agents are specified in "pipeline settings" now, see e.g. buildkite.com/tapeout-aha/steps
-# agents: { jobsize: "hours" }
-
-# 04/2022 Now running tests in parallel
-# Old runtime 30-35m, new runtime 20-25m
+# Agents are specified in "pipeline settings", see e.g. buildkite.com/tapeout-aha/steps
 
 ##############################################################################
-# Use this to test a specific branch/commit:
+# TO TEST A SPECIFIC BRANCH/COMMIT
 # Add to env:
 #   NOV11: ee214ef77b827f969e4b5f056f5d866cf391be7a
 # Add to commands:
-# - pwd; git branch; git checkout $$NOV11
+#   - pwd; git branch; git checkout $$NOV11
 
-##############################################################################
-# Note: "echo exit 13" prevents hang at genus/innovus prompt
 env:
   SETUP: source mflowgen/bin/setup-buildkite.sh
 
   # Env var used by test_module.sh :(
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'
 
+  # For debugging, use --build_dir to save work locally
   TEST: echo exit 13 | mflowgen/test/test_module.sh
-
-  # For debugging, use build_dir flag to save build in indicated local dir
-  # TEST: echo exit 13 | mflowgen/test/test_module.sh --build_dir /build/pmg${BUILDKITE_BUILD_NUMBER}
+# BDIR: /build/pmg${BUILDKITE_BUILD_NUMBER}
+# TEST: echo exit 13 | mflowgen/test/test_module.sh --build_dir $BDIR
 
   # Newer dockers use lake "sparse_strawman" branch offshoots :(
+  # Note 10/10/2022 made this the default in $GARNET/mflowgen/common/rtl/gen_rtl.sh
+  # So for now at least this is redundant
   RTL_DOCKER_IMAGE: 'stanfordaha/garnet@sha256:dd688c7b98b034dadea9f7177781c97a7a030d737ae4751a78dbb97ae8b72af4'
+
+  # TODO/FIXME Figure out how to use a top-level parm file :(
 
 steps:
 

--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -9,15 +9,10 @@ export PYTEST_ADDOPTS="--color=yes"
 ROOT=$(dirname $(dirname $(dirname $BASH_SOURCE)))
 cd ${ROOT}
 
-# steveri 10/2022 deleting pond tests (test_pond.py)
-# that have been failing for the past month
-
 pytest --pycodestyle           \
        --cov global_controller \
        --cov io_core           \
        --cov memory_core       \
        --ignore=filecmp.py     \
        --ignore=Genesis2/      \
-       --ignore=tests/test_memory_core/test_pond.py   \
-       --ignore-glob='*/test_pond.py'   \
        -v --cov-report term-missing tests

--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -18,5 +18,6 @@ pytest --pycodestyle           \
        --cov memory_core       \
        --ignore=filecmp.py     \
        --ignore=Genesis2/      \
-       --ignore=test_pond.py   \
+       --ignore=tests/test_memory_core/test_pond.py   \
+       --ignore-glob='*/test_pond.py'   \
        -v --cov-report term-missing tests

--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -9,10 +9,14 @@ export PYTEST_ADDOPTS="--color=yes"
 ROOT=$(dirname $(dirname $(dirname $BASH_SOURCE)))
 cd ${ROOT}
 
+# steveri 10/2022 deleting pond tests (test_pond.py)
+# that have been failing for the past month
+
 pytest --pycodestyle           \
        --cov global_controller \
        --cov io_core           \
        --cov memory_core       \
        --ignore=filecmp.py     \
        --ignore=Genesis2/      \
+       --ignore=test_pond.py   \
        -v --cov-report term-missing tests

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -57,7 +57,7 @@ else
       # FIXME/TODO: should be part of top-level parms
       # FIXME/TODO: whrere are top-level parms???
       amber_dense_sha=dd688c7b98b034dadea9f7177781c97a7a030d737ae4751a78dbb97ae8b72af4
-      default_image="stanfordaha/garnet@sha256:${amber_dense_sha}'
+      default_image="stanfordaha/garnet@sha256:${amber_dense_sha}"
 
       if [ "$rtl_docker_image" == ""        ]; then rtl_docker_image=${default_image}; fi
       if [ "$rtl_docker_image" == "default" ]; then rtl_docker_image=${default_image}; fi

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -52,6 +52,13 @@ else
 
       # Choose a docker image; can set via "rtl_docker_image" parameter
       default_image="stanfordaha/garnet:latest"
+
+      # NOW: to make this branch (master-tsmc) work, must use specific docker image
+      # FIXME/TODO: should be part of top-level parms
+      # FIXME/TODO: whrere are top-level parms???
+      amber_dense_sha=dd688c7b98b034dadea9f7177781c97a7a030d737ae4751a78dbb97ae8b72af4
+      default_image="stanfordaha/garnet@sha256:${amber_dense_sha}'
+
       if [ "$rtl_docker_image" == ""        ]; then rtl_docker_image=${default_image}; fi
       if [ "$rtl_docker_image" == "default" ]; then rtl_docker_image=${default_image}; fi
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -55,6 +55,15 @@ else
       if [ "$rtl_docker_image" == ""        ]; then rtl_docker_image=${default_image}; fi
       if [ "$rtl_docker_image" == "default" ]; then rtl_docker_image=${default_image}; fi
 
+      # Env var overrides all else
+      if [ "$RTL_DOCKER_IMAGE" ]; then
+          echo "+++ WARNING overriding local rtl_docker_image w env var RTL_DOCKER_IMAGE"
+          echo "WAS $rtl_docker_image"
+          rtl_docker_image=${RTL_DOCKER_IMAGE}
+          echo "NOW $rtl_docker_image"
+          echo "--- continue..."
+      fi
+
       # To use a docker image with name other than "latest" can do e.g.
       # rtl_docker_image="stanfordaha/garnet:cst"
 

--- a/mflowgen/common/soc-rtl-v2/run.sh
+++ b/mflowgen/common/soc-rtl-v2/run.sh
@@ -5,6 +5,7 @@ CUR_DIR=$(pwd)
 
 # Clone the SoC Repo
 git clone https://github.com/StanfordAHA/AhaM3SoC.git aham3soc
+(cd aham3soc; git checkout 83dca39f4e4568ae134f0af69c2ad1b0c8adf6e7)
 
 # Clone the ARM IP Repo
 git clone git@r7arm-aha:nyengele/aham3soc_armip.git aham3soc_armip

--- a/mflowgen/common/soc-rtl-v2/run.sh
+++ b/mflowgen/common/soc-rtl-v2/run.sh
@@ -5,7 +5,12 @@ CUR_DIR=$(pwd)
 
 # Clone the SoC Repo
 git clone https://github.com/StanfordAHA/AhaM3SoC.git aham3soc
-(cd aham3soc; git checkout 83dca39f4e4568ae134f0af69c2ad1b0c8adf6e7)
+
+# NOW: to make this branch (master-tsmc) work, must use amber soc
+# FIXME/TODO: should be part of top-level parms
+# FIXME/TODO: whrere are top-level parms???
+amber_soc=83dca39f4e4568ae134f0af69c2ad1b0c8adf6e7
+(cd aham3soc; git checkout $amber_soc)
 
 # Clone the ARM IP Repo
 git clone git@r7arm-aha:nyengele/aham3soc_armip.git aham3soc_armip

--- a/tests/AN_CELL.sv
+++ b/tests/AN_CELL.sv
@@ -1,0 +1,14 @@
+module AN_CELL ( 
+input logic  A1, 
+input logic  A2, 
+output logic  Z); 
+
+`ifdef TSMC16
+AN2D0BWP16P90 inst(.A1(A1), .A2(A2), .Z(Z));
+`elsif GF12
+SC7P5T_AN2X0P5_SSC14R inst(.A(A1), .B(A2), .Z(Z));
+`else
+assign Z = (A1 & A2); 
+`endif
+
+endmodule  

--- a/tests/AO_CELL.sv
+++ b/tests/AO_CELL.sv
@@ -1,0 +1,16 @@
+module AO_CELL ( 
+input logic  A1,
+input logic  A2, 
+input logic  B1, 
+input logic  B2, 
+output logic  Z);  
+
+`ifdef TSMC16
+AO22D0BWP16P90 inst(.A1(A1), .A2(A2), .B1(B1), .B2(B2), .Z(Z));
+`elsif GF12
+SC7P5T_AO22X0P5_SSC14R inst(.A1(A1), .A2(A2), .B1(B1), .B2(B2), .Z(Z));
+`else
+assign Z = ((A1 & A2) | (B1 & B2)); 
+`endif
+
+endmodule 


### PR DESCRIPTION
Recent changes to `aham3soc` repo (to accommodate GF technology and GCD block I suppose) broke the TSMC build. This one-line change pins the repo to a pre-GF version that now works, and should continue to work with, our legacy TSMC build.
