### PR TITLE
Spv merge to spv 8

### DIFF
--- a/memory_core/core_combiner_core.py
+++ b/memory_core/core_combiner_core.py
@@ -11,6 +11,7 @@ from lake.modules.intersect import Intersect
 from lake.modules.scanner import Scanner
 from lake.top.tech_maps import GF_Tech_Map
 import kratos as kts
+import os
 
 if __name__ == "__main__":
     from memtile_util import LakeCoreBase
@@ -19,6 +20,11 @@ else:
 
 
 class CoreCombinerCore(LakeCoreBase):
+
+    if os.getenv('WHICH_SOC') == "amber":
+        mem_width_default=16
+    else:
+        mem_width_default=64
 
     def __init__(self,
                  data_width=16,  # CGRA Params
@@ -33,7 +39,7 @@ class CoreCombinerCore(LakeCoreBase):
                  input_prefix="",
                  dual_port=False,
                  rf=False,
-                 mem_width=64,
+                 mem_width=mem_width_default,
                  mem_depth=512):
 
         self.pnr_tag = pnr_tag
@@ -188,10 +194,15 @@ class CoreCombinerCore(LakeCoreBase):
                     for addr, data in enumerate(content):
                         if (not isinstance(data, int)) and len(data) == 2:
                             addr, data = data
-                        addr_shift = 0
-                        if self.fw > 1:
-                            addr_shift = kts.clog2(self.fw)
-                        addr = addr >> addr_shift
+                            
+                        if os.getenv('WHICH_SOC') == "amber":
+                            addr = addr >> 2
+                        else:
+                            addr_shift = 0
+                            if self.fw > 1:
+                                addr_shift = kts.clog2(self.fw)
+                            addr = addr >> addr_shift
+
                         feat_addr = addr // 256 + 1
                         # And also transform this based on memory depth
                         addr = (addr % 256)

--- a/memory_core/memory_core_magma.py
+++ b/memory_core/memory_core_magma.py
@@ -1,3 +1,4 @@
+import os
 import magma
 import tempfile
 import urllib.request
@@ -61,6 +62,11 @@ def lift_mem_core_ports(port, tile, tile_core):  # pragma: nocover
 
 class MemCore(LakeCoreBase):
 
+    if os.getenv('WHICH_SOC') == "amber":
+        tech_map_default=TSMC_Tech_Map(depth=512, width=32)
+    else:
+        tech_map_default=  GF_Tech_Map(depth=512, width=32)
+
     def __init__(self,
                  data_width=16,  # CGRA Params
                  mem_width=64,
@@ -86,17 +92,24 @@ class MemCore(LakeCoreBase):
                  gate_flush=True,
                  override_name=None,
                  gen_addr=True,
-                 tech_map=GF_Tech_Map(depth=512, width=32),
+                 tech_map=tech_map_default,
                  ready_valid=False):
 
         lake_name = "LakeTop"
 
-        super().__init__(config_data_width=config_data_width,
-                         config_addr_width=config_addr_width,
-                         data_width=data_width,
-                         gate_flush=gate_flush,
-                         ready_valid=ready_valid,
-                         name="MemCore")
+        if os.getenv('WHICH_SOC') == "amber":
+            super().__init__(config_data_width=config_data_width,
+                             config_addr_width=config_addr_width,
+                             data_width=data_width,
+                             gate_flush=gate_flush,
+                             name="MemCore")
+        else:
+            super().__init__(config_data_width=config_data_width,
+                             config_addr_width=config_addr_width,
+                             data_width=data_width,
+                             gate_flush=gate_flush,
+                             ready_valid=ready_valid,
+                             name="MemCore")
 
         # Capture everything to the tile object
         # self.data_width = data_width
@@ -290,8 +303,9 @@ class MemCore(LakeCoreBase):
         else:
             mode = mode_map[instr['mode']]
 
-        if type(mode) is int:
-            mode = mode_num_map[mode]
+        if os.getenv('WHICH_SOC') != "amber":
+            if type(mode) is int:
+                mode = mode_num_map[mode]
 
         if mode == MemoryMode.UNIFIED_BUFFER:
             config_runtime = self.dut.get_static_bitstream_json(top_config)

--- a/memory_core/memtile_util.py
+++ b/memory_core/memtile_util.py
@@ -1,3 +1,4 @@
+import os
 from gemstone.common.testers import BasicTester
 from canal.util import IOSide
 import magma
@@ -116,6 +117,9 @@ class LakeCoreBase(ConfigurableCore):
         # The rest of the signals to wire to the underlying representation...
         other_signals = []
 
+        if os.getenv('WHICH_SOC') == "amber": io_info_full_bus = False
+        else:                                 io_info_full_bus = io_info.full_bus
+
         # for port_name, port_size, port_width, is_ctrl, port_dir, explicit_array, full_bus in core_interface:
         for io_info in core_interface:
             if io_info.port_name in skip_names:
@@ -128,7 +132,7 @@ class LakeCoreBase(ConfigurableCore):
                 intf_type = magma.Bits[io_info.port_width]
             # Due to some tooling weirdness, I've also included a way to explicitly mark
             # a wire as a "full" (16b) bus...
-            elif io_info.full_bus:
+            elif io_info_full_bus:
                 ind_ports = 1
                 intf_type = magma.Bits[io_info.port_width]
             dir_type = magma.In
@@ -165,14 +169,14 @@ class LakeCoreBase(ConfigurableCore):
                                               io_info.expl_arr,
                                               i,
                                               io_info.port_name,
-                                              io_info.full_bus))
+                                              io_info_full_bus))
                 else:
                     other_signals.append((io_info.port_name,
                                           io_info.port_dir,
                                           io_info.expl_arr,
                                           0,
                                           io_info.port_name,
-                                          io_info.full_bus))
+                                          io_info_full_bus))
 
         assert (len(self.__outputs) > 0)
 
@@ -299,53 +303,69 @@ class LakeCoreBase(ConfigurableCore):
             if cfg_info.expl_arr:
                 if cfg_info.port_size[0] > 1:
                     for i in range(cfg_info.port_size[0]):
-                        configurations.append((f"{cfg_info.port_name}_{i}", cfg_info.port_width, cfg_info.read_only))
+                        configurations.append((f"{cfg_info.port_name}_{i}", cfg_info.port_width))
                 else:
-                    configurations.append((cfg_info.port_name, cfg_info.port_width, cfg_info.read_only))
+                    configurations.append((cfg_info.port_name, cfg_info.port_width))
             else:
-                configurations.append((cfg_info.port_name, cfg_info.port_width, cfg_info.read_only))
+                configurations.append((cfg_info.port_name, cfg_info.port_width))
+
+            if os.getenv('WHICH_SOC') != "amber":
+                configurations[-1] = configurations[-1] + (cfg_info.read_only,)
 
         # Do all the stuff for the main config
         main_feature = self.__features[0]
-        for config_reg_name, width, read_only_ in configurations:
-            if width == 1:
-                main_feature.add_config(config_reg_name, width, pass_through=read_only_)
-                if read_only_:
-                    self.wire(main_feature.registers[config_reg_name].ports.I[0],
-                              self.underlying.ports[config_reg_name][0])
-                else:
+
+        if os.getenv('WHICH_SOC') == "amber":
+            for config_reg_name, width in configurations:
+                main_feature.add_config(config_reg_name, width)
+                if(width == 1):
                     self.wire(main_feature.registers[config_reg_name].ports.O[0],
                               self.underlying.ports[config_reg_name][0])
