### PR TITLE
Genlib purge

### DIFF
--- a/.buildkite/pipeline_fullchip.yml
+++ b/.buildkite/pipeline_fullchip.yml
@@ -45,6 +45,24 @@ steps:
 - wait: ~
 
 # Note: "echo exit 13" prevents hang at genus/innovus prompt, allows clean fail
+
+- label: 'GLC'
+  commands:
+  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 74G;
+     echo "--- MAKE GLOBAL_CONTROLLER"; set -o pipefail;
+     echo exit 13 | make global_controller |& tee make-GLC.log;
+     egrep ^FAILED make-GLC.log && exit 13 || echo PASSED'
+- wait: ~
+
+# Note: "echo exit 13" prevents hang at genus/innovus prompt, allows clean fail
+- label: 'glb_top'
+  commands:
+  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 84G;
+     echo "--- MAKE GLB_TOP"; set -o pipefail;
+     echo exit 13 | make glb_top |& tee make-glb_top.log;
+     egrep ^FAILED make-glb_top.log && exit 13 || echo PASSED'
+- wait: ~
+
 - label: 'tile_array'
   commands:
   - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 100G;
@@ -72,23 +90,6 @@ steps:
     - $LVS_CHECK $GOLD
     - ($LVS_CHECK $GOLD | grep INCORRECT > /dev/null) && exit 13 || exit 0
 - wait: { continue_on_failure: true }
-
-# Note: "echo exit 13" prevents hang at genus/innovus prompt, allows clean fail
-- label: 'glb_top'
-  commands:
-  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 84G;
-     echo "--- MAKE GLB_TOP"; set -o pipefail;
-     echo exit 13 | make glb_top |& tee make-glb_top.log;
-     egrep ^FAILED make-glb_top.log && exit 13 || echo PASSED'
-- wait: ~
-
-- label: 'GLC'
-  commands:
-  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 74G;
-     echo "--- MAKE GLOBAL_CONTROLLER"; set -o pipefail;
-     echo exit 13 | make global_controller |& tee make-GLC.log;
-     egrep ^FAILED make-GLC.log && exit 13 || echo PASSED'
-- wait: ~
 
 - label: 'dragon'
   commands:

--- a/.buildkite/pipeline_fullchip.yml
+++ b/.buildkite/pipeline_fullchip.yml
@@ -45,24 +45,6 @@ steps:
 - wait: ~
 
 # Note: "echo exit 13" prevents hang at genus/innovus prompt, allows clean fail
-
-- label: 'GLC'
-  commands:
-  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 74G;
-     echo "--- MAKE GLOBAL_CONTROLLER"; set -o pipefail;
-     echo exit 13 | make global_controller |& tee make-GLC.log;
-     egrep ^FAILED make-GLC.log && exit 13 || echo PASSED'
-- wait: ~
-
-# Note: "echo exit 13" prevents hang at genus/innovus prompt, allows clean fail
-- label: 'glb_top'
-  commands:
-  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 84G;
-     echo "--- MAKE GLB_TOP"; set -o pipefail;
-     echo exit 13 | make glb_top |& tee make-glb_top.log;
-     egrep ^FAILED make-glb_top.log && exit 13 || echo PASSED'
-- wait: ~
-
 - label: 'tile_array'
   commands:
   - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 100G;
@@ -90,6 +72,23 @@ steps:
     - $LVS_CHECK $GOLD
     - ($LVS_CHECK $GOLD | grep INCORRECT > /dev/null) && exit 13 || exit 0
 - wait: { continue_on_failure: true }
+
+# Note: "echo exit 13" prevents hang at genus/innovus prompt, allows clean fail
+- label: 'glb_top'
+  commands:
+  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 84G;
+     echo "--- MAKE GLB_TOP"; set -o pipefail;
+     echo exit 13 | make glb_top |& tee make-glb_top.log;
+     egrep ^FAILED make-glb_top.log && exit 13 || echo PASSED'
+- wait: ~
+
+- label: 'GLC'
+  commands:
+  - 'source mflowgen/bin/setup-buildkite.sh --dir $$GOLD --need_space 74G;
+     echo "--- MAKE GLOBAL_CONTROLLER"; set -o pipefail;
+     echo exit 13 | make global_controller |& tee make-GLC.log;
+     egrep ^FAILED make-GLC.log && exit 13 || echo PASSED'
+- wait: ~
 
 - label: 'dragon'
   commands:

--- a/.buildkite/setup.sh
+++ b/.buildkite/setup.sh
@@ -6,5 +6,5 @@ module load lc
 module load syn/latest
 module load genus
 module load innovus/19.10.000
-module load prime
+module load prime/T-2022.03
 unset OA_HOME

--- a/.buildkite/setup.sh
+++ b/.buildkite/setup.sh
@@ -6,4 +6,5 @@ module load lc
 module load syn/latest
 module load genus
 module load innovus/19.10.000
+module load prime
 unset OA_HOME

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -148,10 +148,7 @@ def construct():
   postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
   signoff        = Step( 'cadence-innovus-signoff',        default=True )
   pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
-  if True:
-      genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
-  else:
-      genlibdb       = Step( 'cadence-genus-genlib',           default=True )
+  genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
 
   if which("calibre") is not None:
       drc            = Step( 'mentor-calibre-drc',             default=True )
@@ -170,13 +167,8 @@ def construct():
 
   synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
 
-  if False:
-    #pt_signoff.extend_inputs( ['sram_tt.db'] )
-    genlibdb.extend_inputs( ['sram_tt.lib'] )
-
-  else:
-    pt_signoff.extend_inputs( ['sram_tt.db'] )
-    genlibdb.extend_inputs( ['sram_tt.lib', 'sram_tt.db'] )
+  pt_signoff.extend_inputs( ['sram_tt.db'] )
+  genlibdb.extend_inputs( ['sram_tt.lib', 'sram_tt.db'] )
 
   # These steps need timing and lef info for srams
 
@@ -420,9 +412,7 @@ def construct():
       g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
       g.connect_by_name( drc_pm,        debugcalibre   )
 
-  # Need this because gf12 uses innovus for lib generation
-  if True:
-      g.connect_by_name( iflow,    genlibdb       )
+  g.connect_by_name( iflow,    genlibdb       )
 
   #-----------------------------------------------------------------------
   # Parameterize
@@ -470,28 +460,20 @@ def construct():
   pin_idx = order.index( 'pin-assignments.tcl' ) # find pin-assignments.tcl
   order.insert( pin_idx + 1, 'edge-blockages.tcl' ) # add here
   init.update_params( { 'order': order } )
-
+  
   # Adding new input for genlibdb node to run
 
   if True:
