### PR TITLE
Mflowgen fix

### DIFF
--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -458,10 +458,10 @@ else
 
     pushd $mflowgen
 
-      # SBKA=/sim/buildkite-agent
-      # On tsmc machines, adks can be found on SBKA/mflowgen.master AND SBKA/adks
-      # On gf machine, adks are only in SBKA/mflowgen.master
-      # FIXME Consult with Alex or somebody to find out where gf12 adks really live
+      # Where $bk=/sim/buildkite-agent:
+      # On tsmc machines, adks can be found on $bk/mflowgen.master AND $bk/adks
+      # On gf machine, adks are only in $bk/mflowgen.master
+      # FIXME/TODO Consult with Alex or somebody to find out where gf12 adks are really supposed to live
 
       function is_gf { test -e /sim/buildkite-agent/mflowgen.master/adks/gf12-adk; }
       if is_gf; then


### PR DESCRIPTION
ADK setup for CI was outdated/incorrect. Previously, it assumed that, if the adk was missing, it could be found at a backup location `/sim/buildkite-agent/adks`. This works on the TSMC machine, but not the GF machine. I cannot access the GF machine, because of licensing, but I know at least one copy of the adks can be found at  `/sim/buildkite-agent/mflowgen.master/adks`, so I changed the script to use that for the GF adk backup.

If anyone knows of a better place to find `gf12-adk` on the GF machine, let me know!
