### PR TITLE
make spVspV work with aha-flow again

### DIFF
--- a/memory_core/core_combiner_core.py
+++ b/memory_core/core_combiner_core.py
@@ -33,7 +33,7 @@ class CoreCombinerCore(LakeCoreBase):
                  input_prefix="",
                  dual_port=False,
                  rf=False,
-                 mem_width=16,
+                 mem_width=64,
                  mem_depth=512):
 
         self.pnr_tag = pnr_tag


### PR DESCRIPTION
This tiny change lets spVspV branch *finally* pass the aha-flow test again, for the first time in many weeks I think. Many thanks to Kalhan and Jack for putting me on this trail so this could finally get done. You can see the successful aha-flow run here: https://buildkite.com/stanford-aha/aha-flow/builds/7839

After we merge this change to spVspV, I will file a pull to integrate spVspV into aha-flow master branch.

The actual bug is this: looks like commit `dbd8123`, way back on Nov 8, changed the default memory width from 64 to 16, maybe as part of "dac memory experiments?" Anyway, apparently aha-flow master was never updated to use that change, because if it had I guess we would have seen the bug? Anyway: this pull should allow us to fix that.