-    # gf12 uses synopsys-ptpx for genlib (default is cadence-genus)
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
     order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
     genlibdb.update_params( { 'order': order } )
 
-    # genlibdb -- Remove 'report-interface-timing.tcl' beacuse it takes
+    # genlibdb -- Remove 'write-interface-timing.tcl' beacuse it takes
     # very long and is not necessary
     order = genlibdb.get_param('order')
     order.remove( 'write-interface-timing.tcl' )
     genlibdb.update_params( { 'order': order } )
-
-  else:
-    order = genlibdb.get_param('order') # get the default script run order
-    read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
-    order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
-    genlibdb.update_params( { 'order': order } )
-
 
   # Pwr aware steps:
   if pwr_aware:

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -420,9 +420,8 @@ def construct():
       g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
       g.connect_by_name( drc_pm,        debugcalibre   )
 
-  # Need this because gf12 uses innovus for lib generation
-  if adk_name == 'gf12-adk':
-      g.connect_by_name( iflow,    genlibdb       )
+  # Need this because new default is to use innovus for lib generation
+  g.connect_by_name( iflow,    genlibdb       )
 
   #-----------------------------------------------------------------------
   # Parameterize

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -463,6 +463,7 @@ def construct():
   
   # Adding new input for genlibdb node to run
 
+  # No longer conditional---amber and onyx now use same genlib mechanism
   if True:
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -473,7 +473,9 @@ def construct():
 
   # Adding new input for genlibdb node to run
 
-  if adk_name == 'gf12-adk':
+  # Using innovus-genlib for everything now, not just gf12
+  # if adk_name == 'gf12-adk':
+  if True:
     # gf12 uses synopsys-ptpx for genlib (default is cadence-genus)
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
@@ -486,11 +488,11 @@ def construct():
     order.remove( 'write-interface-timing.tcl' )
     genlibdb.update_params( { 'order': order } )
 
-  else:
-    order = genlibdb.get_param('order') # get the default script run order
-    read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
-    order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
-    genlibdb.update_params( { 'order': order } )
+#   else:
+#     order = genlibdb.get_param('order') # get the default script run order
+#     read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
+#     order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
+#     genlibdb.update_params( { 'order': order } )
 
 
   # Pwr aware steps:

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -148,10 +148,10 @@ def construct():
   postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
   signoff        = Step( 'cadence-innovus-signoff',        default=True )
   pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
-  if adk_name == 'gf12-adk':
+  if True:
       genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
   else:
-      genlibdb       = Step( this_dir + '/../common/cadence-innovus-genlib' )
+      genlibdb       = Step( 'cadence-genus-genlib',           default=True )
 
   if which("calibre") is not None:
       drc            = Step( 'mentor-calibre-drc',             default=True )
@@ -170,11 +170,11 @@ def construct():
 
   synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
 
-  if adk_name == 'tsmc16':
+  if False:
     #pt_signoff.extend_inputs( ['sram_tt.db'] )
     genlibdb.extend_inputs( ['sram_tt.lib'] )
 
-  elif adk_name == 'gf12-adk':
+  else:
     pt_signoff.extend_inputs( ['sram_tt.db'] )
     genlibdb.extend_inputs( ['sram_tt.lib', 'sram_tt.db'] )
 
@@ -420,8 +420,9 @@ def construct():
       g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
       g.connect_by_name( drc_pm,        debugcalibre   )
 
-  # Need this because new default is to use innovus for lib generation
-  g.connect_by_name( iflow,    genlibdb       )
+  # Need this because gf12 uses innovus for lib generation
+  if True:
+      g.connect_by_name( iflow,    genlibdb       )
 
   #-----------------------------------------------------------------------
   # Parameterize
@@ -472,8 +473,8 @@ def construct():
 
   # Adding new input for genlibdb node to run
 
-  if adk_name == 'gf12-adk':
-    # gf12 uses synopsys-ptpx for genlib (default is cadence-innovus)
+  if True:
+    # gf12 uses synopsys-ptpx for genlib (default is cadence-genus)
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
     order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
@@ -485,12 +486,11 @@ def construct():
     order.remove( 'write-interface-timing.tcl' )
     genlibdb.update_params( { 'order': order } )
 
-# tsmc now using innovus-genlib, which apparently does not have read_design.tcl?
-#   else:
-#     order = genlibdb.get_param('order') # get the default script run order
-#     read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
-#     order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
-#     genlibdb.update_params( { 'order': order } )
+  else:
+    order = genlibdb.get_param('order') # get the default script run order
+    read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
+    order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
+    genlibdb.update_params( { 'order': order } )
 
 
   # Pwr aware steps:

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -463,18 +463,16 @@ def construct():
   
   # Adding new input for genlibdb node to run
 
-  # No longer conditional---amber and onyx now use same genlib mechanism
-  if True:
-    order = genlibdb.get_param('order') # get the default script run order
-    extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
-    order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
-    genlibdb.update_params( { 'order': order } )
+  order = genlibdb.get_param('order') # get the default script run order
+  extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
+  order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
+  genlibdb.update_params( { 'order': order } )
 
-    # genlibdb -- Remove 'write-interface-timing.tcl' beacuse it takes
-    # very long and is not necessary
-    order = genlibdb.get_param('order')
-    order.remove( 'write-interface-timing.tcl' )
-    genlibdb.update_params( { 'order': order } )
+  # genlibdb -- Remove 'write-interface-timing.tcl' beacuse it takes
+  # very long and is not necessary
+  order = genlibdb.get_param('order')
+  order.remove( 'write-interface-timing.tcl' )
+  genlibdb.update_params( { 'order': order } )
 
   # Pwr aware steps:
   if pwr_aware:

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -151,7 +151,7 @@ def construct():
   if adk_name == 'gf12-adk':
       genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
   else:
-      genlibdb       = Step( 'cadence-genus-genlib',           default=True )
+      genlibdb       = Step( 'cadence-innovus-genlib',           default=True )
 
   if which("calibre") is not None:
       drc            = Step( 'mentor-calibre-drc',             default=True )

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -474,9 +474,8 @@ def construct():
   # Adding new input for genlibdb node to run
 
   # Using innovus-genlib for everything now, not just gf12
-  # if adk_name == 'gf12-adk':
-  if True:
-    # gf12 uses synopsys-ptpx for genlib (default is cadence-genus)
+  if adk_name == 'gf12-adk':
+    # gf12 uses synopsys-ptpx for genlib (default is cadence-innovus)
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
     order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
@@ -488,6 +487,7 @@ def construct():
     order.remove( 'write-interface-timing.tcl' )
     genlibdb.update_params( { 'order': order } )
 
