### PR TITLE
make script clean up after itself

### DIFF
--- a/bin/check_docker.sh
+++ b/bin/check_docker.sh
@@ -51,3 +51,4 @@ else
     echo "Docker check looks okay."
 fi
 unset FAIL
+/bin/rm $tmpfile


### PR DESCRIPTION
One of my scripts does not clean up after itself, and now the buildkite client has 171 useless zero-length files `/tmp/tmp.deleteme.*`. This simple change should prevent that from happening in the future.