### PR TITLE
Spv merge to spv

### DIFF
--- a/.buildkite/pipeline_fullchip.yml
+++ b/.buildkite/pipeline_fullchip.yml
@@ -21,6 +21,9 @@ env:
   # Can use this to change target mflowgen branch
   # OVERRIDE_MFLOWGEN_BRANCH: glob-prob
 
+  # Newer dockers use lake "sparse_strawman" branch offshoots :(
+  RTL_DOCKER_IMAGE: 'stanfordaha/garnet@sha256:dd688c7b98b034dadea9f7177781c97a7a030d737ae4751a78dbb97ae8b72af4'
+
 steps:
 - label: 'setup'
   commands:

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/pe_tile_only.yml
+pipelines/pmg.yml

--- a/.buildkite/pipeline_mflowgen.yml
+++ b/.buildkite/pipeline_mflowgen.yml
@@ -1,1 +1,1 @@
-pipelines/pmg.yml
+pipelines/pe_tile_only.yml

--- a/.buildkite/pipelines/check_pe_area.sh
+++ b/.buildkite/pipelines/check_pe_area.sh
@@ -19,7 +19,7 @@ echo $pe_dir
 
 # "echo" to unglob why not
 resdir=`echo $pe_dir/*synthesis/results_syn`
-egrep ^Tile_PE $resdir/final_area.rpt | awk -v max_area=11000 '
+egrep ^Tile_PE $resdir/final_area.rpt | awk -v max_area=8500 '
 { printf("Total area: %d\n", $NF);
   if ($NF > max_area) {
     print ""

--- a/.buildkite/pipelines/check_tile_width.sh
+++ b/.buildkite/pipelines/check_tile_width.sh
@@ -6,7 +6,7 @@
 # Also used in per-checkin CI test e.g. pmg.yml:
 #   commands:
 #   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
-#   - .buildkite/pipelines/check_pe_area.sh Tile_PE --max 110
+#   - .buildkite/pipelines/check_pe_area.sh Tile_PE --max 112
 
 function usage {
 cat <<EOF

--- a/.buildkite/pipelines/glb_tile.yml
+++ b/.buildkite/pipelines/glb_tile.yml
@@ -1,7 +1,5 @@
 # Builds glb_tile but not from scratch, uses pre-cached gold collateral
 
-agents: { jobsize: "hours" }
-
 ##############################################################################
 # Use this to test a specific branch/commit:
 # Add to env:

--- a/.buildkite/pipelines/glb_tile_only.yml
+++ b/.buildkite/pipelines/glb_tile_only.yml
@@ -1,0 +1,44 @@
+##############################################################################
+# TO TEST A SPECIFIC BRANCH/COMMIT
+# -------------------------------------------------
+# Add to env:
+#   NOV11: ee214ef77b827f969e4b5f056f5d866cf391be7a
+# Add to commands:
+#   - pwd; git branch; git checkout $$NOV11
+# -------------------------------------------------
+
+env:
+  SETUP: source mflowgen/bin/setup-buildkite.sh
+
+  # Env var used by test_module.sh :(
+  TEST_MODULE_SBFLAGS: '--skip_mflowgen'
+
+  # For debugging, use build_dir flag to save build in indicated local dir
+  # TEST: echo exit 13 | mflowgen/test/test_module.sh
+  TEST: echo exit 13 | mflowgen/test/test_module.sh --build_dir /build/glb${BUILDKITE_BUILD_NUMBER}
+
+  # Newer dockers use lake "sparse_strawman" branch offshoots :(
+  # Note as of 10/10/2022 this is the default (see common/rtl/gen_rtl.sh)
+  RTL_DOCKER_IMAGE: 'stanfordaha/garnet@sha256:dd688c7b98b034dadea9f7177781c97a7a030d737ae4751a78dbb97ae8b72af4'
+
+  # TODO/FIXME Figure out how to use a top-level parm file :(
+
+steps:
+
+##############################################################################
+# COMMON SETUP to initialize mflowgen
+
+- label: 'setup 2m'
+  commands:
+  - '
+     echo "--- SETUP";
+     set -o pipefail;
+     $$SETUP --dir .;
+    '
+- wait
+
+- label: 'gtile init 20m'
+  commands:
+  - $TEST --need_space 30G full_chip glb_top glb_tile --steps lvs --debug
+  - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors
+

--- a/.buildkite/pipelines/mem_tile_only.yml
+++ b/.buildkite/pipelines/mem_tile_only.yml
@@ -1,8 +1,8 @@
-agents: { jobsize: "hours" }
+# Run MEM TILE in context of tile_array. Save build in e.g. /build/mem4458
 
 env:
-  GOLD: /build/mem${BUILDKITE_BUILD_NUMBER}
-  OVERRIDE_MFLOWGEN_BRANCH: silent_fail
+  BDIR: /build/mem${BUILDKITE_BUILD_NUMBER}
+  # OVERRIDE_MFLOWGEN_BRANCH: silent_fail
 
 steps:
 
@@ -11,14 +11,17 @@ steps:
 
 - label: 'setup'
   commands:
-  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD;
+  - 'source mflowgen/bin/setup-buildkite.sh --dir $$BDIR;
      mflowgen run --design $$GARNET_HOME/mflowgen/tile_array'
 - wait: ~
 
 - label: 'MemTile'
   commands:
-  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 30G;
+  - 'source mflowgen/bin/setup-buildkite.sh --dir $$BDIR --need_space 30G;
      set -o pipefail;
-     make Tile_MemCore |& tee make-mem.log'
+     make Tile_MemCore |& tee make-mem.log;
+     /bin/ls -l */*-cadence-innovus-signoff/outputs/design-merged.gds;
+     strings -a */*-cadence-innovus-signoff/outputs/design-merged.gds | grep _gds && exit 13 || echo PASS
+     '
 
 

--- a/.buildkite/pipelines/pe_synth_only.yml
+++ b/.buildkite/pipelines/pe_synth_only.yml
@@ -10,9 +10,10 @@ steps:
 ##############################################################################
 # INDIVIDUAL TILE RUNS
 # 
+# Set pe max width to 112: fp limits to 110 but then lvs says 112 OK
 - label: 'PE synth 45m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 110
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 112
 
 - wait: { continue_on_failure: true } # One step at a time + continue on failure

--- a/.buildkite/pipelines/pe_tile_only.yml
+++ b/.buildkite/pipelines/pe_tile_only.yml
@@ -1,7 +1,7 @@
 # Run PE TILE in context of tile_array. Save build in e.g. /build/pe4458
 
 env:
-  GOLD: /build/pe${BUILDKITE_BUILD_NUMBER}
+  BDIR: /build/pe${BUILDKITE_BUILD_NUMBER}
   # OVERRIDE_MFLOWGEN_BRANCH: silent_fail
 
 steps:
@@ -11,14 +11,17 @@ steps:
 
 - label: 'setup'
   commands:
-  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD;
+  - 'source mflowgen/bin/setup-buildkite.sh --dir $$BDIR;
      mflowgen run --design $$GARNET_HOME/mflowgen/tile_array'
 - wait: ~
 
+# Set pe max width to 112: fp limits to 110 but then lvs says 112 OK
 - label: 'PE'
   commands:
-  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 30G;
+  - 'source mflowgen/bin/setup-buildkite.sh --dir $$BDIR --need_space 30G;
      set -o pipefail;
      echo exit 13 | make Tile_PE |& tee make-pe.log;
-     $$GARNET_HOME/.buildkite/pipelines/check_tile_width.sh Tile_PE --max 110
+     $$GARNET_HOME/.buildkite/pipelines/check_tile_width.sh Tile_PE --max 112;
+     /bin/ls -l */*-cadence-innovus-signoff/outputs/design-merged.gds;
+     strings -a */*-cadence-innovus-signoff/outputs/design-merged.gds | grep _gds && exit 13 || echo PASS
      '

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -1,28 +1,30 @@
-# Agents are specified in "pipeline settings" now, see e.g. buildkite.com/tapeout-aha/steps
-# agents: { jobsize: "hours" }
-
-# 04/2022 Now running tests in parallel
-# Old runtime 30-35m, new runtime 20-25m
+# Agents are specified in "pipeline settings", see e.g. buildkite.com/tapeout-aha/steps
 
 ##############################################################################
-# Use this to test a specific branch/commit:
+# TO TEST A SPECIFIC BRANCH/COMMIT
+# -------------------------------------------------
 # Add to env:
 #   NOV11: ee214ef77b827f969e4b5f056f5d866cf391be7a
 # Add to commands:
-# - pwd; git branch; git checkout $$NOV11
+#   - pwd; git branch; git checkout $$NOV11
+# -------------------------------------------------
 
-##############################################################################
-# Note: "echo exit 13" prevents hang at genus/innovus prompt
 env:
   SETUP: source mflowgen/bin/setup-buildkite.sh
 
   # Env var used by test_module.sh :(
   TEST_MODULE_SBFLAGS: '--skip_mflowgen'
 
-  # For debugging, use $BUILD flag to build in indicated local dir
   TEST: echo exit 13 | mflowgen/test/test_module.sh
-# TEST: echo exit 13 | mflowgen/test/test_module.sh --build_dir /build/pmg${BUILDKITE_BUILD_NUMBER}
 
+  # For debugging, use build_dir flag to save build in indicated local dir
+  # TEST: echo exit 13 | mflowgen/test/test_module.sh --build_dir /build/pmg${BUILDKITE_BUILD_NUMBER}
+
+  # Newer dockers use lake "sparse_strawman" branch offshoots :(
+  # Note as of 10/10/2022 this is the default (see common/rtl/gen_rtl.sh)
+  RTL_DOCKER_IMAGE: 'stanfordaha/garnet@sha256:dd688c7b98b034dadea9f7177781c97a7a030d737ae4751a78dbb97ae8b72af4'
+
+  # TODO/FIXME Figure out how to use a top-level parm file :(
 
 steps:
 
@@ -42,10 +44,11 @@ steps:
 # INDIVIDUAL TILE RUNS
 # Builds in dir e.g. mflowgen/full_chip/19-tile_array/16-Tile_MemCore
 
+# Set pe max width to 112: fp limits to 110 but then lvs says 112 OK
 - label: 'ptile init 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 110
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 112
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'mtile init 25m'

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -44,21 +44,35 @@ steps:
 # INDIVIDUAL TILE RUNS
 # Builds in dir e.g. mflowgen/full_chip/19-tile_array/16-Tile_MemCore
 
+# For non-GF (TSMC) branches, run the usual three tile tests.
+# But GF branches cannot run synthesis on my machine, so
+# add if-condition to do a single RTL-only test for GF branches;
+
 # Set pe max width to 112: fp limits to 110 but then lvs says 112 OK
 - label: 'ptile init 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
   - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 112
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
+  if: build.branch !~ /to-spv/ &&  build.branch !~ /spV/
 
 - label: 'mtile init 25m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
   - .buildkite/pipelines/check_tile_width.sh Tile_MemCore --max 250
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
+  if: build.branch !~ /to-spv/ &&  build.branch !~ /spV/
 
 - label: 'gtile init 20m'
   commands:
   - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
   - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors
+  if: build.branch !~ /to-spv/ &&  build.branch !~ /spV/
+
+# GF branches cannot run synthesis on my machine, so do RTL only I guess
+- label: 'RTL only'
+  commands:
+  - 'export RTL_DOCKER_IMAGE=stanfordaha/garnet:latest;
+    $TEST --need_space 30G full_chip --steps rtl --debug'
+  if: build.branch =~ /to-spv/ || build.branch =~ /spV/
 

--- a/.buildkite/pipelines/pmtile_synth_only.yml
+++ b/.buildkite/pipelines/pmtile_synth_only.yml
@@ -22,10 +22,11 @@ steps:
 # INDIVIDUAL TILE RUNS
 # Builds in dir e.g. mflowgen/full_chip/19-tile_array/16-Tile_MemCore
 
+# Set pe max width to 112: fp limits to 110 but then lvs says 112 OK
 - label: 'PE synth 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps synthesis --debug
-  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 110
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 112
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'MemCore synth 25m'


### PR DESCRIPTION
Slowly trying to merge gf and tsmc garnet versions back into one, so we can have a single common master branch.

This first merge should be easy to approve, you can see that none of the proposed changes will affect RTL or PD build functionality in any way. (Heads up: Future merges my be more challenging.)

Before this merge, the two branches have 175 files difference between them. After this merge, that goes down to 165. It's not much, but it's a start.

```
% git diff master-dense-tsmc-amber origin/spVspV | egrep ^diff | wc -l
175

% git diff master-dense-tsmc-amber spv-merge-to-spv | egrep ^diff | wc -l
165

```

FYI the larger plan is:
- master-dense-tsmc-amber is the "official" working TSMC branch
- spVspV is the "official" working GF branch
- we hack away at the diffs until 'git diff' produces the null set
- at this point spVspV == master-dense-tsmc-amber and we can choose one to be the new master branch.