+# tsmc now using innovus-genlib, which apparently does not have read_design.tcl?
 #   else:
 #     order = genlibdb.get_param('order') # get the default script run order
 #     read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -151,7 +151,7 @@ def construct():
   if adk_name == 'gf12-adk':
       genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
   else:
-      genlibdb       = Step( 'cadence-innovus-genlib',           default=True )
+      genlibdb       = Step( this_dir + '/../common/cadence-innovus-genlib' )
 
   if which("calibre") is not None:
       drc            = Step( 'mentor-calibre-drc',             default=True )
@@ -472,7 +472,6 @@ def construct():
 
   # Adding new input for genlibdb node to run
 
-  # Using innovus-genlib for everything now, not just gf12
   if adk_name == 'gf12-adk':
     # gf12 uses synopsys-ptpx for genlib (default is cadence-innovus)
     order = genlibdb.get_param('order') # get the default script run order

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -155,10 +155,10 @@ def construct():
   postroute    = Step( 'cadence-innovus-postroute',     default=True )
   signoff      = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
-  if adk_name == 'gf12-adk':
+  if True:
       genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
   else:
-      genlibdb       = Step( this_dir + '/../common/cadence-innovus-genlib' )
+      genlibdb       = Step( 'cadence-genus-genlib',           default=True )
 
   if which("calibre") is not None:
       drc          = Step( 'mentor-calibre-drc',            default=True )
@@ -408,8 +408,9 @@ def construct():
       g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
       g.connect_by_name( drc_pm,        debugcalibre   )
 
-# Need this because new default is to use innovus for lib generation
-  g.connect_by_name( iflow,    genlibdb       )
+  # Need this because gf12 uses innovus for lib generation
+  if True:
+      g.connect_by_name( iflow,    genlibdb       )
 
   #-----------------------------------------------------------------------
   # Parameterize
@@ -458,8 +459,8 @@ def construct():
 
   # Adding new input for genlibdb node to run
 
-  if adk_name == 'gf12-adk':
-    # gf12 uses synopsys-ptpx for genlib (default is cadence-innovus)
+  if True:
+    # gf12 uses synopsys-ptpx for genlib (default is cadence-genus)
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
     order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
@@ -471,12 +472,11 @@ def construct():
     order.remove( 'write-interface-timing.tcl' )
     genlibdb.update_params( { 'order': order } )
 
-# tsmc now using innovus-genlib, which apparently does not have read_design.tcl?
-#   else:
-#     order = genlibdb.get_param('order') # get the default script run order
-#     read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
-#     order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
-#     genlibdb.update_params( { 'order': order } )
+  else:
+    order = genlibdb.get_param('order') # get the default script run order
+    read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
+    order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
+    genlibdb.update_params( { 'order': order } )
 
 
   # Pwr aware steps:

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -455,17 +455,16 @@ def construct():
   # Adding new input for genlibdb node to run
 
   # No longer conditional---amber and onyx now use same genlib mechanism
-  if True:
-    order = genlibdb.get_param('order') # get the default script run order
-    extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
-    order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
-    genlibdb.update_params( { 'order': order } )
+  order = genlibdb.get_param('order') # get the default script run order
+  extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
+  order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
+  genlibdb.update_params( { 'order': order } )
 
-    # genlibdb -- Remove 'report-interface-timing.tcl' beacuse it takes
-    # very long and is not necessary
-    order = genlibdb.get_param('order')
-    order.remove( 'write-interface-timing.tcl' )
-    genlibdb.update_params( { 'order': order } )
+  # genlibdb -- Remove 'report-interface-timing.tcl' beacuse it takes
+  # very long and is not necessary
+  order = genlibdb.get_param('order')
+  order.remove( 'write-interface-timing.tcl' )
+  genlibdb.update_params( { 'order': order } )
 
   # Pwr aware steps:
   if pwr_aware:

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -459,10 +459,8 @@ def construct():
 
   # Adding new input for genlibdb node to run
 
-  # Using innovus-genlib for everything now, not just gf12
-  # if adk_name == 'gf12-adk':
-  if True:
-    # gf12 uses synopsys-ptpx for genlib (default is cadence-genus)
+  if adk_name == 'gf12-adk':
+    # gf12 uses synopsys-ptpx for genlib (default is cadence-innovus)
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
     order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
@@ -474,6 +472,7 @@ def construct():
     order.remove( 'write-interface-timing.tcl' )
     genlibdb.update_params( { 'order': order } )
 
+# tsmc now using innovus-genlib, which apparently does not have read_design.tcl?
 #   else:
 #     order = genlibdb.get_param('order') # get the default script run order
 #     read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -158,7 +158,7 @@ def construct():
   if adk_name == 'gf12-adk':
       genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
   else:
-      genlibdb       = Step( 'cadence-genus-genlib',           default=True )
+      genlibdb       = Step( 'cadence-innovus-genlib',           default=True )
 
   if which("calibre") is not None:
       drc          = Step( 'mentor-calibre-drc',            default=True )

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -155,10 +155,7 @@ def construct():
   postroute    = Step( 'cadence-innovus-postroute',     default=True )
   signoff      = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
-  if True:
-      genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
-  else:
-      genlibdb       = Step( 'cadence-genus-genlib',           default=True )
+  genlibdb     = Step( 'synopsys-ptpx-genlibdb',        default=True )
 
   if which("calibre") is not None:
       drc          = Step( 'mentor-calibre-drc',            default=True )
@@ -408,9 +405,7 @@ def construct():
       g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
       g.connect_by_name( drc_pm,        debugcalibre   )
 
-  # Need this because gf12 uses innovus for lib generation
-  if True:
-      g.connect_by_name( iflow,    genlibdb       )
+  g.connect_by_name( iflow,    genlibdb       )
 
   #-----------------------------------------------------------------------
   # Parameterize
@@ -459,8 +454,7 @@ def construct():
 
   # Adding new input for genlibdb node to run
 
-  if True:
-    # gf12 uses synopsys-ptpx for genlib (default is cadence-genus)
+  if True:   # Now true for both TSMC and GF
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
     order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
@@ -471,13 +465,6 @@ def construct():
     order = genlibdb.get_param('order')
     order.remove( 'write-interface-timing.tcl' )
     genlibdb.update_params( { 'order': order } )
-
-  else:
-    order = genlibdb.get_param('order') # get the default script run order
-    read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
-    order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
-    genlibdb.update_params( { 'order': order } )
-
 
   # Pwr aware steps:
   if pwr_aware:

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -459,7 +459,9 @@ def construct():
 
   # Adding new input for genlibdb node to run
 
