### PR TITLE
allow larger PE tile for GF CI builds

### DIFF
--- a/.buildkite/pipeline_checkin_gf.yml
+++ b/.buildkite/pipeline_checkin_gf.yml
@@ -36,7 +36,7 @@ steps:
 - label: 'ptile init 20m'
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
-  - .buildkite/pipelines/check_pe_area.sh
+  - .buildkite/pipelines/check_pe_area.sh --max 10200
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'mtile init 25m'

--- a/.buildkite/pipelines/check_pe_area.sh
+++ b/.buildkite/pipelines/check_pe_area.sh
@@ -1,13 +1,20 @@
-#!/usr/bin/bash
+#!/bin/bash
+
+# Can do e.g. "check_pe_area.sh --max 10400 215" to check dir
+# /build/gold.215 for max PE size 10400 (default is 8500)
+
+MAX=8500
+if [ "$1" == "--max" ]; then shift; MAX=$1; shift; fi
 
 # Can do e.g. "check_pe_area.sh 215" to check dir /build/gold.215
 # else defaults to curdir
+# (Or is this too silly)
 if [ "$1" != "" ]; then cd /build/gold.$1; fi
 
 
 cat <<EOF
 
---- FINAL CHECK: Tile_PE total area must be < 7500 u^2
+--- FINAL CHECK: Tile_PE total area must be < $MAX u^2
 
 EOF
 
@@ -19,7 +26,7 @@ echo $pe_dir
 
 # "echo" to unglob why not
 resdir=`echo $pe_dir/*synthesis/results_syn`
-egrep ^Tile_PE $resdir/final_area.rpt | awk -v max_area=8500 '
+egrep ^Tile_PE $resdir/final_area.rpt | awk -v max_area=$MAX '
 { printf("Total area: %d\n", $NF);
   if ($NF > max_area) {
     print ""


### PR DESCRIPTION
This should fix the `checkin-gf` CI test. We did two things: 1) turn on two buildkite agents on the GF machine `aha-gf` and 2) allow final PE tile area to be much larger without generating an error.

The full test takes about an hour, assuming two buildkite agents available on the GF machine. As of now, the full test is triggered on every branch push. The test takes about the same amount of time as a couple of the tests that alreadyour existing `aha-flow test`, so it's not really slowing anything down versus the existing test setup.

Alternatively, we could run the test only on pull requests etc., your input on this is welcome.

After this pull, we will have five tests that run (in parallel of course) on each pull:

* `build` (garnet pytests), 4 min, e.g. https://github.com/StanfordAHA/garnet/actions/runs/4997401637/jobs/8951727137

* `StanfordAHA Flow` (aha "pr" regressions), 50 min, e.g. https://buildkite.com/stanford-aha/aha-flow/builds/8107

* `buildkite/garnet` (aha "pr" regressions), 50 min, e.g. https://buildkite.com/stanford-aha/garnet/builds/3792

* `buildkite/mflowgen` (TSMC floorplanning), 20 min, e.g. https://buildkite.com/tapeout-aha/mflowgen/builds/6893

* `buildkite/checkin-gf` (GF floorplanning), 55 min, e.g. https://buildkite.com/tapeout-aha/checkin-gf/builds/1905


Not sure what the difference is between `StanfordAHA Flow` and `buildkite/garnet` except that `buildkite/garnet` launches buildkite directly, while `StanfordAHA Flow` runs indirectly via something like `github app => github action => buildkite`
