### PR TITLE
checkin-gf: soft-fail + larger max area for pe tile

### DIFF
--- a/.buildkite/pipeline_checkin_gf.yml
+++ b/.buildkite/pipeline_checkin_gf.yml
@@ -34,17 +34,20 @@ steps:
 # Builds in dir e.g. mflowgen/full_chip/19-tile_array/16-Tile_MemCore
 
 - label: 'ptile init 20m'
+  soft_fail: true
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps init --debug
-  - .buildkite/pipelines/check_pe_area.sh --max 10200
+  - .buildkite/pipelines/check_pe_area.sh --max 10400
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_PE --show-all-errors
 
 - label: 'mtile init 25m'
+  soft_fail: true
   commands:
   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps init --debug
   - mflowgen/bin/buildcheck.sh full_chip/*tile_array/*Tile_MemCore --show-all-errors
 
 - label: 'gtile init 20m'
+  soft_fail: true
   commands:
   - $TEST --need_space 30G full_chip glb_top glb_tile --steps init --debug
   - mflowgen/bin/buildcheck.sh full_chip/*glb_top/*glb_tile --show-all-errors


### PR DESCRIPTION
Fixes two problems related to CI buildkite pipeline `checkin-gf`
* increases max allowable PE tile size so as to prevent tile-too-big error;
* adds soft-fail so that if and when any of the tiles fail in the future, it will not impact a pull request (because GF pass/fail should not be a gating factor on the code going forward...)

Note this *does not* fix the problem where the buildkite agent periodically cannot check out the garnet repo branch needed for the test e.g. https://buildkite.com/tapeout-aha/checkin-gf/builds/2408#018b5d3d-4a53-4925-af9d-873a5aaf41f3
```
fatal: reference is not a tree: bf30e9f33e1592036d436d94bc6100653db829d5
⚠️ Warning: Checkout failed! exit status 128 (Attempt 1/3 Retrying in 2s)
```

This error happens *before* the pipeline gets loaded, so cannot be bypassed with a soft fail :(
For now, we will have to either ignore this error and/or keep retrying the test until it works.