-  if adk_name == 'gf12-adk':
+  # Using innovus-genlib for everything now, not just gf12
+  # if adk_name == 'gf12-adk':
+  if True:
     # gf12 uses synopsys-ptpx for genlib (default is cadence-genus)
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
@@ -472,11 +474,11 @@ def construct():
     order.remove( 'write-interface-timing.tcl' )
     genlibdb.update_params( { 'order': order } )
 
-  else:
-    order = genlibdb.get_param('order') # get the default script run order
-    read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
-    order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
-    genlibdb.update_params( { 'order': order } )
+#   else:
+#     order = genlibdb.get_param('order') # get the default script run order
+#     read_idx = order.index( 'read_design.tcl' ) # find read_design.tcl
+#     order.insert( read_idx + 1, 'genlibdb-constraints.tcl' ) # add here
+#     genlibdb.update_params( { 'order': order } )
 
 
   # Pwr aware steps:

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -158,7 +158,7 @@ def construct():
   if adk_name == 'gf12-adk':
       genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
   else:
-      genlibdb       = Step( 'cadence-innovus-genlib',           default=True )
+      genlibdb       = Step( this_dir + '/../common/cadence-innovus-genlib' )
 
   if which("calibre") is not None:
       drc          = Step( 'mentor-calibre-drc',            default=True )

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -454,7 +454,8 @@ def construct():
 
   # Adding new input for genlibdb node to run
 
-  if True:   # Now true for both TSMC and GF
+  # No longer conditional---amber and onyx now use same genlib mechanism
+  if True:
     order = genlibdb.get_param('order') # get the default script run order
     extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
     order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -408,9 +408,8 @@ def construct():
       g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
       g.connect_by_name( drc_pm,        debugcalibre   )
 
-  # Need this because gf12 uses innovus for lib generation
-  if adk_name == 'gf12-adk':
-      g.connect_by_name( iflow,    genlibdb       )
+# Need this because new default is to use innovus for lib generation
+  g.connect_by_name( iflow,    genlibdb       )
 
   #-----------------------------------------------------------------------
   # Parameterize

--- a/mflowgen/common/cadence-innovus-genlib/scripts/generate-lib.tcl
+++ b/mflowgen/common/cadence-innovus-genlib/scripts/generate-lib.tcl
@@ -1,2 +1,2 @@
-do_extract_model design.lib -view analysis_default
+do_extract_model design.lib -view $vars(default_setup_view)
 

--- a/mflowgen/full_chip/glb_top/get_glb_top_outputs.sh
+++ b/mflowgen/full_chip/glb_top/get_glb_top_outputs.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail   # Fail when/if any individual command in the script fails
+
 mflowgen run --design $GARNET_HOME/mflowgen/glb_top/
 make synopsys-dc-lib2db
 if command -v calibre &> /dev/null

--- a/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
+++ b/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
@@ -12,7 +12,10 @@ fi
 
 mkdir -p outputs
 
-if [ -f *cadence-genus-genlib/outputs/design.lib ]; then 
+if [ -f *synopsys-ptpx-genlibdb/outputs/design.lib ]; then 
+  cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/global_controller_tt.lib
+
+elif [ -f *cadence-genus-genlib/outputs/design.lib ]; then 
   cp -L *cadence-genus-genlib/outputs/design.lib outputs/global_controller_tt.lib
 
 elif [ -f *cadence-innovus-genlib/outputs/design.lib ]; then

--- a/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
+++ b/mflowgen/full_chip/global_controller/get_global_controller_outputs.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail   # Fail when/if any individual command in the script fails
+
 mflowgen run --design $GARNET_HOME/mflowgen/global_controller/
 make synopsys-dc-lib2db
 if command -v calibre &> /dev/null

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -20,7 +20,11 @@ fi
 mkdir -p outputs
 
 if [ "$WHICH_SOC" == "amber" ]; then
-    cp -L *cadence-genus-genlib/outputs/design.lib outputs/tile_array_tt.lib
+    if [ -f *cadence-genus-genlib/outputs/design.lib ]; then 
+      cp -L *cadence-genus-genlib/outputs/design.lib outputs/tile_array_tt.lib
+    elif [ -f *cadence-innovus-genlib/outputs/design.lib ]; then
+      cp -L *cadence-innovus-genlib/outputs/design.lib outputs/tile_array_tt.lib
+    fi
     cp -L *synopsys-dc-lib2db/outputs/design.db outputs/tile_array_tt.db
 else
     cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/tile_array_tt.db
@@ -36,4 +40,5 @@ cp -L *Tile_MemCore/outputs/sram.spi outputs/tile_array.sram.spi
 cp -L *Tile_MemCore/outputs/sram.v outputs/tile_array.sram.v
 cp -L *Tile_MemCore/outputs/sram_pwr.v outputs/tile_array.sram.pwr.v
 cp -L *Tile_MemCore/outputs/sram_tt.db outputs/tile_array.sram_tt.db
+
 

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -20,13 +20,8 @@ else
 fi
 mkdir -p outputs
 
-if [ ]; then
-    cp -L *cadence-genus-genlib/outputs/design.lib outputs/tile_array_tt.lib
-    cp -L *synopsys-dc-lib2db/outputs/design.db outputs/tile_array_tt.db
-else
     cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/tile_array_tt.db
     cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/tile_array_tt.lib
-fi
 
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/tile_array.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/tile_array.vcs.v

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail   # Fail when/if any individual command in the script fails
 
 # default is "not amber"
 [ "$WHICH_SOC" ] || WHICH_SOC=default
@@ -36,5 +37,4 @@ cp -L *Tile_MemCore/outputs/sram.spi outputs/tile_array.sram.spi
 cp -L *Tile_MemCore/outputs/sram.v outputs/tile_array.sram.v
 cp -L *Tile_MemCore/outputs/sram_pwr.v outputs/tile_array.sram.pwr.v
 cp -L *Tile_MemCore/outputs/sram_tt.db outputs/tile_array.sram_tt.db
-
 

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -20,11 +20,7 @@ fi
 mkdir -p outputs
 
 if [ "$WHICH_SOC" == "amber" ]; then
-    if [ -f *cadence-genus-genlib/outputs/design.lib ]; then 
-      cp -L *cadence-genus-genlib/outputs/design.lib outputs/tile_array_tt.lib
-    elif [ -f *cadence-innovus-genlib/outputs/design.lib ]; then
-      cp -L *cadence-innovus-genlib/outputs/design.lib outputs/tile_array_tt.lib
-    fi
+    cp -L *cadence-innovus-genlib/outputs/design.lib outputs/tile_array_tt.lib
     cp -L *synopsys-dc-lib2db/outputs/design.db outputs/tile_array_tt.db
 else
     cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/tile_array_tt.db

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -20,8 +20,8 @@ else
 fi
 mkdir -p outputs
 