-            elif width > 32:
-                # Need to chop it down to size
-                num_regs_remainder = width % 32 != 0
-                num_regs = (width // 32)
-                if num_regs_remainder:
-                    num_regs += 1
-                total_width = width
-                running_base = 0
-                for idx_ in range(num_regs):
-                    if total_width > 32:
-                        use_width = 32
-                    else:
-                        use_width = total_width
-                    main_feature.add_config(f"{config_reg_name}_{idx_}", use_width, pass_through=read_only_)
-                    if read_only_:
-                        self.wire(main_feature.registers[f"{config_reg_name}_{idx_}"].ports.I,
-                                  self.underlying.ports[config_reg_name][running_base:running_base + use_width])
-                    else:
-                        self.wire(main_feature.registers[f"{config_reg_name}_{idx_}"].ports.O,
-                                  self.underlying.ports[config_reg_name][running_base:running_base + use_width])
-                    total_width -= use_width
-                    running_base += use_width
-            else:
-                main_feature.add_config(config_reg_name, width, pass_through=read_only_)
-                if read_only_:
-                    self.wire(main_feature.registers[config_reg_name].ports.I,
-                              self.underlying.ports[config_reg_name])
                 else:
                     self.wire(main_feature.registers[config_reg_name].ports.O,
                               self.underlying.ports[config_reg_name])
+        else:
+            for config_reg_name, width, read_only_ in configurations:
+                if width == 1:
+                    main_feature.add_config(config_reg_name, width, pass_through=read_only_)
+                    if read_only_:
+                        self.wire(main_feature.registers[config_reg_name].ports.I[0],
+                                  self.underlying.ports[config_reg_name][0])
+                    else:
+                        self.wire(main_feature.registers[config_reg_name].ports.O[0],
+                                  self.underlying.ports[config_reg_name][0])
+                elif width > 32:
+                    # Need to chop it down to size
+                    num_regs_remainder = width % 32 != 0
+                    num_regs = (width // 32)
+                    if num_regs_remainder:
+                        num_regs += 1
+                    total_width = width
+                    running_base = 0
+                    for idx_ in range(num_regs):
+                        if total_width > 32:
+                            use_width = 32
+                        else:
+                            use_width = total_width
+                        main_feature.add_config(f"{config_reg_name}_{idx_}", use_width, pass_through=read_only_)
+                        if read_only_:
+                            self.wire(main_feature.registers[f"{config_reg_name}_{idx_}"].ports.I,
+                                      self.underlying.ports[config_reg_name][running_base:running_base + use_width])
+                        else:
+                            self.wire(main_feature.registers[f"{config_reg_name}_{idx_}"].ports.O,
+                                      self.underlying.ports[config_reg_name][running_base:running_base + use_width])
+                        total_width -= use_width
+                        running_base += use_width
+                else:
+                    main_feature.add_config(config_reg_name, width, pass_through=read_only_)
+                    if read_only_:
+                        self.wire(main_feature.registers[config_reg_name].ports.I,
+                                  self.underlying.ports[config_reg_name])
+                    else:
+                        self.wire(main_feature.registers[config_reg_name].ports.O,
+                                  self.underlying.ports[config_reg_name])
+
+
 
         # SRAM
         # These should also account for num features

--- a/memory_core/memtile_util.py
+++ b/memory_core/memtile_util.py
@@ -117,11 +117,14 @@ class LakeCoreBase(ConfigurableCore):
         # The rest of the signals to wire to the underlying representation...
         other_signals = []
 
-        if os.getenv('WHICH_SOC') == "amber": io_info_full_bus = False
-        else:                                 io_info_full_bus = io_info.full_bus
-
         # for port_name, port_size, port_width, is_ctrl, port_dir, explicit_array, full_bus in core_interface:
         for io_info in core_interface:
+
+            if os.getenv('WHICH_SOC') == "amber":
+                io_info_full_bus = False
+            else:
+                io_info_full_bus = io_info.full_bus
+
             if io_info.port_name in skip_names:
                 continue
             ind_ports = io_info.port_width

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
+
+# default is "not amber"
+[ "$WHICH_SOC" ] || WHICH_SOC=default
+
 mflowgen run --design $GARNET_HOME/mflowgen/tile_array/
-make synopsys-ptpx-genlibdb -j 2
+
+if [ "$WHICH_SOC" == "amber" ]; then
+    make synopsys-dc-lib2db -j 2
+else
+    make synopsys-ptpx-genlibdb -j 2
+fi
+
 if command -v calibre &> /dev/null
 then
     make mentor-calibre-lvs
@@ -8,8 +18,15 @@ else
     make cadence-pegasus-lvs
 fi
 mkdir -p outputs
-cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/tile_array_tt.db
-cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/tile_array_tt.lib
+
+if [ "$WHICH_SOC" == "amber" ]; then
+    cp -L *cadence-genus-genlib/outputs/design.lib outputs/tile_array_tt.lib
+    cp -L *synopsys-dc-lib2db/outputs/design.db outputs/tile_array_tt.db
+else
+    cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/tile_array_tt.db
+    cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/tile_array_tt.lib
+fi
+
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/tile_array.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/tile_array.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/tile_array.sdf


### PR DESCRIPTION
This pull is 8th in a series that so far includes https://github.com/StanfordAHA/garnet/pull/934 , https://github.com/StanfordAHA/garnet/pull/935 , https://github.com/StanfordAHA/garnet/pull/937 , https://github.com/StanfordAHA/garnet/pull/938 , https://github.com/StanfordAHA/garnet/pull/939 , https://github.com/StanfordAHA/garnet/pull/941 , https://github.com/StanfordAHA/garnet/pull/943 , slowly merging gf/onyx and tsmc/amber versions back into one, for a single common master branch.

After the most recent pull https://github.com/StanfordAHA/garnet/pull/943 , the two branches had 90 files difference between them. This pull cuts that down to 84:
<!-- -->
<!-- pause to make sure you merged $smd => master-dense-tsmc-amber -->
<!-- and/or use official_dense_branch=spv-merge-to-dense           -->
<!-- -->

```
official_dense_branch=origin/master-dense-tsmc-amber
official_sparse_branch=origin/spVspV
new_sparse_branch=spv-merge-to-spv-8

git diff $official_dense_branch $new_sparse_branch | egrep ^diff | wc -l
    84
```
Below is a summary of the changes included in this pull, along with an explanation of why each change should have no adverse impact on existing spVspV functionality. Six files were affected, but only five appear in this pull, as explained below.

<!-- -->
<!-- git diff $sms7 $sms8 -->
<!-- -->

1) Five files were unified simply by modifying them with `if AMBER then {} else {}` type of code changes:
```
    core_combiner_core.py
    memory_core_magma.py
    memtile_util.py
    pond_core.py
    mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
    peak_core/peak_core.py
```

2) The sixth and final "merged" file `pond_core.py` was changed on the amber branch to exactly match the version in the `spVspV` branch.

3) These changes have been vetted and have passed both amber full-chip build and onyx aha-flow CI tests.
* https://buildkite.com/tapeout-aha/fullchip/builds/488
* https://buildkite.com/stanford-aha/aha-flow/builds/7875