-if [ "$WHICH_SOC" == "amber" ]; then
-    cp -L *cadence-innovus-genlib/outputs/design.lib outputs/tile_array_tt.lib
+if [ ]; then
+    cp -L *cadence-genus-genlib/outputs/design.lib outputs/tile_array_tt.lib
     cp -L *synopsys-dc-lib2db/outputs/design.db outputs/tile_array_tt.db
 else
     cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/tile_array_tt.db

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -6,11 +6,7 @@ set -eo pipefail   # Fail when/if any individual command in the script fails
 
 mflowgen run --design $GARNET_HOME/mflowgen/tile_array/
 
-if [ "$WHICH_SOC" == "amber" ]; then
-    make synopsys-dc-lib2db -j 2
-else
-    make synopsys-ptpx-genlibdb -j 2
-fi
+make synopsys-ptpx-genlibdb -j 2
 
 if command -v calibre &> /dev/null
 then

--- a/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
+++ b/mflowgen/full_chip/tile_array/get_tile_array_outputs.sh
@@ -16,8 +16,8 @@ else
 fi
 mkdir -p outputs
 
-    cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/tile_array_tt.db
-    cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/tile_array_tt.lib
+cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/tile_array_tt.db
+cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/tile_array_tt.lib
 
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/tile_array.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/tile_array.vcs.v

--- a/mflowgen/glb_top/glb_tile/get_glb_outputs.sh
+++ b/mflowgen/glb_top/glb_tile/get_glb_outputs.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail   # Fail when/if any individual command in the script fails
+
 mflowgen run --design $GARNET_HOME/mflowgen/glb_tile/
 make synopsys-dc-lib2db
 if command -v calibre &> /dev/null

--- a/mflowgen/global_controller/construct.py
+++ b/mflowgen/global_controller/construct.py
@@ -122,7 +122,7 @@ def construct():
   #   'global_controller', between libraries 'analysis_default.lib' and
   #   'analysis_hold.lib'. The libraries cannot be used for merging.
 
-  cmd = "cat scripts/extract_model.tcl | sed 's/\(merge_model_timing.*\)/\1 -pin_cap_tolerance .001/' > inputs/extract_model.tcl"
+  cmd = "cat scripts/extract_model.tcl | sed 's/\(merge_model_timing.*\)/\\1 -pin_cap_tolerance .001/' > inputs/extract_model.tcl"
   genlib.pre_extend_commands( [ cmd ] )
 
   # TSMC needs streamout *without* the (new) default -uniquify flag

--- a/mflowgen/global_controller/construct.py
+++ b/mflowgen/global_controller/construct.py
@@ -116,15 +116,6 @@ def construct():
   init.extend_inputs( custom_init.all_outputs() )
   power.extend_inputs( custom_power.all_outputs() )
 
-  # Must adjust pin_cap_tolerance to prevent:
-  # **ERROR: (TECHLIB-1071): Identified pin capacitance mismatch
-  #   '0.015400' and '0.015300' in pin 'trst_n', for cell 'global_controller',
-  #   between libraries 'analysis_default.lib' and 'analysis_hold.lib'.
-
-  # Before: merge_model_timing ... -outfile design.lib
-  # Or:     merge_model_timing ... -outfile design.lib -pin_cap_tolerance .000001
-  # After:  merge_model_timing ... -outfile design.lib -pin_cap_tolerance .0005
-
   # TSMC needs streamout *without* the (new) default -uniquify flag
   # This python script finds 'stream-out.tcl' and strips out that flag.
   if adk_name == "tsmc16":

--- a/mflowgen/global_controller/construct.py
+++ b/mflowgen/global_controller/construct.py
@@ -102,10 +102,7 @@ def construct():
   postroute_hold    = Step( 'cadence-innovus-postroute_hold',default=True )
   signoff      = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
-  if which_soc == "onyx":
-    genlib       = Step( 'cadence-innovus-genlib',        default=True )
-  else:
-    genlib       = Step( 'cadence-genus-genlib',          default=True )
+  genlib       = Step( 'cadence-innovus-genlib',        default=True )
   if which("calibre") is not None:
       drc          = Step( 'mentor-calibre-drc',            default=True )
       lvs          = Step( 'mentor-calibre-lvs',            default=True )

--- a/mflowgen/global_controller/construct.py
+++ b/mflowgen/global_controller/construct.py
@@ -116,13 +116,16 @@ def construct():
   init.extend_inputs( custom_init.all_outputs() )
   power.extend_inputs( custom_power.all_outputs() )
 
-  # Must adjust pin_cap_tolerance to prevent this:
+  # Must adjust pin_cap_tolerance to prevent:
   # **ERROR: (TECHLIB-1071): Identified pin capacitance mismatch
-  #   '0.015400' and '0.015300' in pin 'trst_n', for cell
-  #   'global_controller', between libraries 'analysis_default.lib' and
-  #   'analysis_hold.lib'. The libraries cannot be used for merging.
+  #   '0.015400' and '0.015300' in pin 'trst_n', for cell 'global_controller',
+  #   between libraries 'analysis_default.lib' and 'analysis_hold.lib'.
 
-  cmd = "cat scripts/extract_model.tcl | sed 's/\(merge_model_timing.*\)/\\1 -pin_cap_tolerance .001/' > inputs/extract_model.tcl"
+  # Before: merge_model_timing ... -outfile design.lib
+  # Or:     merge_model_timing ... -outfile design.lib -pin_cap_tolerance .000001
+  # After:  merge_model_timing ... -outfile design.lib -pin_cap_tolerance .0005
+
+  cmd = "cat scripts/extract_model.tcl | sed 's/\(merge_model_timing.*design.lib\).*/\\1 -pin_cap_tolerance .0005/' > inputs/extract_model.tcl"
   genlib.pre_extend_commands( [ cmd ] )
 
   # TSMC needs streamout *without* the (new) default -uniquify flag

--- a/mflowgen/global_controller/construct.py
+++ b/mflowgen/global_controller/construct.py
@@ -102,7 +102,10 @@ def construct():
   postroute_hold    = Step( 'cadence-innovus-postroute_hold',default=True )
   signoff      = Step( 'cadence-innovus-signoff',       default=True )
   pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
-  genlib       = Step( 'cadence-innovus-genlib',        default=True )
+  if True:
+    genlib       = Step( 'cadence-innovus-genlib',        default=True )
+  else:
+    genlib       = Step( 'cadence-genus-genlib',          default=True )
   if which("calibre") is not None:
       drc          = Step( 'mentor-calibre-drc',            default=True )
       lvs          = Step( 'mentor-calibre-lvs',            default=True )

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -e;    # FAIL if any individual command fails
+set -eo pipefail   # Fail when/if any individual command in the script fails
 
 mflowgen run --design $GARNET_HOME/mflowgen/Tile_MemCore/
 

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -23,7 +23,7 @@ fi
 
 mkdir -p outputs
 if [ "$WHICH_SOC" == "amber" ]; then
-cp -L *cadence-genus-genlib/outputs/design.lib outputs/Tile_MemCore_tt.lib
+cp -L *cadence-innovus-genlib/outputs/design.lib outputs/Tile_MemCore_tt.lib
 cp -L *synopsys-dc-lib2db/outputs/design.db outputs/Tile_MemCore_tt.db
 else
 cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/Tile_MemCore_tt.lib

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -21,8 +21,8 @@ fi
 # make pwr-aware-gls
 
 mkdir -p outputs
-if [ "$WHICH_SOC" == "amber" ]; then
-cp -L *cadence-innovus-genlib/outputs/design.lib outputs/Tile_MemCore_tt.lib
+if [ ]; then
+cp -L *cadence-genus-genlib/outputs/design.lib outputs/Tile_MemCore_tt.lib
 cp -L *synopsys-dc-lib2db/outputs/design.db outputs/Tile_MemCore_tt.db
 else
 cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/Tile_MemCore_tt.lib

--- a/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
+++ b/mflowgen/tile_array/Tile_MemCore/get_Tile_MemCore_outputs.sh
@@ -21,13 +21,10 @@ fi
 # make pwr-aware-gls
 
 mkdir -p outputs
-if [ ]; then
-cp -L *cadence-genus-genlib/outputs/design.lib outputs/Tile_MemCore_tt.lib
-cp -L *synopsys-dc-lib2db/outputs/design.db outputs/Tile_MemCore_tt.db
-else
+
 cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/Tile_MemCore_tt.lib
 cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/Tile_MemCore_tt.db
-fi
+
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/Tile_MemCore.lef
 cp -L *cadence-innovus-signoff/outputs/design-merged.gds outputs/Tile_MemCore.gds
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/Tile_MemCore.vcs.v

--- a/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
+++ b/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
@@ -20,13 +20,9 @@ fi
 
 mkdir -p outputs
 
-if [ ]; then
-cp -L *cadence-genus-genlib/outputs/design.lib outputs/Tile_PE_tt.lib
-cp -L *synopsys-dc-lib2db/outputs/design.db outputs/Tile_PE_tt.db
-else
 cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/Tile_PE_tt.lib
 cp -L *synopsys-ptpx-genlibdb/outputs/design.db outputs/Tile_PE_tt.db
-fi
+
 cp -L *cadence-innovus-signoff/outputs/design.lef outputs/Tile_PE.lef
 cp -L *cadence-innovus-signoff/outputs/design.vcs.v outputs/Tile_PE.vcs.v
 cp -L *cadence-innovus-signoff/outputs/design.sdf outputs/Tile_PE.sdf

--- a/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
+++ b/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -e;    # FAIL if any individual command fails
+set -eo pipefail   # Fail when/if any individual command in the script fails
 
 mflowgen run --design $GARNET_HOME/mflowgen/Tile_PE/
 

--- a/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
+++ b/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
@@ -22,7 +22,7 @@ fi
 mkdir -p outputs
 
 if [ "$WHICH_SOC" == "amber" ]; then
-cp -L *cadence-genus-genlib/outputs/design.lib outputs/Tile_PE_tt.lib
+cp -L *cadence-innovus-genlib/outputs/design.lib outputs/Tile_PE_tt.lib
 cp -L *synopsys-dc-lib2db/outputs/design.db outputs/Tile_PE_tt.db
 else
 cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/Tile_PE_tt.lib

--- a/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
+++ b/mflowgen/tile_array/Tile_PE/get_Tile_PE_outputs.sh
@@ -20,8 +20,8 @@ fi
 
 mkdir -p outputs
 
-if [ "$WHICH_SOC" == "amber" ]; then
-cp -L *cadence-innovus-genlib/outputs/design.lib outputs/Tile_PE_tt.lib
+if [ ]; then
+cp -L *cadence-genus-genlib/outputs/design.lib outputs/Tile_PE_tt.lib
 cp -L *synopsys-dc-lib2db/outputs/design.db outputs/Tile_PE_tt.db
 else
 cp -L *synopsys-ptpx-genlibdb/outputs/design.lib outputs/Tile_PE_tt.lib

--- a/mflowgen/tile_array/constraints/constraints.tcl
+++ b/mflowgen/tile_array/constraints/constraints.tcl
@@ -112,3 +112,10 @@ set_multicycle_path 9 -to [get_ports read_config_data] -hold
 # causes hi,lo -> tile_id connections on cgra tiles to be
 # optimized away and replaced with tie cells.
 #set_dont_touch [get_references *mantle_wire*]
+
+# 1. After transitioning TSMC genlib from genus to innovus/ptpx, synthesis
+#    started inserting buffers on these hi/lo nets (below)! Why??
+# 2. These nets are either tied constant hi or lo, right?
+#    Timing should not be an issue!?
+set_dont_touch [get_nets Tile*_lo_*]
+set_dont_touch [get_nets Tile*_hi_*]

--- a/mflowgen/tile_array/constraints/constraints.tcl
+++ b/mflowgen/tile_array/constraints/constraints.tcl
@@ -80,13 +80,12 @@ set_multicycle_path -hold 1 -from [get_ports stall*]
 # Ensure that no buffers get inserted on abutted nets
 # First get all nets connected to CGRA tiles
 set tile_nets [get_nets -of_objects [get_cells -filter {ref_name =~ *Tile*}]]
-# Now iterate over collection and check if net connects > 1
-# CGRA tile and no other cells. If this is true, don't try to route it.
+# Now iterate over collection and check if net connects ONLY to
+# CGRA tiles and no other cells. If this is true, don't try to route it.
 foreach_in_collection net $tile_nets {
   set connected_cells [get_cells -of_object $net]
   set connected_tiles [filter_collection $connected_cells {ref_name =~ *Tile*}]
-  set num_connected_tiles [sizeof_collection $connected_tiles]
-  if {($num_connected_tiles > 1) && ([compare_collections $connected_cells $connected_tiles] == 0)} {
+  if { [compare_collections $connected_cells $connected_tiles] == 0 } {
     set_dont_touch $net true
   }
 }
@@ -112,10 +111,3 @@ set_multicycle_path 9 -to [get_ports read_config_data] -hold
 # causes hi,lo -> tile_id connections on cgra tiles to be
 # optimized away and replaced with tie cells.
 #set_dont_touch [get_references *mantle_wire*]
-
-# 1. After transitioning TSMC genlib from genus to innovus/ptpx, synthesis
-#    started inserting buffers on these hi/lo nets (below)! Why??
-# 2. These nets are either tied constant hi or lo, right?
-#    Timing should not be an issue!?
-set_dont_touch [get_nets Tile*_lo_*]
-set_dont_touch [get_nets Tile*_hi_*]

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -139,10 +139,12 @@ def construct():
   postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
   signoff        = Step( 'cadence-innovus-signoff',        default=True )
   pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
-  genlib         = Step( 'cadence-innovus-genlib',         default=True )
-
-  if which_soc == 'onyx':
+  if True:
     pt_genlibdb    = Step( 'synopsys-ptpx-genlibdb',         default=True )
+    genlib         = Step( 'cadence-innovus-genlib',         default=True )
+  else:
+    #genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
+    genlib         = Step( 'cadence-genus-genlib',           default=True )
 
   if which("calibre") is not None:
       drc            = Step( 'mentor-calibre-drc',             default=True )
@@ -168,7 +170,7 @@ def construct():
   pt_signoff.extend_inputs( ['Tile_MemCore_tt.db'] )
   genlib.extend_inputs( ['Tile_PE_tt.lib'] )
   genlib.extend_inputs( ['Tile_MemCore_tt.lib'] )
-  if which_soc == 'onyx':
+  if True:
     pt_genlibdb.extend_inputs( ['Tile_PE_tt.db'] )
     pt_genlibdb.extend_inputs( ['Tile_MemCore_tt.db'] )
 
@@ -287,8 +289,8 @@ def construct():
   g.add_step( gls_args       )
   g.add_step( testbench      )
   g.add_step( vcs_sim        )
+  g.add_step( pt_genlibdb    )
   if which_soc == "onyx":
-    g.add_step( pt_genlibdb    )
     g.add_step( drc_pm         )
     g.add_step( lvs_adk        )
 
@@ -365,8 +367,8 @@ def construct():
       # only be used if memory tile is present
       g.connect_by_name( custom_lvs,        lvs            )
       g.connect_by_name( Tile_MemCore,      vcs_sim        )
+      g.connect_by_name( Tile_MemCore,      pt_genlibdb    )
       if which_soc == "onyx":
-        g.connect_by_name( Tile_MemCore,      pt_genlibdb    )
         g.connect_by_name( Tile_MemCore,      drc_pm         )
 
   # inputs to Tile_PE
@@ -388,8 +390,8 @@ def construct():
   g.connect_by_name( Tile_PE,      genlib         )
   g.connect_by_name( Tile_PE,      drc            )
   g.connect_by_name( Tile_PE,      lvs            )
+  g.connect_by_name( Tile_PE,      pt_genlibdb    )
   if which_soc == "onyx":
-    g.connect_by_name( Tile_PE,      pt_genlibdb    )
     g.connect_by_name( Tile_PE,      drc_pm         )
 
   #g.connect_by_name( rtl,            dc        )
@@ -423,8 +425,7 @@ def construct():
   g.connect_by_name( iflow,    postroute      )
   g.connect_by_name( iflow,    postroute_hold )
   g.connect_by_name( iflow,    signoff        )
-  if which_soc == "onyx":
-    g.connect_by_name( iflow,    genlib         )
+  g.connect_by_name( iflow,    genlib         )
 
   g.connect_by_name( custom_init,  init     )
   g.connect_by_name( custom_power, power    )
@@ -449,7 +450,7 @@ def construct():
   g.connect_by_name( adk,          pt_signoff   )
   g.connect_by_name( signoff,      pt_signoff   )
 
-  if which_soc == "onyx":
+  if True:
     g.connect_by_name( adk,          pt_genlibdb )
     g.connect_by_name( adk,          genlib      )
     g.connect_by_name( signoff,      pt_genlibdb )
@@ -506,7 +507,7 @@ def construct():
 
   # pt_genlibdb -- Remove 'report-interface-timing.tcl' beacuse it takes
   # very long and is not necessary
-  if which_soc == "onyx":
+  if True:
     order = pt_genlibdb.get_param('order')
     order.remove( 'write-interface-timing.tcl' )
     pt_genlibdb.update_params( { 'order': order } )

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -139,12 +139,10 @@ def construct():
   postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
   signoff        = Step( 'cadence-innovus-signoff',        default=True )
   pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
+  genlib         = Step( 'cadence-innovus-genlib',         default=True )
+
   if which_soc == 'onyx':
     pt_genlibdb    = Step( 'synopsys-ptpx-genlibdb',         default=True )
-    genlib         = Step( 'cadence-innovus-genlib',         default=True )
-  else:
-    #genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
-    genlib         = Step( 'cadence-genus-genlib',           default=True )
 
   if which("calibre") is not None:
       drc            = Step( 'mentor-calibre-drc',             default=True )

--- a/mflowgen/tile_array/construct.py
+++ b/mflowgen/tile_array/construct.py
@@ -139,12 +139,9 @@ def construct():
   postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
   signoff        = Step( 'cadence-innovus-signoff',        default=True )
   pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
-  if True:
-    pt_genlibdb    = Step( 'synopsys-ptpx-genlibdb',         default=True )
-    genlib         = Step( 'cadence-innovus-genlib',         default=True )
-  else:
-    #genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
-    genlib         = Step( 'cadence-genus-genlib',           default=True )
+
+  pt_genlibdb    = Step( 'synopsys-ptpx-genlibdb',         default=True )
+  genlib         = Step( 'cadence-innovus-genlib',         default=True )
 
   if which("calibre") is not None:
       drc            = Step( 'mentor-calibre-drc',             default=True )
@@ -170,9 +167,9 @@ def construct():
   pt_signoff.extend_inputs( ['Tile_MemCore_tt.db'] )
   genlib.extend_inputs( ['Tile_PE_tt.lib'] )
   genlib.extend_inputs( ['Tile_MemCore_tt.lib'] )
-  if True:
-    pt_genlibdb.extend_inputs( ['Tile_PE_tt.db'] )
-    pt_genlibdb.extend_inputs( ['Tile_MemCore_tt.db'] )
+
+  pt_genlibdb.extend_inputs( ['Tile_PE_tt.db'] )
+  pt_genlibdb.extend_inputs( ['Tile_MemCore_tt.db'] )
 
   e2e_apps = ["tests/conv_3_3", "apps/cascade", "apps/harris_auto", "apps/resnet_i1_o1_mem", "apps/resnet_i1_o1_pond"]
 
@@ -450,14 +447,10 @@ def construct():
   g.connect_by_name( adk,          pt_signoff   )
   g.connect_by_name( signoff,      pt_signoff   )
 
-  if True:
-    g.connect_by_name( adk,          pt_genlibdb )
-    g.connect_by_name( adk,          genlib      )
-    g.connect_by_name( signoff,      pt_genlibdb )
-    g.connect_by_name( signoff,      genlib      )
-  else:
-    g.connect_by_name( adk,          genlib   )
-    g.connect_by_name( signoff,      genlib   )
+  g.connect_by_name( adk,          pt_genlibdb )
+  g.connect_by_name( adk,          genlib      )
+  g.connect_by_name( signoff,      pt_genlibdb )
+  g.connect_by_name( signoff,      genlib      )
   
   g.connect_by_name( genlib,       lib2db   )
 
@@ -505,12 +498,11 @@ def construct():
   #dc.update_params( { 'order': order } )
   #synth.update_params( { 'order': order } )
 
-  # pt_genlibdb -- Remove 'report-interface-timing.tcl' beacuse it takes
+  # pt_genlibdb -- Remove 'write-interface-timing.tcl' because it takes
   # very long and is not necessary
-  if True:
-    order = pt_genlibdb.get_param('order')
-    order.remove( 'write-interface-timing.tcl' )
-    pt_genlibdb.update_params( { 'order': order } )
+  order = pt_genlibdb.get_param('order')
+  order.remove( 'write-interface-timing.tcl' )
+  pt_genlibdb.update_params( { 'order': order } )
 
   # init -- Add 'dont-touch.tcl' before reporting
 


### PR DESCRIPTION
This branch had two goals
1. Change amber to use same genlib mechanisms as onyx; in particular, now neither build uses the deprecated `genus-genlib` step.
2. Any shell script called from `mflowgen-run` should have the `pipefail` property enabled, such that a failing command in the script makes the build fail instantly.

Side effects that had to be addressed along the way:
* Added "dont-touch" properties to lo and hi nets for Tile ID because, with the new tighter lib files(?), synthesis was adding buffers(?!!), which messes up our tile-id patch-wire hack.
* Changed `generate-lib.tcl` to use a parameter for the default setup view, instead of being hard-coded.
* Added a `pin_cap_tolerance` parameter to prevent `genlib` errors, see mflowgen issue 145:
https://github.com/mflowgen/mflowgen/issues/145 .

The changes have been tested on a full amber build and passed: https://buildkite.com/tapeout-aha/fullchip/builds/529

The changes increase full chip build time by a little over 1.5 hours. The "better" genlib mechanism results in tighter timing for the tile array, which takes an extra hour in each of its `postroute` and `postroute_hold` steps. All the other steps ran slightly faster than before, not sure why, maybe because of different background server load during the two runs.
```
--------------------------------------------------------------------------------------
Runtimes for full build                          OLD                      NEW
--------------------------------------------------------------------------------------
10-rtl                              --         13 min 26 sec  --          9 min 50 sec 
16-glb_top                          --    4 hr 35 min  9 sec  --    4 hr 25 min 28 sec 
17-global_controller                --         38 min 11 sec  --         43 min 38 sec 
19-tile_array                       --    8 hr 19 min 55 sec  --   10 hr 30 min 15 sec ***** +2 HOURS *****
20-cadence-genus-synthesis          --    1 hr 16 min  7 sec  --    1 hr 11 min 28 sec 
24-cadence-innovus-init             --          6 min 57 sec  --          6 min 38 sec 
25-cadence-innovus-power            --         18 min 55 sec  --         18 min 31 sec 
26-cadence-innovus-place            --    2 hr 33 min 40 sec  --    2 hr 29 min 21 sec 
28-cadence-innovus-cts              --    2 hr 11 min 25 sec  --    2 hr  8 min  4 sec 
29-cadence-innovus-postcts_hold     --         11 min 52 sec  --         11 min 41 sec 
30-cadence-innovus-route            --    1 hr 37 min  9 sec  --    1 hr 32 min 24 sec 
31-cadence-innovus-postroute        --    3 hr 43 min  8 sec  --    3 hr 39 min 51 sec 
32-cadence-innovus-postroute_hold   --    2 hr 26 min 44 sec  --    2 hr 26 min 44 sec 
33-cadence-innovus-signoff          --         37 min 44 sec  --         37 min 18 sec 
34-gdsmerge-dragonphy-rdl           --          1 min 35 sec  --          1 min 35 sec 
37-mentor-calibre-lvs               --    1 hr  5 min 45 sec  --    1 hr  3 min 48 sec 
--------------------------------------------------------------------------------------
Total                               --   29 hr 58 min  5 sec  --   31 hr 37 min 10 sec 


--------------------------------------------------------------------------------------
Runtimes for 19-tile_array only                OLD                       NEW
--------------------------------------------------------------------------------------
16-Tile_MemCore                     --    1 hr 50 min 33 sec  --    1 hr 51 min  3 sec 
17-Tile_PE                          --    2 hr 14 min  6 sec  --    2 hr  2 min 34 sec 
18-cadence-genus-synthesis          --         29 min 51 sec  --         26 min 18 sec 
20-cadence-innovus-init             --          6 min  8 sec  --          6 min 19 sec 
21-cadence-innovus-power            --          4 min  4 sec  --          3 min 53 sec 
22-cadence-innovus-place            --    1 hr  9 min 59 sec  --    1 hr  9 min 36 sec 
23-cadence-innovus-cts              --         53 min 42 sec  --         59 min 19 sec 
24-cadence-innovus-postcts_hold     --         12 min  0 sec  --         32 min 27 sec 
25-cadence-innovus-route            --         12 min 10 sec  --         12 min 35 sec 
26-cadence-innovus-postroute        --    1 hr  5 min 21 sec  --    2 hr  6 min  6 sec  ***** +1 HOUR *****
27-cadence-innovus-postroute_hold   --         30 min 25 sec  --    1 hr 31 min 33 sec  ***** +1 HOUR *****
28-cadence-innovus-signoff          --         12 min 21 sec  --         13 min 18 sec 
29-cadence-genus-genlib             --          7 min  5 sec  -- 
36-mentor-calibre-lvs               --    1 hr        50 sec  --         58 min 10 sec 
38-synopsys-ptpx-genlibdb           --                        --          6 min 44 sec 
--------------------------------------------------------------------------------------
Total                               --   10 hr  8 min 56 sec  --   12 hr 20 min  9 sec 
```
