### PR TITLE
Refactor

### DIFF
--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -40,99 +40,96 @@ steps:
 #   - 'bin/rtl-goldcheck.sh --use-docker $$IMAGE $$CONTAINER amber'
 
 - label: "Gold RTL: Onyx 1m"
-
-  # Let's NOT be soft for awhile. Remember to restore this before final merge!
-  # soft_fail: true
-
+  soft_fail: true
   commands:
   - 'bin/rtl-goldcheck.sh --use-docker $$IMAGE $$CONTAINER onyx'
 
 - wait: { continue_on_failure: true }
 
-# ##############################################################################
-# # INDIVIDUAL TILE RUNS
-# # Builds in dir e.g. mflowgen/full_chip/19-tile_array/17-Tile_PE
-# 
-# # Default is to run three tile tests (PE, Mem, GLB) up through
-# # floorplanning (init), which should take about 20-30 minutes.
-# 
-# # ------------------------------------------------------------------------
-# 
-# # PTILE through init
-# # Set pe max width to 112: fp limits to 110 but then lvs says 112 OK
-# - label: 'ptile init 20m'
+##############################################################################
+# INDIVIDUAL TILE RUNS
+# Builds in dir e.g. mflowgen/full_chip/19-tile_array/17-Tile_PE
+
+# Default is to run three tile tests (PE, Mem, GLB) up through
+# floorplanning (init), which should take about 20-30 minutes.
+
+# ------------------------------------------------------------------------
+
+# PTILE through init
+# Set pe max width to 112: fp limits to 110 but then lvs says 112 OK
+- label: 'ptile init 20m'
+  commands:
+  - 'source mflowgen/bin/setup-buildkite.sh $$SETUP_FLAGS;
+     echo "--- BEGIN mflowgen run";
+     mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
+     echo "--- BEGIN make init";
+     echo make tile_array-Tile_PE-cadence-innovus-init;
+     echo exit 13 | make tile_array-Tile_PE-cadence-innovus-init;'
+  - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 112 $BDIR
+  - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*tile_array/*Tile_PE --show-all-errors
+
+# PTILE through LVS
+# - label: 'ptile lvs 2h'
 #   commands:
-#   - 'source mflowgen/bin/setup-buildkite.sh $$SETUP_FLAGS;
-#      echo "--- BEGIN mflowgen run";
-#      mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
-#      echo "--- BEGIN make init";
-#      echo make tile_array-Tile_PE-cadence-innovus-init;
-#      echo exit 13 | make tile_array-Tile_PE-cadence-innovus-init;'
+#   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps mentor-calibre-lvs --debug
 #   - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 112 $BDIR
 #   - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*tile_array/*Tile_PE --show-all-errors
-# 
-# # PTILE through LVS
-# # - label: 'ptile lvs 2h'
-# #   commands:
-# #   - $TEST --need_space 30G full_chip tile_array Tile_PE --steps mentor-calibre-lvs --debug
-# #   - .buildkite/pipelines/check_tile_width.sh Tile_PE --max 112 $BDIR
-# #   - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*tile_array/*Tile_PE --show-all-errors
-# #   if: build.branch !~ /to-spv/ && build.branch !~ /spV/
-# 
-# # ------------------------------------------------------------------------
-# 
-# # MTILE through init
-# - label: 'mtile init 25m'
+#   if: build.branch !~ /to-spv/ && build.branch !~ /spV/
+
+# ------------------------------------------------------------------------
+
+# MTILE through init
+- label: 'mtile init 25m'
+  commands:
+  - 'source mflowgen/bin/setup-buildkite.sh $$SETUP_FLAGS;
+     echo "--- BEGIN mflowgen run";
+     mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
+     echo "--- BEGIN make init";
+     echo make tile_array-Tile_MemCore-cadence-innovus-init;
+     echo exit 13 | make tile_array-Tile_MemCore-cadence-innovus-init;'
+  - .buildkite/pipelines/check_tile_width.sh Tile_MemCore --max 250 $BDIR
+  - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*tile_array/*Tile_MemCore --show-all-errors
+
+# MTILE through LVS
+# - label: 'mtile lvs 2h'
 #   commands:
-#   - 'source mflowgen/bin/setup-buildkite.sh $$SETUP_FLAGS;
-#      echo "--- BEGIN mflowgen run";
-#      mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
-#      echo "--- BEGIN make init";
-#      echo make tile_array-Tile_MemCore-cadence-innovus-init;
-#      echo exit 13 | make tile_array-Tile_MemCore-cadence-innovus-init;'
+#   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps mentor-calibre-lvs --debug
 #   - .buildkite/pipelines/check_tile_width.sh Tile_MemCore --max 250 $BDIR
 #   - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*tile_array/*Tile_MemCore --show-all-errors
-# 
-# # MTILE through LVS
-# # - label: 'mtile lvs 2h'
-# #   commands:
-# #   - $TEST --need_space 30G full_chip tile_array Tile_MemCore --steps mentor-calibre-lvs --debug
-# #   - .buildkite/pipelines/check_tile_width.sh Tile_MemCore --max 250 $BDIR
-# #   - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*tile_array/*Tile_MemCore --show-all-errors
-# 
-# # ------------------------------------------------------------------------
-# 
-# # GTILE through init
-# - label: 'gtile init 20m'
+
+# ------------------------------------------------------------------------
+
+# GTILE through init
+- label: 'gtile init 20m'
+  commands:
+  - 'source mflowgen/bin/setup-buildkite.sh $$SETUP_FLAGS;
+     echo "--- BEGIN mflowgen run";
+     mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
+     echo "--- BEGIN make init";
+     echo make glb_top-glb_tile-cadence-innovus-init;
+     echo exit 13 | make glb_top-glb_tile-cadence-innovus-init;'
+  - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*glb_top/*glb_tile --show-all-errors
+
+# GTILE through LVS
+# - label: 'gtile lvs 3h'
 #   commands:
-#   - 'source mflowgen/bin/setup-buildkite.sh $$SETUP_FLAGS;
-#      echo "--- BEGIN mflowgen run";
-#      mflowgen run --design $$GARNET_HOME/mflowgen/full_chip;
-#      echo "--- BEGIN make init";
-#      echo make glb_top-glb_tile-cadence-innovus-init;
-#      echo exit 13 | make glb_top-glb_tile-cadence-innovus-init;'
+#   - $TEST --need_space 30G full_chip glb_top glb_tile --steps mentor-calibre-lvs --debug
 #   - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*glb_top/*glb_tile --show-all-errors
-# 
-# # GTILE through LVS
-# # - label: 'gtile lvs 3h'
-# #   commands:
-# #   - $TEST --need_space 30G full_chip glb_top glb_tile --steps mentor-calibre-lvs --debug
-# #   - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*glb_top/*glb_tile --show-all-errors
-# 
-# # ------------------------------------------------------------------------
-# 
-# # GTOP through LVS
-# # - label: 'gtop lvs 3h?'
-# #   commands:
-# #   - $TEST --need_space 30G full_chip glb_top --steps mentor-calibre-lvs --debug
-# #   - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*glb_top --show-all-errors
-# 
-# # ------------------------------------------------------------------------
-# 
-# # ONYX BRANCHES ONLY
-# # GF branches cannot run synthesis on my machine, so do RTL only I guess
-# # - label: 'RTL only 25m'
-# #   commands:
-# #   - 'export WHICH_SOC=onyx;
-# #     $TEST --need_space 30G full_chip --steps rtl --debug'
-# #   if: build.branch =~ /to-spv/ || build.branch =~ /spV/ || build.branch =~ /sms/
+
+# ------------------------------------------------------------------------
+
+# GTOP through LVS
+# - label: 'gtop lvs 3h?'
+#   commands:
+#   - $TEST --need_space 30G full_chip glb_top --steps mentor-calibre-lvs --debug
+#   - mflowgen/bin/buildcheck.sh $BDIR/full_chip/*glb_top --show-all-errors
+
+# ------------------------------------------------------------------------
+
+# ONYX BRANCHES ONLY
+# GF branches cannot run synthesis on my machine, so do RTL only I guess
+# - label: 'RTL only 25m'
+#   commands:
+#   - 'export WHICH_SOC=onyx;
+#     $TEST --need_space 30G full_chip --steps rtl --debug'
+#   if: build.branch =~ /to-spv/ || build.branch =~ /spV/ || build.branch =~ /sms/

--- a/README.md
+++ b/README.md
@@ -247,4 +247,3 @@ prefix `Test` will be considered tests.
 magma ecosystem) with abstractions for testing hardware.  See the 
 [README](https://github.com/leonardt/fault#fault) for example usage and links to
 documentation.
-

--- a/README.md
+++ b/README.md
@@ -247,3 +247,4 @@ prefix `Test` will be considered tests.
 magma ecosystem) with abstractions for testing hardware.  See the 
 [README](https://github.com/leonardt/fault#fault) for example usage and links to
 documentation.
+

--- a/daemon/README.txt
+++ b/daemon/README.txt
@@ -1,0 +1,86 @@
+INTRODUCTION - PNR using garnet daemon
+
+Previously, PNR for an app required two stages: 1) build the (garnet) circuit and 2) place/route the app onto the circuit. A second PNR, for a second app, would go through the same two stages, even when/if the garnet circuit produced is the same for both apps.
+
+This new daemon-based PNR builds the garnet circuit just *once*, then runs in the background, waiting to use the circuit for one or more requesting apps to do their PNR.
+```
+    % aha pnr app1 --daemon launch
+        => 100 sec to build garnet circuit
+        =>  50 sec to do PNR for app1
+
+    % aha pnr app2 --daemon use
+        =>  0 sec to build garnet circuit (reuses prev circuit)
+        => 50 sec to do PNR for app2
+
+    % aha pnr app3 --daemon use ...
+    % aha pnr app4 --daemon use ...
+```
+
+Below are before-and-after timings for our "daily" regression tests (with after-daemon times in parens). The daemon reduces total runtime by about one third, from 2972 seconds (50 min) down to 2080 seconds (35 min).
+
+Step                Total  (d)     Map  (d)    PNR   (d)    Test (d)
+------------------- -----------   ---------   ----------   ---------
+garnet               709  (709)
+apps/pointwise       218  (215)    51  (51)    141 (138)    26  (26)
+apps/pointwise       190   (99)    42  (42)    138  (47)    10  (10)
+tests/ushift         204  (113)    41  (41)    139  (48)    24  (24)
+tests/arith          207  (114)    41  (41)    140  (47)    26  (26)
+tests/absolute       201  (110)    40  (40)    137  (46)    24  (24)
+tests/scomp          222  (132)    41  (41)    157  (67)    24  (24)
+tests/ucomp          223  (130)    41  (41)    159  (66)    23  (23)
+tests/uminmax        205  (112)    41  (41)    138  (45)    26  (26)
+tests/rom            201  (113)    41  (41)    135  (47)    25  (25)
+tests/conv_1_2       197  (116)    41  (41)    130  (49)    26  (26)
+tests/conv_2_1       195  (117)    41  (41)    128  (50)    26  (26)
+------------------- -----------   ---------   ----------   ---------
+TOTAL               2972 (2080)   461 (461)   1542 (650)   260 (260)
+
+
+PNR makes use of a version of `garnet.py` enhanced with daemon capabilities by way of the "GarnetDaemon" class in `daemon.py`. I.e. when you do
+```
+    aha pnr my-app --width 28 --height 16 --daemon launch
+```
+the `aha pnr` wrapper does something like
+```
+   garnet.py --daemon launch
+         --no-pd --interconnect-only
+         --input-app ${app_dir}/bin/design_top.json
+         --input-file ${app_dir}/bin/input${ext}
+         --output-file ${app_dir}/bin/${args_app_name}.bs
+         --gold-file ${app_dir}/bin/gold${ext}
+         --input-broadcast-branch-factor 2
+         --input-broadcast-max-leaves 16
+         --rv --sparse-cgra --sparse-cgra-combined --pipeline-pnr
+         --width 28 --height 16 &
+```
+
+You can use '--daemon help' to find the latest info about how to use the daemon.
+```
+    % garnet.py --daemon help
+
+    DESCRIPTION:
+      garnet.py can run as a daemon to save you time when generating bitstreams
+      for multiple apps using the same garnet circuit. Use the "launch" command
+      to build a circuit and keep state in the background. The "use-daemon" command
+      reuses the background state to more quickly do pnr and bitstream generation.
+
+          --daemon launch -> process args and launch a daemon
+          --daemon use    -> use existing daemon to process args
+          --daemon wait   -> wait for daemon to finish processing args
+          --daemon kill   -> kill the daemon
+          --daemon status -> print daemon status and exit
+          --daemon force  -> same as kill + launch
+
+    EXAMPLE:
+        garnet.py --daemon kill
+        garnet.py --width 28 --height 16 --verilog ...
+        garnet.py <app1-pnr-args> --daemon launch
+        garnet.py <app2-pnr-args> --daemon use
+        garnet.py <app3-pnr-args> --daemon use
+        garnet.py <app4-pnr-args> --daemon use
+        ...
+        garnet.py --daemon kill
+
+    NOTE! 'daemon.use' width and height must match 'daemon.launch'!!!
+    NOTE 2: cannot use the same daemon for verilog *and* pnr (not sure why).
+```

--- a/daemon/README.txt
+++ b/daemon/README.txt
@@ -1,9 +1,9 @@
 ==== GARNET DAEMON
 
-The GarnetDaemon class enables daemon capability for a python program,
-tailored specifically for our `garnet.py` chip builder. In particular, we 
-can use a daemon-enabled `garnet.py` to save time when using `garnet.py`
-to do PNR for multiple applications mapped onto the same Garnet build.
+The GarnetDaemon class enables daemon capability, tailored
+specifically for `garnet.py`. In particular, daemon-enhanced
+`garnet.py` can save time when doing PNR for multiple applications
+mapped onto the same Garnet build.
 
 ==== PNR USING GARNET DAEMON
 
@@ -50,9 +50,8 @@ tests/conv_2_1       195  (117)    41  (41)    128  (50)    26  (26)
 TOTAL               2972 (2080)   461 (461)   1542 (650)   260 (260)
 
 
-PNR makes use of a version of `garnet.py` enhanced with daemon
-capabilities by way of the "GarnetDaemon" class in `daemon.py`.
-I.e. when you do
+In the above table, PNR uses `garnet.py` enhanced using the
+"GarnetDaemon" class in `daemon.py`.  I.e. when you do
 ```
     aha pnr my-app --width 28 --height 16 --daemon launch
 ```
@@ -72,7 +71,7 @@ the `aha pnr` wrapper does something like
 
 You can use `--daemon help` to find the latest info about how to use the daemon.
 ```
-    % garnet.py --daemon help
+    % python garnet.py --daemon help
 
     DESCRIPTION:
 

--- a/daemon/README.txt
+++ b/daemon/README.txt
@@ -1,4 +1,11 @@
-INTRODUCTION - PNR using garnet daemon
+==== GARNET DAEMON
+
+The GarnetDaemon class enables daemon capability for a python program,
+tailored specifically for our `garnet.py` chip builder. In particular, we 
+can use a daemon-enabled `garnet.py` to save time when using `garnet.py`
+to do PNR for multiple applications mapped onto the same Garnet build.
+
+==== PNR USING GARNET DAEMON
 
 Previously, PNR for an app required two stages: 1) build the (garnet)
 circuit and 2) place/route the app onto the circuit. A second PNR, for

--- a/daemon/README.txt
+++ b/daemon/README.txt
@@ -84,6 +84,7 @@ You can use `--daemon help` to find the latest info about how to use the daemon.
 
           --daemon launch -> process args and launch a daemon
           --daemon use    -> use existing daemon to process args
+          --daemon auto   -> "launch" if no daemon yet, else "use"
           --daemon wait   -> wait for daemon to finish processing args
           --daemon kill   -> kill the daemon
           --daemon status -> print daemon status and exit

--- a/daemon/README.txt
+++ b/daemon/README.txt
@@ -1,8 +1,13 @@
 INTRODUCTION - PNR using garnet daemon
 
-Previously, PNR for an app required two stages: 1) build the (garnet) circuit and 2) place/route the app onto the circuit. A second PNR, for a second app, would go through the same two stages, even when/if the garnet circuit produced is the same for both apps.
+Previously, PNR for an app required two stages: 1) build the (garnet)
+circuit and 2) place/route the app onto the circuit. A second PNR, for
+a second app, would go through the same two stages, even when/if the
+garnet circuit produced is the same for both apps.
 
-This new daemon-based PNR builds the garnet circuit just *once*, then runs in the background, waiting to use the circuit for one or more requesting apps to do their PNR.
+This new daemon-based PNR builds the garnet circuit just *once*, then
+runs in the background, waiting to use the circuit for one or more
+requesting apps to do their PNR.
 ```
     % aha pnr app1 --daemon launch
         => 100 sec to build garnet circuit
@@ -16,7 +21,9 @@ This new daemon-based PNR builds the garnet circuit just *once*, then runs in th
     % aha pnr app4 --daemon use ...
 ```
 
-Below are before-and-after timings for our "daily" regression tests (with after-daemon times in parens). The daemon reduces total runtime by about one third, from 2972 seconds (50 min) down to 2080 seconds (35 min).
+Below are before-and-after timings for our "daily" regression tests (with
+after-daemon times in parens). The daemon reduces total runtime by about 
+one third, from 2972 seconds (50 min) down to 2080 seconds (35 min).
 
 Step                Total  (d)     Map  (d)    PNR   (d)    Test (d)
 ------------------- -----------   ---------   ----------   ---------
@@ -36,7 +43,9 @@ tests/conv_2_1       195  (117)    41  (41)    128  (50)    26  (26)
 TOTAL               2972 (2080)   461 (461)   1542 (650)   260 (260)
 
 
-PNR makes use of a version of `garnet.py` enhanced with daemon capabilities by way of the "GarnetDaemon" class in `daemon.py`. I.e. when you do
+PNR makes use of a version of `garnet.py` enhanced with daemon
+capabilities by way of the "GarnetDaemon" class in `daemon.py`.
+I.e. when you do
 ```
     aha pnr my-app --width 28 --height 16 --daemon launch
 ```
@@ -54,15 +63,17 @@ the `aha pnr` wrapper does something like
          --width 28 --height 16 &
 ```
 
-You can use '--daemon help' to find the latest info about how to use the daemon.
+You can use `--daemon help` to find the latest info about how to use the daemon.
 ```
     % garnet.py --daemon help
 
     DESCRIPTION:
-      garnet.py can run as a daemon to save you time when generating bitstreams
-      for multiple apps using the same garnet circuit. Use the "launch" command
-      to build a circuit and keep state in the background. The "use-daemon" command
-      reuses the background state to more quickly do pnr and bitstream generation.
+
+      garnet.py can run as a daemon to save you time when generating
+      bitstreams for multiple apps using the same garnet circuit. Use
+      the "launch" command to build a circuit and keep state in the
+      background. The "use-daemon" command reuses the background state
+      to more quickly do pnr and bitstream generation.
 
           --daemon launch -> process args and launch a daemon
           --daemon use    -> use existing daemon to process args

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -63,6 +63,7 @@ echo "--- BEGIN DAEMON_TEST.SH"
 # Duplicate this table with and without daemon
 
 # FLAGS1
+flags1="--width  4 --height  2 --verilog --use_sim_sram --rv --sparse-cgra --sparse-cgra-combined"
 flags1="--width 28 --height 16 --verilog --use_sim_sram --rv --sparse-cgra --sparse-cgra-combined"
 echo flags1=$flags1 | fold -sw 120
 
@@ -141,7 +142,7 @@ set +x
 # GARNET BUILD & LAUNCH
 echo "--- BEGIN GARNET VERILOG BUILD"
 t_start=`date +%s`
-aha garnet $flags1 |& tee garnet.log &
+aha garnet $flags1 |& tee garnet.log
 t_garnet=$(( `date +%s` - $t_start ))
 echo "Initial garnet build took $t_garnet seconds"
 

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -42,10 +42,9 @@ alias j=jobs
 alias h="history|tail"
 
 GARNET=/nobackup/steveri/github/garnet
-f=garnet.py
-docker cp $GARNET/$f $container:/aha/garnet/$f
-f=daemon/daemon.py
-f=daemon/daemon-test.sh
+f=garnet.py; docker cp $GARNET/$f $container:/aha/garnet/$f
+f=daemon/daemon.py; docker cp $GARNET/$f $container:/aha/garnet/$f
+f=daemon/daemon-test.sh; docker cp $GARNET/$f $container:/aha/garnet/$f
 '
 if [ "$1" == "--help" ]; then echo "$HELP"; exit; fi
 
@@ -187,13 +186,13 @@ set +x
 # cd /aha
 # test -e $dmj && echo found json file || echo "NO JSON FILE (yet)"
 
-# POINTWISE TEST
+# TEST
 t_start=`date +%s`
 if ! which vcs; then
   . /cad/modules/tcl/init/bash
     module load base; module load vcs
 fi
-aha test apps/pointwise |& tee test.log
+aha test $app |& tee test.log
 t_test=$(( `date +%s` - $t_start ))
 echo "'$ap' test took $t_test seconds"
 

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -204,7 +204,7 @@ if ! [ "$DAEMON_LAUNCHED" ]; then
 else
     echo aha pnr $app --width 28 --height 16 --daemon use
     $nobuf aha pnr $app --width 28 --height 16 --daemon use \
-        |& $nobuf tee pnr_launch.log &
+        |& $nobuf tee pnr_use.log &
 fi
 sleep 2 # BUG/FIXME should not need this
 aha garnet --daemon wait

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -16,6 +16,7 @@ function docker-launch {
 }
 image=stanfordaha/garnet:latest
 container=deleteme
+docker kill $container
 docker-launch $image $container
 
 # ------------------------------------------------------------------------

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -110,6 +110,28 @@ apps='
     conv5_1
 '
 
+# apps='
+#     apps/pointwise
+#     apps/pointwise
+#     tests/ushift
+#     tests/arith
+#     tests/absolute
+#     tests/scomp
+#     tests/ucomp
+#     tests/uminmax
+#     tests/rom
+#     tests/conv_1_2
+#     tests/conv_2_1
+#     conv5_1
+# '
+
+apps='
+    apps/pointwise
+    conv3_1
+'
+
+
+
 # (For now) must replace non-daemon-capable pnr.py with my version
 echo '--- (daemon-test.sh) PNR.PY REPLACE'
 set -x
@@ -137,6 +159,10 @@ for app in $apps; do
 
     layer=""
     if [ "$app" == "conv5_1" ]; then
+        layer="--layer $app"
+        app=apps/resnet_output_stationary
+    fi
+    if [ "$app" == "conv3_1" ]; then
         layer="--layer $app"
         app=apps/resnet_output_stationary
     fi

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -154,6 +154,7 @@ aha map $app --chain $layer |& tee map.log
 t_map=$(( `date +%s` - $t_start ))
 echo "'$ap' map took $t_map seconds"
 
+
 echo "--- (daemon-test.sh) PNR $ap, no daemon"
 # PNR ("MAP"), no daemon
 t_start=`date +%s`
@@ -162,23 +163,22 @@ aha pnr $app --width 28 --height 16 $layer |& tee pnr_no_daemon.log
 t_pnr_no_daemon=$(( `date +%s` - $t_start ))
 echo "No-daemon '$ap' pnr took $t_pnr_no_daemon seconds"
 
-echo "--- (daemon-test.sh) PNR $ap, using daemon"
 # Using 'aha pnr' instead of flags2 maybe?
 # flags2=`get_flags2 $app`; echo flags2=$flags2 | fold -sw 120
-# 
+
+echo "--- (daemon-test.sh) PNR $ap, using daemon"
 # PNR ("MAP"), using daemon
-# 
 # First time through, launch the daemon; aftwerwards *use* the daemon
 t_start=`date +%s`; nobuf='stdbuf -oL -eL'
 if ! [ "$DAEMON_LAUNCHED" ]; then
-    echo   aha pnr $app --width 28 --height 16 $layer --daemon launch
-    $nobuf aha pnr $app --width 28 --height 16 $layer --daemon launch \
+    echo   aha pnr $app --width 28 --height 16 $layer --daemon auto
+    $nobuf aha pnr $app --width 28 --height 16 $layer --daemon auto \
         |& $nobuf sed 's/^/DAEMON: /' \
         |  $nobuf tee pnr_launch.log &
         DAEMON_LAUNCHED=True
 else
-    echo   aha pnr $app --width 28 --height 1 $layer6 --daemon use
-    $nobuf aha pnr $app --width 28 --height 16 $layer --daemon use \
+    echo   aha pnr $app --width 28 --height 1 $layer6 --daemon auto
+    $nobuf aha pnr $app --width 28 --height 16 $layer --daemon auto \
         |& $nobuf tee pnr_use.log &
 fi
 # sleep 2 # BUG/FIXME should not need this

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -39,7 +39,7 @@ tail -f dtest.log
 docker cp /usr/bin/vim.tiny $container:/usr/bin
 alias vim=vim.tiny
 alias j=jobs
-alias h='history|tail'
+alias h="history|tail"
 
 GARNET=/nobackup/steveri/github/garnet
 f=garnet.py

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -97,7 +97,6 @@ echo flags1=$flags1 | fold -sw 120
 
 aha garnet --daemon kill
 
-apps/pointwise
 apps='
     apps/pointwise
     apps/pointwise

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -175,13 +175,13 @@ if ! [ "$DAEMON_LAUNCHED" ]; then
     $nobuf aha pnr $app --width 28 --height 16 $layer --daemon launch \
         |& $nobuf sed 's/^/DAEMON: /' \
         |  $nobuf tee pnr_launch.log &
+        DAEMON_LAUNCHED=True
 else
     echo   aha pnr $app --width 28 --height 1 $layer6 --daemon use
     $nobuf aha pnr $app --width 28 --height 16 $layer --daemon use \
         |& $nobuf tee pnr_use.log &
 fi
-DAEMON_LAUNCHED=True
-sleep 2 # BUG/FIXME should not need this
+# sleep 2 # BUG/FIXME should not need this
 aha garnet --daemon wait
 t_pnr_daemon=$(( `date +%s` - $t_start ))
 echo "'$ap' w/daemon pnr took $t_pnr_daemon seconds"

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -100,6 +100,8 @@ apps='
     apps/pointwise
     tests/ushift
     tests/arith
+    conv1
+    conv3_1
     tests/absolute
     tests/scomp
     tests/ucomp
@@ -107,8 +109,6 @@ apps='
     tests/rom
     tests/conv_1_2
     tests/conv_2_1
-    conv1
-    conv3_1
 '
 
 # (For now) must replace non-daemon-capable pnr.py with my version

--- a/daemon/daemon-test.sh
+++ b/daemon/daemon-test.sh
@@ -110,6 +110,7 @@ apps='
     tests/rom
     tests/conv_1_2
     tests/conv_2_1
+    conv5_1
 '
 # Don't rightly know how to do conv5 yet...
 #     conv5_1 
@@ -278,7 +279,7 @@ echo "--- BEGIN SUMMARY 2 $ap"
 #        $t_test            "($t_test)"
 
 printf "%-19s %4s %-6s %4s %-6s %4s %-6s %4s %-6s\n" \
-       $app \
+       $ap \
        $t_total_no_daemon "($t_total_daemon)" \
        $t_map             "($t_map)" \
        $t_pnr_no_daemon   "($t_pnr_daemon)" \

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -432,8 +432,8 @@ class GarnetDaemon:
             # if status == 'ready': print('', flush=True)
             # if status == 'ready': return True
 
-            if 'no daemon found' in status:
-                assert False, '--- ERROR no daemon has died'
+            if 'dead' in status:
+                assert False, '--- ERROR daemon is dead, viva daemon!'
 
             if 'done' in status: print('', flush=True)
             if 'done' in status: return True

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -275,7 +275,7 @@ class GarnetDaemon:
         if prev_job == -1:
             print(f'\n--- DAEMON WAIT - wait for daemon ready', flush=True)
         else:
-            print(f'\n--- DAEMON WAIT - wait for daemon to finish job > {prev_job}', flush=True)
+            print(f'\n--- DAEMON WAIT - wait for daemon to finish jobs 0..{prev_job}', flush=True)
 
         gd = GarnetDaemon; gd.args = args
         time.sleep(2)

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -30,6 +30,7 @@ DESCRIPTION:
 
       --daemon launch -> process args and launch a daemon
       --daemon use    -> use existing daemon to process args
+      --daemon auto   -> "launch" if no daemon yet, else "use"
       --daemon wait   -> wait for daemon to finish processing args
       --daemon kill   -> kill the daemon
       --daemon status -> print daemon status and exit
@@ -52,7 +53,7 @@ NOTE 2: cannot use the same daemon for verilog *and* pnr (not sure why).
 class GarnetDaemon:
 
     # Permissible daemon commands
-    choices = [ 'help','launch', 'use', 'kill', 'status', 'force', 'wait' ]
+    choices = [ 'help','launch', 'use', 'auto', 'kill', 'status', 'force', 'wait' ]
 
     # Disk storage for persistent daemon state
     FN_PID    = "/tmp/garnet-daemon-pid"    # Daemon pid
@@ -86,6 +87,11 @@ class GarnetDaemon:
             print(f'- hello here i am forcing a launch')
             GarnetDaemon.kill(dbg=1)
             args.daemon = "launch"
+
+        if args.daemon == "auto":
+            print(f'- hello here i am doing a auto')
+            args.daemon = "launch"
+            if GarnetDaemon.daemon_exists(): args.daemon = "use"
 
         if args.daemon == "help":
             GarnetDaemon.help(); exit()

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -151,6 +151,16 @@ class GarnetDaemon:
         old = args.__dict__; new = new_args.__dict__
         old.update(new)
 
+        # Update env vars! To match client env. Client should have packed them in 'args.ENV'
+        assert new['ENV'] == old['ENV']
+        new_env = new['ENV']
+        for i in new_env:
+            newval = new_env[i]
+            oldval = os.environ[i]  if i in os.environ else "NULL"
+            if oldval != newval:
+                print(f'- daemon.py load_args() env var "{i}" :: "{oldval}" => "{newval}"', flush=True)
+                os.environ[i] = newval
+
         if dbg: s = dict(sorted(new.items()))
         if dbg: print(f"- loaded args {json.dumps(s, indent=4)}")
 
@@ -353,21 +363,6 @@ class GarnetDaemon:
             new_args.glb_params = GarnetDaemon.saved_glb_params
             new_args.pe_fc      = GarnetDaemon.saved_pe_fc
         except: pass
-
-        # Update env vars I guess. Is this the best place to do this?
-        for i in new_args.ENV:
-            # print(i, new_args.ENV[i])
-            newval = new_args.ENV[i]
-            if i not in os.environ:
-                print(f'- daemon.py load_args(): env var "{i}" :: "" => "{newval}"')
-                os.environ[i] = newval
-            else:
-                oldval = os.environ[i]
-                if oldval != newval:
-                    print(f'- daemon.py load_args() env var "{i}" :: "{oldval}" => "{newval}"')
-                os.environ[i] = newval
-
-
 
         if dbg: print(f'- restored args {new_args} from {fname}')
         if dbg: print(f"- loaded args {json.dumps(args_dict, indent=4)}")

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -137,7 +137,7 @@ class GarnetDaemon:
         # On CONT, register status and load new args from 'reload' file
         print(f'\n\n--- DAEMON RESUMES')
         GarnetDaemon.put_status('busy')
-        return gd.load_args()
+        return gd.load_args(dbg=1)
 
     # ------------------------------------------------------------------------
     # "Private" methods for processing individual daemon commands:
@@ -305,7 +305,7 @@ class GarnetDaemon:
         except: pass
 
         if dbg: print(f'- restored args {new_args} from {fname}')
-        if dbg: print("- loaded args {json.dumps(args_dict, indent=4))}")
+        if dbg: print(f"- loaded args {json.dumps(args_dict, indent=4)}")
         return new_args
 
     # ------------------------------------------------------------------------

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -305,6 +305,7 @@ class GarnetDaemon:
         except: pass
 
         if dbg: print(f'- restored args {new_args} from {fname}')
+        if dbg: print("- loaded args {json.dumps(args_dict, indent=4))}")
         return new_args
 
     # ------------------------------------------------------------------------

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -176,7 +176,7 @@ class GarnetDaemon:
     def help():
         print(GarnetDaemon_HELP); return GarnetDaemon_HELP
 
-    def use(args, DBG=1):
+    def use(args, DBG=0):
         gd = GarnetDaemon
         if DBG: print('--- DAEMON USE; wait for daemon ready', flush=True)
         prev = gd.wait_daemon(args)       # Wait for daemon to exist
@@ -244,10 +244,10 @@ class GarnetDaemon:
             if verbose: print('- daemon_status: ' + status)
         return status
 
-    def wait_daemon(args, prev_job=-1):
+    def wait_daemon(args, prev_job=-1, DBG=0):
         '''Check daemon status, do not continue until/unless daemon exists AND IS READY'''
         if prev_job == -1:
-            print(f'\n--- DAEMON WAIT - wait for daemon ready', flush=True)
+            if DBG: print(f'\n--- DAEMON WAIT - wait for daemon ready', flush=True)
         else:
             print(f'\n--- DAEMON WAIT - wait for daemon to finish jobs 0..{prev_job}', flush=True)
 
@@ -289,7 +289,7 @@ class GarnetDaemon:
             print(f'- KEEP WAITING (recurse on wait_daemon())', flush=True)
             return wait_daemon(args, prev_job)
 
-        print('\n--- DAEMON READY, continuing...', flush=True)
+        if DBG: print('\n--- DAEMON READY, continuing...', flush=True)
         return done_job
 
 

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -432,6 +432,9 @@ class GarnetDaemon:
             # if status == 'ready': print('', flush=True)
             # if status == 'ready': return True
 
+            if 'no daemon found' in status:
+                assert False, '--- ERROR no daemon has died'
+
             if 'done' in status: print('', flush=True)
             if 'done' in status: return True
 

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -321,6 +321,9 @@ class GarnetDaemon:
         # Cannot save glb_param and pe_fc to a file b/c they are "unserializable"
         GarnetDaemon.save_the_unsaveable(args)
 
+        # Let's save the environment too why not
+        args.ENV = dict(os.environ)
+
         # Save args as a sorted dict
         argdic = vars(args)
         sorted_argdic=dict(sorted(argdic.items()))
@@ -350,6 +353,21 @@ class GarnetDaemon:
             new_args.glb_params = GarnetDaemon.saved_glb_params
             new_args.pe_fc      = GarnetDaemon.saved_pe_fc
         except: pass
+
+        # Update env vars I guess. Is this the best place to do this?
+        for i in new_args.ENV:
+            # print(i, new_args.ENV[i])
+            newval = new_args.ENV[i]
+            if i not in os.environ:
+                print(f'- daemon.py load_args(): env var "{i}" :: "" => "{newval}"')
+                os.environ[i] = newval
+            else:
+                oldval = os.environ[i]
+                if oldval != newval:
+                    print(f'- daemon.py load_args() env var "{i}" :: "{oldval}" => "{newval}"')
+                os.environ[i] = newval
+
+
 
         if dbg: print(f'- restored args {new_args} from {fname}')
         if dbg: print(f"- loaded args {json.dumps(args_dict, indent=4)}")
@@ -443,7 +461,6 @@ class GarnetDaemon:
 
     # Helper function for "wait_daemon()"
     def check_daemon(sec_per_dot, nsec, dots_per_line):
-        print('yoo hoo this is check_daemon_new', flush=True)
         errmsg = f'\nERROR there is no daemon, did you forget to launch it?'
         assert GarnetDaemon.daemon_exists(), errmsg
         # -----------------------------------------------------------------------

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -169,85 +169,58 @@ class GarnetDaemon:
         gd = GarnetDaemon
         gd.die_if_daemon_exists()
         gd.register_pid(); gs = gd.grid_size(args)    # E.g. "4x2"
-        print(f'\n--- LAUNCHING {gs} DAEMON {gd.PID}')
+        print(f'\n--- LAUNCHING {gs} DAEMON {gd.PID}', flush=True)
         gd.put_status('busy 0'); assert GarnetDaemon.jobnum == 0
         gd.save_state0(args)
 
     def help():
         print(GarnetDaemon_HELP); return GarnetDaemon_HELP
 
-    def use(args):
-
-#         GarnetDaemon.wait_daemon(args)       # Wait for daemon to exist
-#         GarnetDaemon.save_args(args)         # Save args where the daemon will find them
-#         GarnetDaemon.args_match_or_die(args) # Grid size must match!!! (todo combine w/sigcont?)
-#         GarnetDaemon.sigcont()               # Tell daemon to CONTinue
-#         exit()                               # Kill yourself, daemon will take it from here...
-
-
-        DBG=1
+    def use(args, DBG=1):
         gd = GarnetDaemon
-        if DBG: print('--- DAEMON USE; wait for daemon ready')
+        if DBG: print('--- DAEMON USE; wait for daemon ready', flush=True)
         prev = gd.wait_daemon(args)       # Wait for daemon to exist
 
-        if DBG: print(f'- DAEMON READY, last job was #{prev}')
+        if DBG: print(f'- DAEMON READY, last job was #{prev}', flush=True)
         gd.save_args(args)                # Save args where the daemon will find them
         gd.args_match_or_die(args)        # Grid size must match!!! (todo combine w/sigcont?)
         gd.sigcont()                      # Tell daemon to CONTinue
 
-        if DBG: print(f'- DAEMON POKED; wait for daemon ready again')
+        if DBG: print(f'- DAEMON POKED; wait for daemon ready again', flush=True)
         next = gd.wait_daemon(args, prev) # Wait to complete next_job > prev_job
         assert next == (prev + 1)         # Verify that job num incremented correctly and we didn't skip a job or anything
         exit()
 
-        # Update wait_daemon(args, jobno=-1)
-        # => wait for status 'done <n>' where <n> > jobno
-        # => return <n>
-
-        # inestaed fo sgicont, above, do something like
-        # find prev jobnum e.g. 'done 14'
-        # send the cont signal
-        # wait for 'done 15'
-        # exit
-
-        # prevjobnum = GarnetDaemon.wait_daemon(args, -1)
-        # GarnetDaemon.sigcont()
-        # newjobnum = GarnetDaemon.wait_daemon(args, prevjobnum+1)
-        # assert newjobnum == prevjobnum+1
-
-
-
-
     def kill(dbg=1):
         if GarnetDaemon.daemon_exists():
             pid = GarnetDaemon.retrieve_pid()  # FIXME there are way too many retrive_pid calls!!!
-            if dbg: print(f'- found daemon pid {pid}, killing it now')
+            if dbg: print(f'- found daemon pid {pid}, killing it now', flush=True)
             GarnetDaemon.sigkill()
             time.sleep(1) # Maybe wait a second to let it die
         else:
-            print(f'- daemon is already dead')
+            print(f'- daemon is already dead', flush=True)
 
-        print(f'- cleanup on aisle "/tmp"')
+        print(f'- cleanup on aisle "/tmp"', flush=True)
         GarnetDaemon.cleanup()
 
     def status(args, verbose=True, dbg=0):
-        if dbg: print(f'\n--- STATUS: daemon status requested')
+        if dbg: print(f'\n--- STATUS: daemon status requested', flush=True)
         gd = GarnetDaemon;
 
-        if dbg: print(f'- checking for orphans')
+        if dbg: print(f'- checking for orphans', flush=True)
         gd.check_for_orphans()
 
         pid = gd.retrieve_pid()
-        if dbg: print(f'- checking status of process {pid}')
+        if dbg: print(f'- checking status of process {pid}', flush=True)
 
         if not gd.daemon_exists():
-            if verbose: print("- no daemon found")
+            if verbose: print("- no daemon found", flush=True)
 
             # Do this once per session only
             if    gd.already_found_files: return 'dead'
             else: gd.already_found_files = True
             for f in gd.DAEMONFILES: 
-                if os.path.exists(f): print(f'WARNING found daemon file {f}')
+                if os.path.exists(f): print(f'WARNING found daemon file {f}', flush=True)
             return 'dead'
 
         # Don't 'if dbg' this, pytest needs it
@@ -258,6 +231,7 @@ class GarnetDaemon:
         if not gd.do_cmd(f'test -f {state0_file}'):
             print(f'- WARNING: cannot find daemon state file "{state0_file}"')
             print(f'- WARNING: daemon state corrupted: suggest you do "kill {pid}"')
+            sys.stdout.flush()
             return
 
         state0_args = gd.load_args(state0_file)
@@ -312,10 +286,10 @@ class GarnetDaemon:
         print(f'- want DONE signal from job > {prev_job}')
         print(f'- found DONE signal for job {done_job}')
         if done_job <= prev_job:
-            print(f'- KEEP WAITING (recurse on wait_daemon())')
+            print(f'- KEEP WAITING (recurse on wait_daemon())', flush=True)
             return wait_daemon(args, prev_job)
 
-        print('\n--- DAEMON READY, continuing...')
+        print('\n--- DAEMON READY, continuing...', flush=True)
         return done_job
 
 

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -235,23 +235,57 @@ class GarnetDaemon:
         time.sleep(2)
         while True:
             if GarnetDaemon.status(args) == 'ready': break
+
+            # Timeout after 2 hours or 7200 seconds, yes?
             # Each set of waits is broken down into groups b/c of stdout tees and lesses and flushes and such
 
-            print(f'- daemon busy, will retry once per second for twenty seconds')
-            print(f'- (in four groups of five seconds each)')
-            if gd.check_daemon(20,   1, ngroups=4): break
+#             print(f'- daemon busy, will do 1 sec/retry for 100 seconds')
+#             # 300 tries, 1 sec/try, 5 groups (1 minute/line)
+#             if gd.check_daemon(300,   1, ngroups=5): break  # 5 min @ 1 sec/dot
+# 
+#             if gd.check_daemon(1200,  2, ngroups=40): break # 20 min @ 2 sec/dot
 
-            print(f'- daemon still busy, will do twenty more tries @ 2 sec each')
-            if gd.check_daemon(20,   2, ngroups=4): break
+            print(f'- daemon busy    0 sec so far, will do  1 sec/retry for  360 seconds') #  6 min
+            if gd.check_daemon(sec_per_dot=1, nsec=360, dots_per_line=30); break           # 12 lines
+            # ---------------------------------------------------------------------------------------
 
-            print(f'- 20 tries @ one minute per try:')  # Total 21 min wait
-            if gd.check_daemon(20,  60, ngroups=4): break
+            print(f'- daemon busy  360 sec so far, will do  4 sec/retry for 1440 seconds') # 24 min
+            if gd.check_daemon(sec_per_dot=4, nsec=1440, dots_per_line=30); break          # 12 lines
+            # ---------------------------------------------------------------------------------------
 
-            print(f'- 20 tries @ two minutes per try:') # Total 1 hr wait
-            if gd.check_daemon(20, 120, ngroups=2): break
 
-            print(f'- 12 tries @ 5 min / try"') # Total 2 hr wait
-            if gd.check_daemon(12, 300, ngroups=3): break
+            print(f'- daemon busy 1800 sec so far, will do 20 sec/retry for 1800 seconds') # 30 min
+            if gd.check_daemon(sec_per_dot=20, nsec=1800, dots_per_line=10); break         #  9 lines?
+            # ---------------------------------------------------------------------------------------
+
+            print(f'- daemon busy 3600 sec so far, will do 60 sec/retry for 3600 seconds') # 60 min
+            if gd.check_daemon(sec_per_dot=60, nsec=3600, dots_per_line=10); break         # 6 lines?
+
+
+
+
+
+
+#             print(f'- daemon busy, will retry once per 4-secs for twenty minutes')
+#             if gd.check_daemon(2400,  4, ngroups=40): break # 40 min @ 4 sec/dot
+# 
+# #             # Each set of waits is broken down into groups b/c of stdout tees and lesses and flushes and such
+# # 
+# #             print(f'- daemon busy, will retry once per second for twenty seconds')
+# #             print(f'- (in four groups of five seconds each)')
+# #             if gd.check_daemon(20,   1, ngroups=4): break
+# # 
+# #             print(f'- daemon still busy, will do twenty more tries @ 2 sec each')
+# #             if gd.check_daemon(20,   2, ngroups=4): break
+# # 
+# #             print(f'- 20 tries @ one minute per try:')  # Total 21 min wait
+# #             if gd.check_daemon(20,  60, ngroups=4): break
+# # 
+# #             print(f'- 20 tries @ two minutes per try:') # Total 1 hr wait
+# #             if gd.check_daemon(20, 120, ngroups=2): break
+# 
+#             print(f'- 12 tries @ 5 min / try"') # Total 2 hr wait
+#             if gd.check_daemon(12, 300, ngroups=3): break
 
             # sys.stderr.write('ERROR Timeout waiting for daemon. Did you forget to launch it?\n')
             sys.stderr.write('ERROR Timeout after two hours waiting for daemon.\n')
@@ -354,13 +388,24 @@ class GarnetDaemon:
         print('', flush=True)
         return False
 
-    def check_daemon(ntries, secs_per_try, ngroups=1):
+    def check_daemon(sec_per_dot, nsec, dots_per_line):
         errmsg = f'\nERROR there is no daemon, did you forget to launch it?'
         assert GarnetDaemon.daemon_exists(), errmsg
-        tries_per_group = int(ntries/ngroups)
-        for g in range(ngroups):
-            if GarnetDaemon.wait_stage(secs_per_try, tries_per_group): return True
+        # -----------------------------------------------------------------------
+        total_dots = int(nsec / secs_per_dot)
+        nlines     = int(total_dots / dots_per_line)
+        # -----------------------------------------------------------------------
+        for g in range(nlines):
+            if GarnetDaemon.wait_stage(sec_per_dot, dots_per_line): return True
         return False
+
+#     def check_daemon(ntries, secs_per_try, ngroups=1):
+#         errmsg = f'\nERROR there is no daemon, did you forget to launch it?'
+#         assert GarnetDaemon.daemon_exists(), errmsg
+#         tries_per_group = int(ntries/ngroups)
+#         for g in range(ngroups):
+#             if GarnetDaemon.wait_stage(secs_per_try, tries_per_group): return True
+#         return False
 
     def die_if_daemon_exists():
         '''If existing daemon is found, issue an error message and die'''

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -272,7 +272,11 @@ class GarnetDaemon:
 
     def wait_daemon(args, prev_job=-1):
         '''Check daemon status, do not continue until/unless daemon exists AND IS READY'''
-        print(f'\n--- DAEMON WAIT - wait for daemon to finish job > {prev_job}')
+        if prev_job == -1:
+            print(f'\n--- DAEMON WAIT - wait for daemon ready', flush=True)
+        else:
+            print(f'\n--- DAEMON WAIT - wait for daemon to finish job > {prev_job}', flush=True)
+
         gd = GarnetDaemon; gd.args = args
         time.sleep(2)
         while True:

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -454,39 +454,6 @@ class GarnetDaemon:
 
     # Stop, but do not kill, pid. Can continue again w "sigcont"
     def sigstop(pid=None, dbg=1):
-
-
-#         import getpipes    # FIXME need a better name than "getpipes" :(
-#         procs = getpipes.find_proc_stop_order()
-#         if dbg:
-#             print(f'\nI think I found the procs to STOP, in this order:')
-#             print(f'  {procs}')
-#             sys.stdout.flush()
-#         
-# # Oops one of theseis the pytest program maybe?
-# #      [2530480, 2530481, 2530484]
-# # 
-# #  % ps
-# #     PID TTY          TIME CMD
-# #   25833 pts/2    00:00:03 bash
-# # 2530481 pts/2    00:00:00 tee
-# # 2530484 pts/2    00:00:00 python3
-# # 2530733 pts/2    00:00:00 ps
-# 
-#         procs.remove(min(procs))
-#         print(f'\nOops no, take out pytest, new order is maybe:\n')
-#         print(f'  {procs}')
-#         sys.stdout.flush()
-#         
-#         subprocess.run('ps -o pid,stat,tty,comm'.split()); sys.stdout.flush()
-# 
-# #         for p in procs:
-# #             print(f'Want to stop: {p}\n\n', flush=True)
-# # 
-# #             print(f'\nstopping {p}\n\n', flush=True)
-# #             os.kill(p, signal.SIGSTOP)
-# #         return
-
         if not pid: pid = GarnetDaemon.retrieve_pid()
         
         # print(f'\nstopping final {pid}\n\n', flush=True)
@@ -495,10 +462,8 @@ class GarnetDaemon:
         os.kill(int(pid), signal.SIGSTOP)
         # Okay but hold on suppose it takes a second to actually STOP!!???
         import time
-        time.sleep(10)
-
-
-
+#         time.sleep(10)
+        time.sleep(1)
 
     # Send a "CONTinue" signal to a process
     def sigcont(pid=None, dbg=1):

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -369,15 +369,6 @@ class GarnetDaemon:
             if GarnetDaemon.wait_stage(sec_per_dot, dots_per_line): return True
         return False
 
-    def check_daemon_old(ntries, secs_per_try, ngroups=1):
-        print('yoo hoo this is check_daemon', flush=True)
-        errmsg = f'\nERROR there is no daemon, did you forget to launch it?'
-        assert GarnetDaemon.daemon_exists(), errmsg
-        tries_per_group = int(ntries/ngroups)
-        for g in range(ngroups):
-            if GarnetDaemon.wait_stage(secs_per_try, tries_per_group): return True
-        return False
-
     def die_if_daemon_exists():
         '''If existing daemon is found, issue an error message and die'''
         if GarnetDaemon.daemon_exists():

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -239,53 +239,21 @@ class GarnetDaemon:
             # Timeout after 2 hours or 7200 seconds, yes?
             # Each set of waits is broken down into groups b/c of stdout tees and lesses and flushes and such
 
-#             print(f'- daemon busy, will do 1 sec/retry for 100 seconds')
-#             # 300 tries, 1 sec/try, 5 groups (1 minute/line)
-#             if gd.check_daemon(300,   1, ngroups=5): break  # 5 min @ 1 sec/dot
-# 
-#             if gd.check_daemon(1200,  2, ngroups=40): break # 20 min @ 2 sec/dot
-
             print(f'- daemon busy    0 sec so far, will do  1 sec/retry for  360 seconds') #  6 min
-            if gd.check_daemon(sec_per_dot=1, nsec=360, dots_per_line=30); break           # 12 lines
+            if gd.check_daemon(sec_per_dot=1, nsec=360, dots_per_line=30): break           # 12 lines
             # ---------------------------------------------------------------------------------------
 
             print(f'- daemon busy  360 sec so far, will do  4 sec/retry for 1440 seconds') # 24 min
-            if gd.check_daemon(sec_per_dot=4, nsec=1440, dots_per_line=30); break          # 12 lines
+            if gd.check_daemon(sec_per_dot=4, nsec=1440, dots_per_line=30): break          # 12 lines
             # ---------------------------------------------------------------------------------------
 
 
             print(f'- daemon busy 1800 sec so far, will do 20 sec/retry for 1800 seconds') # 30 min
-            if gd.check_daemon(sec_per_dot=20, nsec=1800, dots_per_line=10); break         #  9 lines?
+            if gd.check_daemon(sec_per_dot=20, nsec=1800, dots_per_line=10): break         #  9 lines?
             # ---------------------------------------------------------------------------------------
 
             print(f'- daemon busy 3600 sec so far, will do 60 sec/retry for 3600 seconds') # 60 min
-            if gd.check_daemon(sec_per_dot=60, nsec=3600, dots_per_line=10); break         # 6 lines?
-
-
-
-
-
-
-#             print(f'- daemon busy, will retry once per 4-secs for twenty minutes')
-#             if gd.check_daemon(2400,  4, ngroups=40): break # 40 min @ 4 sec/dot
-# 
-# #             # Each set of waits is broken down into groups b/c of stdout tees and lesses and flushes and such
-# # 
-# #             print(f'- daemon busy, will retry once per second for twenty seconds')
-# #             print(f'- (in four groups of five seconds each)')
-# #             if gd.check_daemon(20,   1, ngroups=4): break
-# # 
-# #             print(f'- daemon still busy, will do twenty more tries @ 2 sec each')
-# #             if gd.check_daemon(20,   2, ngroups=4): break
-# # 
-# #             print(f'- 20 tries @ one minute per try:')  # Total 21 min wait
-# #             if gd.check_daemon(20,  60, ngroups=4): break
-# # 
-# #             print(f'- 20 tries @ two minutes per try:') # Total 1 hr wait
-# #             if gd.check_daemon(20, 120, ngroups=2): break
-# 
-#             print(f'- 12 tries @ 5 min / try"') # Total 2 hr wait
-#             if gd.check_daemon(12, 300, ngroups=3): break
+            if gd.check_daemon(sec_per_dot=60, nsec=3600, dots_per_line=10): break         # 6 lines?
 
             # sys.stderr.write('ERROR Timeout waiting for daemon. Did you forget to launch it?\n')
             sys.stderr.write('ERROR Timeout after two hours waiting for daemon.\n')
@@ -389,23 +357,26 @@ class GarnetDaemon:
         return False
 
     def check_daemon(sec_per_dot, nsec, dots_per_line):
+        print('yoo hoo this is check_daemon_new', flush=True)
         errmsg = f'\nERROR there is no daemon, did you forget to launch it?'
         assert GarnetDaemon.daemon_exists(), errmsg
         # -----------------------------------------------------------------------
-        total_dots = int(nsec / secs_per_dot)
+        total_dots = int(nsec / sec_per_dot)
         nlines     = int(total_dots / dots_per_line)
         # -----------------------------------------------------------------------
+        print(f'nlines={nlines}, sec_per_dot={sec_per_dot}, dots_per_line={dots_per_line}', flush=True)
         for g in range(nlines):
             if GarnetDaemon.wait_stage(sec_per_dot, dots_per_line): return True
         return False
 
-#     def check_daemon(ntries, secs_per_try, ngroups=1):
-#         errmsg = f'\nERROR there is no daemon, did you forget to launch it?'
-#         assert GarnetDaemon.daemon_exists(), errmsg
-#         tries_per_group = int(ntries/ngroups)
-#         for g in range(ngroups):
-#             if GarnetDaemon.wait_stage(secs_per_try, tries_per_group): return True
-#         return False
+    def check_daemon_old(ntries, secs_per_try, ngroups=1):
+        print('yoo hoo this is check_daemon', flush=True)
+        errmsg = f'\nERROR there is no daemon, did you forget to launch it?'
+        assert GarnetDaemon.daemon_exists(), errmsg
+        tries_per_group = int(ntries/ngroups)
+        for g in range(ngroups):
+            if GarnetDaemon.wait_stage(secs_per_try, tries_per_group): return True
+        return False
 
     def die_if_daemon_exists():
         '''If existing daemon is found, issue an error message and die'''

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -142,7 +142,14 @@ class GarnetDaemon:
         # On CONT, register status and load new args from 'reload' file
         print(f'\n\n--- DAEMON RESUMES')
         GarnetDaemon.put_status('busy')
-        return gd.load_args(dbg=1)
+
+        new_args = gd.load_args(dbg=1)
+        new = new_args.__dict__; old = args.__dict__
+        # print(f'Before merge: new_args[app]={new["app"]}, old_args[app]={old["app"]}')
+        # Update old dict with new info
+        old.update(new)
+        # print(f'After merge:  new_args[app]={new["app"]}, old_args[app]={old["app"]}')
+        return Namespace(**old)
 
     # ------------------------------------------------------------------------
     # "Private" methods for processing individual daemon commands:

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -158,7 +158,7 @@ class GarnetDaemon:
             newval = new_env[i]
             oldval = os.environ[i]  if i in os.environ else "NULL"
             if oldval != newval:
-                print(f'- daemon.py load_args() env var "{i}" :: "{oldval}" => "{newval}"', flush=True)
+                print(f'- daemon.py load_args env["{i}"]="{newval}" (was "{oldval}")', flush=True)
                 os.environ[i] = newval
 
         if dbg: s = dict(sorted(new.items()))

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -128,7 +128,6 @@ class GarnetDaemon:
         # Okay but somebody is going to send a CONT as soon as they see "READY" right?
         # what if the CONT shows up BEFORE the stop?
 
-
         # Register status; stop and wait for CONT signal from client
         GarnetDaemon.put_status('ready')
         gd.sigstop()
@@ -143,12 +142,14 @@ class GarnetDaemon:
         print(f'\n\n--- DAEMON RESUMES')
         GarnetDaemon.put_status('busy')
 
-        new_args = gd.load_args(dbg=1)
-        new = new_args.__dict__; old = args.__dict__
-        # print(f'Before merge: new_args[app]={new["app"]}, old_args[app]={old["app"]}')
-        # Update old dict with new info
+        # Fetch new args, use them to update old args
+        new_args = gd.load_args(dbg=0)
+        old = args.__dict__; new = new_args.__dict__
         old.update(new)
-        # print(f'After merge:  new_args[app]={new["app"]}, old_args[app]={old["app"]}')
+
+        if dbg: s = dict(sorted(new.items()))
+        if dbg: print(f"- loaded args {json.dumps(s, indent=4)}")
+
         return Namespace(**old)
 
     # ------------------------------------------------------------------------

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -21,10 +21,12 @@ from argparse import Namespace
 
 GarnetDaemon_HELP = '''
 DESCRIPTION:
-  garnet.py can run as a daemon to save you time when generating bitstreams
-  for multiple apps using the same garnet circuit. Use the "launch" command
-  to build a circuit and keep state in the background. The "use-daemon" command
-  reuses the background state to more quickly do pnr and bitstream generation.
+
+  garnet.py can run as a daemon to save you time when generating
+  bitstreams for multiple apps using the same garnet circuit. Use
+  the "launch" command to build a circuit and keep state in the
+  background. The "use-daemon" command reuses the background state
+  to more quickly do pnr and bitstream generation.
 
       --daemon launch -> process args and launch a daemon
       --daemon use    -> use existing daemon to process args

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -279,7 +279,7 @@ class GarnetDaemon:
         'Save current state (args) to arg-save (reload) file'
 
         # Cannot save glb_param and pe_fc to a file b/c they are "unserializable"
-        save_the_unsaveable(args)
+        GarnetDaemon.save_the_unsaveable(args)
 
         # Save args as a sorted dict
         argdic = vars(args)

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -27,20 +27,24 @@ DESCRIPTION:
   reuses the background state to more quickly do pnr and bitstream generation.
 
       --daemon launch -> process args and launch a daemon
-      --daemon use    -> use existing daemon to process 
+      --daemon use    -> use existing daemon to process args
+      --daemon wait   -> wait for daemon to finish processing args
       --daemon kill   -> kill the daemon
       --daemon status -> print daemon status and exit
       --daemon force  -> same as kill + launch
 
 EXAMPLE:
-    garnet.py --width 4 --height 2 --daemon launch
-    garnet.py <app1-args> --daemon use
-    garnet.py <app2-args> --daemon use
+    garnet.py --daemon kill
+    garnet.py --width 28 --height 16 --verilog ...
+    garnet.py <app1-pnr-args> --daemon launch
+    garnet.py <app2-pnr-args> --daemon use
+    garnet.py <app3-pnr-args> --daemon use
+    garnet.py <app4-pnr-args> --daemon use
+    ...
     garnet.py --daemon kill
 
 NOTE! 'daemon.use' width and height must match 'daemon.launch'!!!
-
-See README.txt for more info
+NOTE 2: cannot use the same daemon for verilog *and* pnr (not sure why).
 '''
 
 class GarnetDaemon:
@@ -82,7 +86,7 @@ class GarnetDaemon:
             args.daemon = "launch"
 
         if args.daemon == "help":
-            GarnetDaemon.help(args); exit()
+            GarnetDaemon.help(); exit()
 
         elif args.daemon == "use":
             print("hello here i am doing a 'daemon use'", flush=True)

--- a/daemon/pnr.py
+++ b/daemon/pnr.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+import os
+import subprocess
+import sys
+import copy
+import json
+
+def add_subparser(subparser):
+    parser = subparser.add_parser(Path(__file__).stem, aliases=['pipeline'], description='AHA flow command for pipelining a mapped halide application, doing place and route, and generating a bitstream to configure the CGRA')
+    parser.add_argument("app", help="Required parameter specifying which halide application to compile")
+    parser.add_argument("--base", default=None, type=str, help="Optional parameter for specifying a base directory of an app")
+    parser.add_argument("--no-parse", action="store_true", help="Skips the parse_design_meta.py script")
+    parser.add_argument("--log", action="store_true", help="Creates a log for command output")
+    parser.add_argument("--layer", type=str, help="Specifies layer parameters if running 'aha pipeline apps/resnet_output_stationary', options for LAYER are in application_parameters.json")
+    parser.add_argument("--env-parameters", default="", type=str, help="Specifies which environmental parameters to use from application_parameters.json, options for ENV_PARAMETERS are in application_parameters.json")
+    parser.set_defaults(dispatch=dispatch)
+
+
+def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log", do_cmd=subprocess.check_call):
+    if do_cmd == subprocess.check_call:
+        print('--- PNR/scl: check_call')
+    elif do_cmd == subprocess.Popen:
+        print('--- PNR/scl: POPEN')
+    if log:
+        print("[log] Command  : {}".format(" ".join(cmd)))
+        print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
+        with open(log_file_path, "a") as flog:
+            do_cmd(
+                cmd,
+                cwd=cwd,
+                env=env,
+                stdout=flog,
+                stderr=flog
+            )
+        print("done")
+    else:
+        do_cmd(
+            cmd,
+            env=env,
+            cwd=cwd
+        )
+
+
+def load_environmental_vars(env, app, layer=None, env_parameters=None):
+    filename = os.path.realpath(os.path.dirname(__file__)) + "/application_parameters.json"
+    new_env_vars = {}
+    app_name = str(app) if layer is None else str(layer)
+
+    if not os.path.exists(filename):
+        print(f"{filename} not found, not setting environmental variables")
+    else:
+        fin = open(filename, 'r')
+        env_vars_fin = json.load(fin)
+        if "global_parameters" in env_vars_fin:
+            if env_parameters is None or str(env_parameters) not in env_vars_fin["global_parameters"]:
+                new_env_vars.update(env_vars_fin["global_parameters"]["default"])
+            else:
+                new_env_vars.update(env_vars_fin["global_parameters"][str(env_parameters)])
+
+        if app_name in env_vars_fin:
+            if env_parameters is None or str(env_parameters) not in env_vars_fin[app_name]:
+                new_env_vars.update(env_vars_fin[app_name]["default"])
+            else:
+                new_env_vars.update(env_vars_fin[app_name][str(env_parameters)])
+
+    for n, v in new_env_vars.items():
+        env[n] = v
+
+
+
+def dispatch(args, extra_args=None):
+    args.app = Path(args.app)
+    env = copy.deepcopy(os.environ)
+    env["COREIR_DIR"] = str(args.aha_dir / "coreir")
+    env["COREIR_PATH"] = str(args.aha_dir / "coreir")
+    env["LAKE_PATH"] = str(args.aha_dir / "lake")
+    env["CLOCKWORK_PATH"] = str(args.aha_dir / "clockwork")
+
+    load_environmental_vars(env, args.app, layer=args.layer, env_parameters=args.env_parameters)
+
+    if args.base is None:
+        app_dir = Path(
+            f"{args.aha_dir}/Halide-to-Hardware/apps/hardware_benchmarks/{args.app}"
+        )
+    else:
+        app_dir = (Path(args.base) / args.app).resolve()
+    
+    if os.path.exists(str(app_dir / "bin/input.raw")):
+        ext = ".raw"
+    else:
+        ext = ".pgm"
+
+    log_path = app_dir / Path("log")
+    log_file_path = log_path / Path("aha_pnr.log")
+
+    if args.log:
+        subprocess.check_call(["mkdir", "-p", log_path])
+        subprocess.check_call(["rm", "-f", log_file_path])
+
+    print (f"Using testbench file extension: {ext}.")
+
+    map_args = [
+        "--no-pd",
+        "--interconnect-only",
+        "--input-app",
+        str(app_dir / "bin/design_top.json"),
+        "--input-file",
+        str(app_dir / f"bin/input{ext}"),
+        "--output-file",
+        str(app_dir / f"bin/{args.app.name}.bs"),
+        "--gold-file",
+        str(app_dir / f"bin/gold{ext}"),
+        "--input-broadcast-branch-factor", "2",
+        "--input-broadcast-max-leaves", "16",
+        "--rv",
+        "--sparse-cgra",
+        "--sparse-cgra-combined",
+        "--pipeline-pnr"
+    ]
+
+    # When this is called with --daemon use....then it exits before PNR is done...
+
+    print(f'--- PNR: extra_args={extra_args}')
+    if '--daemon' in extra_args and not 'use' in extra_args:
+        print('--- PNR: POPEN')
+        do_cmd = subprocess.Popen
+    else:
+        print('--- PNR: CHECK_CALL')
+        do_cmd = subprocess.check_call
+
+    subprocess_call_log (
+        cmd=[sys.executable, "garnet.py"] + map_args + extra_args,
+        cwd=args.aha_dir / "garnet",
+        log=args.log,
+        log_file_path=log_file_path,
+        env=env,
+        do_cmd=do_cmd,
+    )
+    print('--- PNR: FINISHED GARNET ALL')
+    
+    # When thing above is called with --daemon use....then it exits before PNR is done...
+    # And the rest of this (below) goes off prematurely...
+
+    # if '--daemon' in extra_args and 'use' in extra_args:
+    if '--daemon' in extra_args:
+        print(f'--- BEGIN DAEMON FOUND in pnr; waiting now...')
+        subprocess.run([sys.executable, 'garnet.py', '--daemon', 'wait'], cwd='/aha/garnet')
+
+    # generate meta_data.json file
+    if not args.no_parse:
+        if not str(args.app).startswith("handcrafted"):
+            # get the full path of the app
+            arg_path = f"{args.aha_dir}/Halide-to-Hardware/apps/hardware_benchmarks/{args.app}"
+            subprocess_call_log (
+                cmd=[sys.executable,
+                 f"{args.aha_dir}/Halide-to-Hardware/apps/hardware_benchmarks/hw_support/parse_design_meta.py",
+                 "bin/design_meta_halide.json",
+                 "--top", "bin/design_top.json",
+                 "--place", "bin/design.place"],
+                cwd=arg_path,
+                log=args.log,
+                log_file_path=log_file_path,
+                env=env
+            )
+
+    print('--- DONE PNR'); sys.stdout.flush(); sys.stderr.flush(); sys.stdin.flush()

--- a/daemon/pnr.py
+++ b/daemon/pnr.py
@@ -109,7 +109,7 @@ def dispatch(args, extra_args=None):
         "--gold-file",
         str(app_dir / f"bin/gold{ext}"),
         "--input-broadcast-branch-factor", "2",
-        "--input-broadcast-max-leaves", "16",
+        "--input-broadcast-max-leaves", "4",
         "--rv",
         "--sparse-cgra",
         "--sparse-cgra-combined",
@@ -130,6 +130,11 @@ def dispatch(args, extra_args=None):
         env=env,
         do_cmd=do_cmd,
     )
+
+    # FIXME might need a brief sleep here to prevent
+    # wait (below) from getting a "ready" too soon, get it?
+    # BETTER figure out how to prevent a race condition?
+    # does load-and-go supposed to do that???
 
     # When running as a daemon, this will tell us when the PNR is done
     if '--daemon' in extra_args:

--- a/daemon/pnr.py
+++ b/daemon/pnr.py
@@ -17,10 +17,8 @@ def add_subparser(subparser):
 
 
 def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log", do_cmd=subprocess.check_call):
-    if do_cmd == subprocess.check_call:
-        print('--- PNR/scl: check_call')
-    elif do_cmd == subprocess.Popen:
-        print('--- PNR/scl: POPEN')
+    if do_cmd == subprocess.check_call: print('--- PNR/scl: check_call')
+    elif do_cmd == subprocess.Popen:    print('--- PNR/scl: POPEN')
     if log:
         print("[log] Command  : {}".format(" ".join(cmd)))
         print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
@@ -118,15 +116,11 @@ def dispatch(args, extra_args=None):
         "--pipeline-pnr"
     ]
 
-    # When this is called with --daemon use....then it exits before PNR is done...
-
-    print(f'--- PNR: extra_args={extra_args}')
+    # When running as daemon, must use non-blocking "Popen" and not "check_call"
     if '--daemon' in extra_args and not 'use' in extra_args:
-        print('--- PNR: POPEN')
-        do_cmd = subprocess.Popen
+        print('--- PNR: POPEN');      do_cmd = subprocess.Popen
     else:
-        print('--- PNR: CHECK_CALL')
-        do_cmd = subprocess.check_call
+        print('--- PNR: CHECK_CALL'); do_cmd = subprocess.check_call
 
     subprocess_call_log (
         cmd=[sys.executable, "garnet.py"] + map_args + extra_args,
@@ -136,12 +130,8 @@ def dispatch(args, extra_args=None):
         env=env,
         do_cmd=do_cmd,
     )
-    print('--- PNR: FINISHED GARNET ALL')
-    
-    # When thing above is called with --daemon use....then it exits before PNR is done...
-    # And the rest of this (below) goes off prematurely...
 
-    # if '--daemon' in extra_args and 'use' in extra_args:
+    # When running as a daemon, this will tell us when the PNR is done
     if '--daemon' in extra_args:
         print(f'--- BEGIN DAEMON FOUND in pnr; waiting now...')
         subprocess.run([sys.executable, 'garnet.py', '--daemon', 'wait'], cwd='/aha/garnet')

--- a/daemon/pnr.py
+++ b/daemon/pnr.py
@@ -17,8 +17,8 @@ def add_subparser(subparser):
 
 
 def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log", do_cmd=subprocess.check_call):
-    if do_cmd == subprocess.check_call: print('--- PNR/scl: check_call (run) garnet.py')
-    elif do_cmd == subprocess.Popen:    print('--- PNR/scl: Popen (background) garnet.py')
+    # if do_cmd == subprocess.check_call: print('--- PNR/scl: check_call (run) garnet.py')
+    # elif do_cmd == subprocess.Popen:    print('--- PNR/scl: Popen (background) garnet.py')
     if log:
         print("[log] Command  : {}".format(" ".join(cmd)))
         print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
@@ -117,10 +117,22 @@ def dispatch(args, extra_args=None):
     ]
 
     # When running as daemon, must use non-blocking "Popen" and not "check_call"
-    if '--daemon' in extra_args and not 'use' in extra_args:
-        do_cmd = subprocess.Popen
-    else:
-        do_cmd = subprocess.check_call
+    # if '--daemon' in extra_args and not 'use' in extra_args:
+
+    launch_daemon = False
+    do_cmd = subprocess.check_call
+    if '--daemon' in extra_args:
+        cmd = [sys.executable, "garnet.py", "--daemon", "status"]
+        p = subprocess.run(cmd, text=True, cwd=args.aha_dir / "garnet",
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # print(f"--- daemon status returned: {p.stdout}", flush=True)
+
+        launch_daemon = 'no daemon found' in p.stdout
+        if launch_daemon:
+            print(f"--- found no daemon, setting do_cmd to Popen", flush=True)
+            do_cmd = subprocess.Popen
+        else:
+            print(f"--- found the daemon, leaving do_cmd alone", flush=True)
 
     subprocess_call_log (
         cmd=[sys.executable, "garnet.py"] + map_args + extra_args,
@@ -131,14 +143,9 @@ def dispatch(args, extra_args=None):
         do_cmd=do_cmd,
     )
 
-    # FIXME might need a brief sleep here to prevent
-    # wait (below) from getting a "ready" too soon, get it?
-    # BETTER figure out how to prevent a race condition?
-    # does load-and-go supposed to do that???
-
-    # When running as a daemon, this will tell us when the PNR is done
-    if '--daemon' in extra_args:
-        print(f'--- BEGIN DAEMON FOUND in pnr; waiting now...')
+    # When launching a new daemon, this will tell us when the PNR is done
+    if launch_daemon:
+        print(f'--- BEGIN LAUNCHED NEW DAEMON in pnr; waiting now...')
         subprocess.run([sys.executable, 'garnet.py', '--daemon', 'wait'], cwd='/aha/garnet')
 
     # generate meta_data.json file

--- a/daemon/pnr.py
+++ b/daemon/pnr.py
@@ -17,8 +17,8 @@ def add_subparser(subparser):
 
 
 def subprocess_call_log(cmd, cwd, env=None, log=False, log_file_path="log.log", do_cmd=subprocess.check_call):
-    if do_cmd == subprocess.check_call: print('--- PNR/scl: check_call')
-    elif do_cmd == subprocess.Popen:    print('--- PNR/scl: POPEN')
+    if do_cmd == subprocess.check_call: print('--- PNR/scl: check_call (run) garnet.py')
+    elif do_cmd == subprocess.Popen:    print('--- PNR/scl: Popen (background) garnet.py')
     if log:
         print("[log] Command  : {}".format(" ".join(cmd)))
         print("[log] Log Path : {}".format(log_file_path), end="  ...", flush=True)
@@ -118,9 +118,9 @@ def dispatch(args, extra_args=None):
 
     # When running as daemon, must use non-blocking "Popen" and not "check_call"
     if '--daemon' in extra_args and not 'use' in extra_args:
-        print('--- PNR: POPEN');      do_cmd = subprocess.Popen
+        do_cmd = subprocess.Popen
     else:
-        print('--- PNR: CHECK_CALL'); do_cmd = subprocess.check_call
+        do_cmd = subprocess.check_call
 
     subprocess_call_log (
         cmd=[sys.executable, "garnet.py"] + map_args + extra_args,

--- a/daemon/test_daemon.py
+++ b/daemon/test_daemon.py
@@ -98,20 +98,21 @@ def mydaemon():
 
     # Daemonology; TODO this could be a separate method call
     while True:
-        if not args.daemon: break
-
-        # WAIT for a client to send new args for processing
-        print('\nLOOPING')
-        args = GarnetDaemon.loop(args)
-
-        childpid = os.fork()
+        childpid = os.fork() # Fork a child
         if childpid > 0:
-            pid, status = os.waitpid(childpid, 0)
+            pid, status = os.waitpid(childpid, 0) # Wait for child to finish
             print(f'Child process {childpid} finished with exit status {status}')
             assert pid == childpid # Right???
+
+            # IF we're not running as a daemon, we're done here.
+            if not args.daemon: break
+
+            # ELSE parent (daemon) WAITs for a client to send new args for processing
+            print('\nLOOPING')
+            args = GarnetDaemon.loop(args)
             continue
 
-        # Child process does this
+        # Forked child process does the work, then exits
         print(f'- loaded new args {args} i guess?')
         print(f'- gonna build a: {args.animal} grid')
         print(f' -updated/used the grid')

--- a/daemon/test_daemon.py
+++ b/daemon/test_daemon.py
@@ -205,6 +205,7 @@ def test_daemon_use():
     p2 = subprocess.run(f'{DAEMON} use --animal foxy'.split(), text=True, capture_output=True)
     sys.stdout.flush()
     min_sleep()
+    p3 = subprocess.run(f'{DAEMON} wait'.split(), text=True, capture_output=True)
 
     print('\nKILL the daemon\n')
     subprocess.run(f'{DAEMON} kill'.split())
@@ -410,6 +411,8 @@ def test_cleanup():    announce_unit(': TBD')
 def test_wait_stage(): announce_unit(': TBD')
 def test_check_daemon(): announce_unit(': TBD')
 
+def test_save_the_unsaveable():    announce_unit(': TBD')
+
 ########################################################################
 # Helper functions
 
@@ -440,6 +443,9 @@ def try_animal(animal, tmpfile):
     print(f'- sacrificing {animal} to daemon', flush=True)
     time.sleep(2)    # Give it a second to process, dude
 
+    # Wait for daemon to finish using the animal
+    p = subprocess.run(f'{DAEMON} wait'.split())
+
     daemon_out = catnew(tmpfile, reset=False)
     print_w_prefix('DAEMON: ', daemon_out)
 
@@ -449,16 +455,13 @@ def try_animal(animal, tmpfile):
 def expect(cmd, expect):
     '''Run <cmd> and display output. Return True if output contains <spect> string'''
     # TODO for extra credit maybe <expect> could be a regex omg
-    p = subprocess.Popen(
+    # print('launching expect process')
+    p = subprocess.run(
         cmd.split(), text=True, 
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     found = False
-    while p.poll() is None:
-        out = p.stdout.readline()
-        sys.stdout.write(out); sys.stdout.flush()
-        if expect in out: found = True
-
+    if expect in p.stdout: found = True
     return found
 
 def kill_existing_daemon():

--- a/daemon/test_daemon.py
+++ b/daemon/test_daemon.py
@@ -476,7 +476,6 @@ def expect(cmd, expect):
     if expect in p.stdout: return True
     else:                  return False
 
-
 def kill_existing_daemon():
     print(f"Kill existing daemon (p.stdout should say 'already dead')",flush=True)
     p = subprocess.run(f'{DAEMON} kill'.split())

--- a/daemon/test_daemon.py
+++ b/daemon/test_daemon.py
@@ -199,9 +199,6 @@ def test_daemon_use():
     # TODO maybe use expect() instead???
 
     p2 = subprocess.run(f'{DAEMON} use --animal foxy'.split(), text=True, capture_output=True)
-    sys.stdout.flush()
-    min_sleep()
-    p3 = subprocess.run(f'{DAEMON} wait'.split(), text=True, capture_output=True)
 
     print('\nKILL the daemon\n')
     subprocess.run(f'{DAEMON} kill'.split())
@@ -454,10 +451,6 @@ def print_w_prefix(prefix, text):
 def try_animal(animal, tmpfile):
     assert expect(f'{DAEMON} use --animal {animal}', 'sending CONT')
     print(f'- sacrificing {animal} to daemon', flush=True)
-    time.sleep(2)    # Give it a second to process, dude
-
-    # Wait for daemon to finish using the animal
-    p = subprocess.run(f'{DAEMON} wait'.split())
 
     # Show what happened since last time daemon was used
     daemon_out = catnew(tmpfile, reset=False)
@@ -473,9 +466,16 @@ def expect(cmd, expect):
         cmd.split(), text=True, 
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-    found = False
-    if expect in p.stdout: found = True
-    return found
+    # Print stdout
+    print(f'({cmd}) ')
+    prefix='    '
+    print((prefix+p.stdout).replace('\n',f'\n{prefix}'), flush=True)
+    print('', flush=True)
+
+    # Did we get what we expected?
+    if expect in p.stdout: return True
+    else:                  return False
+
 
 def kill_existing_daemon():
     print(f"Kill existing daemon (p.stdout should say 'already dead')",flush=True)

--- a/daemon/test_daemon.py
+++ b/daemon/test_daemon.py
@@ -247,7 +247,7 @@ def test_help():
     print('------------------------------------------------------------------------')
     print("VISUAL CHECK: DOES THIS LOOK RIGHT TO YOU?")
     print('------------------------------------------------------------------------')
-    GarnetDaemon.help()
+    subprocess.run(f'{DAEMON} help'.split())
 
 ########################################################################
 # Unit tests (optional)

--- a/daemon/test_daemon.py
+++ b/daemon/test_daemon.py
@@ -214,6 +214,39 @@ def test_daemon_use():
     print('\nSecond assertion PASSED')
     # FIXME/TODO where is first assertion? what's going on here?
 
+def test_daemon_auto():
+    'Same as test_daemon_use except "auto" instead'
+    announce()
+    catnew_reset()
+
+    print('\nKILL any existing daemon\n')
+    subprocess.run(f'{DAEMON} kill'.split())
+
+    tmpfile = f'deleteme-GarnetDaemon.test_daemon_auto.{int(time.time())}'
+    force_launch_and_capture(tmpfile, cmd='auto')
+    verify_successful_build(tmpfile)  # (calls catnew)
+    print('\nFirst assertion PASSED')
+
+    p2 = subprocess.run(f'{DAEMON} auto --animal foxy'.split(), text=True, capture_output=True)
+    sys.stdout.flush()
+    min_sleep()
+    p3 = subprocess.run(f'{DAEMON} wait'.split(), text=True, capture_output=True)
+
+    print('\nKILL the daemon\n')
+    subprocess.run(f'{DAEMON} kill'.split())
+
+    print('\nWAKEUP and flush')
+    daemon_out = catnew(tmpfile)
+    print_w_prefix('DAEMON: ', daemon_out)
+    os.remove(tmpfile)
+    assert 'using animal: foxy' in daemon_out
+    print('\nSecond assertion PASSED')
+    # FIXME/TODO where is first assertion? what's going on here?
+
+
+
+
+
 def test_incompatible_daemon():
     'Launch a 7x13 daemon; try to use a 3x5 daemon; verify error'
     announce()

--- a/garnet.py
+++ b/garnet.py
@@ -890,6 +890,14 @@ def main():
             # ELSE parent (daemon) WAITs for a client to send new args for processing
             print('\nLOOPING')
             args = GarnetDaemon.loop(args, dbg=1)
+
+            argdic = vars(args)
+            sorted_argdic=dict(sorted(argdic.items()))
+            import json
+            print(f"- loaded args {json.dumps(sorted_argdic, indent=4)}")
+
+
+
             continue
 
         # Forked child process does the work, then exits

--- a/garnet.py
+++ b/garnet.py
@@ -13,17 +13,10 @@ import archipelago
 import archipelago.power
 import archipelago.io
 from lassen.sim import PE_fc as lassen_fc
-# from metamapper.coreir_mapper import Mapper # Not used??
-# from canal.global_signal import GlobalSignalWiring
 
 from daemon.daemon import GarnetDaemon
 
-# FIXME disperse this to where it needs to be...
-import metamapper.peak_util as putil
-from mapper.netlist_util import create_netlist_info, print_netlist_info
-from metamapper.coreir_mapper import Mapper
-from metamapper.map_design_top import map_design_top
-from metamapper.node import Nodes
+# from metamapper.coreir_mapper import Mapper # not used?
 
 # set the debug mode to false to speed up construction
 from gemstone.generator.generator import set_debug_mode
@@ -339,6 +332,7 @@ class Garnet(Generator):
         from metamapper.io_tiles import IO_fc, BitIO_fc
         import metamapper.peak_util as putil
         from mapper.netlist_util import create_netlist_info, print_netlist_info
+        from metamapper.node import Nodes
 
         app_dir = os.path.dirname(app)
 

--- a/garnet.py
+++ b/garnet.py
@@ -918,11 +918,17 @@ def main():
                         len(args.gold)   > 0 and \
                         len(args.output) > 0
 
+        # DEBUG info: args
         argdic = vars(args)
         sorted_argdic=dict(sorted(argdic.items()))
         sorted_argdic['glb_params'] = "UKNOWN"
         sorted_argdic['pe_fc'] = "UKNOWN"
         print(f"- BEGIN pre-pnr/bs args {json.dumps(sorted_argdic, indent=4)}")
+
+        # DEBUG info: env
+        envdic = dict(os.environ)
+        sorted_envdic=dict(sorted(envdic.items()))
+        print(f"- BEGIN pre-pnr/bs env {json.dumps(sorted_envdic, indent=4)}")
 
         do_pnr = app_specified and not args.virtualize
         if do_pnr:

--- a/garnet.py
+++ b/garnet.py
@@ -740,6 +740,7 @@ def parse_args():
     return args
 
 def build_verilog(args, garnet):
+    print('--- BEGIN build_verilog 743', flush=True)
     garnet_circ = garnet.circuit()
     magma.compile("garnet", garnet_circ, output="coreir-verilog",
                   coreir_libs={"float_CW"},
@@ -767,8 +768,11 @@ def build_verilog(args, garnet):
             gfd.writelines(lines_garnet)
             gfd.writelines(lines_pe)
 
+    print('--- BEGIN build_verilog 771', flush=True)
     garnet.create_stub()
+    print('--- BEGIN build_verilog 773', flush=True)
     if not args.interconnect_only:
+        print('--- BEGIN build_verilog 775', flush=True)
         garnet_home = os.getenv('GARNET_HOME')
         if not garnet_home:
             garnet_home = os.path.dirname(os.path.abspath(__file__))
@@ -783,6 +787,10 @@ def build_verilog(args, garnet):
         gen_rdl_header(top_name="glc",
                        rdl_file=os.path.join(garnet_home, "global_controller/systemRDL/rdl_models/glc.rdl.final"),
                        output_folder=os.path.join(garnet_home, "global_controller/header"))
+
+        print('--- BEGIN build_verilog 791', flush=True)
+
+    print('--- BEGIN build_verilog 793', flush=True)
 
 # FIXME/TODO send pnr, pnr_wrapper etc. to util/garnetPNR or some such
 # e.g. "import util.pnr then call util.pnr.{pnr,pnr_wrapper} etc. maybe
@@ -878,14 +886,20 @@ def main():
     if args.verilog:
         print("--- BEGIN verilog inside garnet", flush=True)
         build_verilog(args, garnet)
+        print("--- DONE verilog inside garnet", flush=True)
+    print("--- continuing", flush=True)
+    print(f"args.daemon={args.daemon}", flush=True)
 
     # USE GARNET
     import json # for debugging, maybe temporary
     while True:
-      if args.daemon:
-        # Fork a child to do the work, wait for it to finish, then continue
-        childpid = os.fork() # Fork a child
-        if childpid > 0:
+        print('--- BEGIN LOOPING')
+        if args.daemon:
+          print('--- BEGIN ARGS.DAEMON')
+          # Fork a child to do the work, wait for it to finish, then continue
+          childpid = os.fork() # Fork a child
+          if childpid > 0:
+            print('--- BEGIN CHILDPID > 0')
             pid, status = os.waitpid(childpid, 0) # Wait for child to finish
             print(f'Child process {childpid} finished with exit status {status}', flush=True)
             assert pid == childpid # Right???
@@ -911,6 +925,8 @@ def main():
         #         if args.verilog:
         #             print("--- BEGIN verilog inside garnet", flush=True)
         #             build_verilog(args, garnet)
+
+        print("--- BEGIN check for PNR", flush=True)
 
         # PNR
         app_specified = len(args.app)    > 0 and \
@@ -944,6 +960,8 @@ def main():
         # sorted_argdic['glb_params'] = "UKNOWN"; sorted_argdic['pe_fc'] = "UKNOWN"
         # print(f"--- BEGIN pre-dump-config args {json.dumps(sorted_argdic, indent=4)}")
 
+        print("--- BEGIN check for dump-config", flush=True)
+
         # WRITE REGS TO CONFIG.JSON
         from passes.collateral_pass.config_register import get_interconnect_regs, get_core_registers
         if args.dump_config_reg:
@@ -955,6 +973,7 @@ def main():
                 json.dump(ic_reg + core_reg, f)
 
         # CHILD IS DONE
+        print("--- BEGIN GARNET EXIT", flush=True)
         exit()
 
 if __name__ == "__main__":

--- a/garnet.py
+++ b/garnet.py
@@ -889,7 +889,7 @@ def main():
 
             # ELSE parent (daemon) WAITs for a client to send new args for processing
             print('\nLOOPING')
-            args = GarnetDaemon.loop(args)
+            args = GarnetDaemon.loop(args, dbg=1)
             continue
 
         # Forked child process does the work, then exits

--- a/garnet.py
+++ b/garnet.py
@@ -866,16 +866,18 @@ def main():
         # "help"   => echo help and exit
         # "wait"   => wait for "daemon ready"
 
-    # app="/aha/Halide-to-Hardware/apps/hardware_benchmarks/apps/pointwise/bin/design_top.json"
+    # BEFORE: app="/aha/Halide-to-Hardware/.../apps/pointwise/bin/design_top.json"
+    # AFTER:  app="apps/pointwise" (simpler for printing)
     app=args.app
     app=app.replace('/bin/design_top.json','')
     app=app.replace('/aha/Halide-to-Hardware/apps/hardware_benchmarks/','')
-
     print(f'--- GARNET-BUILD ({app})')
+
+    # BUILD GARNET
     garnet = Garnet(args)
 
     # VERILOG
-    # FIXME verilog could be inside loop (below). Should verilog be inside loop?
+    # FIXME verilog could be inside daemon loop (below). Right?
     if args.verilog:
         print('--- GARNET VERILOG')
         build_verilog(args, garnet)

--- a/garnet.py
+++ b/garnet.py
@@ -933,13 +933,6 @@ def main():
                 filename = os.path.join("temp", f"{c_id}.bs")
                 write_out_bitstream(filename, bitstream)
 
-        # argdic = vars(args)
-        # sorted_argdic=dict(sorted(argdic.items()))
-        # sorted_argdic['glb_params'] = "UKNOWN"; sorted_argdic['pe_fc'] = "UKNOWN"
-        # print(f"--- BEGIN pre-dump-config args {json.dumps(sorted_argdic, indent=4)}")
-
-        print("--- BEGIN check for dump-config", flush=True)
-
         # WRITE REGS TO CONFIG.JSON
         from passes.collateral_pass.config_register import get_interconnect_regs, get_core_registers
         if args.dump_config_reg:
@@ -951,7 +944,7 @@ def main():
                 json.dump(ic_reg + core_reg, f)
 
         # CHILD IS DONE
-        print("--- BEGIN GARNET EXIT", flush=True)
+        print("--- garnet.py DONE", flush=True)
         exit()
 
 if __name__ == "__main__":

--- a/garnet.py
+++ b/garnet.py
@@ -740,6 +740,7 @@ def parse_args():
     return args
 
 def build_verilog(args, garnet):
+    print('--- BEGIN build_verilog 743', flush=True)
     garnet_circ = garnet.circuit()
     magma.compile("garnet", garnet_circ, output="coreir-verilog",
                   coreir_libs={"float_CW"},
@@ -767,8 +768,11 @@ def build_verilog(args, garnet):
             gfd.writelines(lines_garnet)
             gfd.writelines(lines_pe)
 
+    print('--- BEGIN build_verilog 771', flush=True)
     garnet.create_stub()
+    print('--- BEGIN build_verilog 773', flush=True)
     if not args.interconnect_only:
+        print('--- BEGIN build_verilog 775', flush=True)
         garnet_home = os.getenv('GARNET_HOME')
         if not garnet_home:
             garnet_home = os.path.dirname(os.path.abspath(__file__))
@@ -874,45 +878,55 @@ def main():
         # "use"    => send args to daemon and exit
         # "kill"   => kill existing daemon and exit
         # "help"   => echo help and exit
-        # "wait"   => wait for "daemon ready"
 
-    print('--- garnet.py BEGIN GARNET CIRCUIT BUILD (magma)')
+    # BUILD GARNET
     garnet = Garnet(args)
 
     # VERILOG
-    # FIXME verilog could be inside loop (below). Should verilog be inside loop?
     if args.verilog:
-        print('--- garnet.py BEGIN GARNET VERILOG BUILD')
+        print("--- BEGIN verilog inside garnet", flush=True)
         build_verilog(args, garnet)
-
-    # print(f"args.daemon={args.daemon}", flush=True)
+        print("--- DONE verilog inside garnet", flush=True)
+    print("--- continuing", flush=True)
+    print(f"args.daemon={args.daemon}", flush=True)
 
     # USE GARNET
     import json # for debugging, maybe temporary
-    print('--- garnet.py BEGIN LOOPING')
     while True:
-        DEBUG = False
+        print('--- BEGIN LOOPING')
         if args.daemon:
-            print('--- garnet.py BEGIN DAEMON')
-            # Fork a child to do the work, wait for it to finish, then continue
-            childpid = os.fork() # Fork a child
-            if childpid > 0:
-                # Only parent does this part
-                pid, status = os.waitpid(childpid, 0) # Wait for child to finish
-                print(f'Child process {childpid} finished with exit status {status}', flush=True)
-                assert pid == childpid # Right???
-                #
-                # Parent halts here and waits for further instructions
-                args = GarnetDaemon.loop(args, dbg=1)
-                continue # Parent loops back
+          print('--- BEGIN ARGS.DAEMON')
+          # Fork a child to do the work, wait for it to finish, then continue
+          childpid = os.fork() # Fork a child
+          if childpid > 0:
+            print('--- BEGIN CHILDPID > 0')
+            pid, status = os.waitpid(childpid, 0) # Wait for child to finish
+            print(f'Child process {childpid} finished with exit status {status}', flush=True)
+            assert pid == childpid # Right???
 
-            # Child falls through to next line below
+            print('\nLOOPING')
+            print(f'Before merge: args.app={args.app}')
+            args = GarnetDaemon.loop(args, dbg=1)
 
-        # Anything from here down is done by forked child (if using daemon)
+            # PRINT DEBUG INFO
+            print(f'After merge:  args.app={args.app}')
+            argdic = vars(args)
+            sorted_argdic=dict(sorted(argdic.items()))
+            sorted_argdic['glb_params'] = "<unserializable obj>" # Cannot serialize glb_params or pe_fc
+            sorted_argdic['pe_fc']      = "<unserializable obj>"
+            print(f"- loaded args (garnet) = {json.dumps(sorted_argdic, indent=4)}")
+
+            continue
+
+        # Forked child process does the work, then exits
 
         # FIXME Verilog should be here probably, Right?
+        #         # VERILOG
+        #         if args.verilog:
+        #             print("--- BEGIN verilog inside garnet", flush=True)
+        #             build_verilog(args, garnet)
 
-        print("--- garnet.py BEGIN check for PNR", flush=True)
+        print("--- BEGIN check for PNR", flush=True)
 
         # PNR
         app_specified = len(args.app)    > 0 and \
@@ -941,6 +955,13 @@ def main():
                 filename = os.path.join("temp", f"{c_id}.bs")
                 write_out_bitstream(filename, bitstream)
 
+        # argdic = vars(args)
+        # sorted_argdic=dict(sorted(argdic.items()))
+        # sorted_argdic['glb_params'] = "UKNOWN"; sorted_argdic['pe_fc'] = "UKNOWN"
+        # print(f"--- BEGIN pre-dump-config args {json.dumps(sorted_argdic, indent=4)}")
+
+        print("--- BEGIN check for dump-config", flush=True)
+
         # WRITE REGS TO CONFIG.JSON
         from passes.collateral_pass.config_register import get_interconnect_regs, get_core_registers
         if args.dump_config_reg:
@@ -952,7 +973,7 @@ def main():
                 json.dump(ic_reg + core_reg, f)
 
         # CHILD IS DONE
-        print("--- garnet.py DONE", flush=True)
+        print("--- BEGIN GARNET EXIT", flush=True)
         exit()
 
 if __name__ == "__main__":

--- a/garnet.py
+++ b/garnet.py
@@ -881,7 +881,7 @@ def main():
         childpid = os.fork() # Fork a child
         if childpid > 0:
             pid, status = os.waitpid(childpid, 0) # Wait for child to finish
-            print(f'Child process {childpid} finished with exit status {status}')
+            print(f'Child process {childpid} finished with exit status {status}', flush=True)
             assert pid == childpid # Right???
 
             # IF we're not running as a daemon, we're done.
@@ -913,6 +913,7 @@ def main():
 
         do_pnr = app_specified and not args.virtualize
         if do_pnr:
+            print("--- BEGIN pnr inside garnet", flush=True)
             # FIXME how is args.app not redundant/unnecessary here?
             pnr(garnet, args, args.app)
 

--- a/garnet.py
+++ b/garnet.py
@@ -13,12 +13,17 @@ import archipelago
 import archipelago.power
 import archipelago.io
 from lassen.sim import PE_fc as lassen_fc
+# from metamapper.coreir_mapper import Mapper # Not used??
+# from canal.global_signal import GlobalSignalWiring
 
 from daemon.daemon import GarnetDaemon
 
-# Not used?
-# from metamapper.coreir_mapper import Mapper
-# from metamapper.map_design_top import map_design_top
+# FIXME disperse this to where it needs to be...
+import metamapper.peak_util as putil
+from mapper.netlist_util import create_netlist_info, print_netlist_info
+from metamapper.coreir_mapper import Mapper
+from metamapper.map_design_top import map_design_top
+from metamapper.node import Nodes
 
 # set the debug mode to false to speed up construction
 from gemstone.generator.generator import set_debug_mode
@@ -335,7 +340,6 @@ class Garnet(Generator):
         from metamapper.io_tiles import IO_fc, BitIO_fc
         import metamapper.peak_util as putil
         from mapper.netlist_util import create_netlist_info, print_netlist_info
-        from metamapper.node import Nodes
 
         app_dir = os.path.dirname(app)
 
@@ -779,6 +783,10 @@ def build_verilog(args, garnet):
         gen_rdl_header(top_name="glc",
                        rdl_file=os.path.join(garnet_home, "global_controller/systemRDL/rdl_models/glc.rdl.final"),
                        output_folder=os.path.join(garnet_home, "global_controller/header"))
+
+        print('--- BEGIN build_verilog 791', flush=True)
+
+    print('--- BEGIN build_verilog 793', flush=True)
 
 # FIXME/TODO send pnr, pnr_wrapper etc. to util/garnetPNR or some such
 # e.g. "import util.pnr then call util.pnr.{pnr,pnr_wrapper} etc. maybe

--- a/garnet.py
+++ b/garnet.py
@@ -16,8 +16,6 @@ from lassen.sim import PE_fc as lassen_fc
 
 from daemon.daemon import GarnetDaemon
 
-# from metamapper.coreir_mapper import Mapper # not used?
-
 # set the debug mode to false to speed up construction
 from gemstone.generator.generator import set_debug_mode
 set_debug_mode(False)
@@ -326,13 +324,16 @@ class Garnet(Generator):
     def load_netlist(self, app, load_only, pipeline_input_broadcasts,
                      input_broadcast_branch_factor, input_broadcast_max_leaves):
 
+        import metamapper.peak_util as putil
+        from mapper.netlist_util import create_netlist_info, print_netlist_info
+        from metamapper.coreir_mapper import Mapper # not used?
+        from metamapper.map_design_top import map_design_top
+        from metamapper.node import Nodes
+
         import metamapper.coreir_util as cutil
         from metamapper import CoreIRContext
         from metamapper.irs.coreir import gen_CoreIRNodes
         from metamapper.io_tiles import IO_fc, BitIO_fc
-        import metamapper.peak_util as putil
-        from mapper.netlist_util import create_netlist_info, print_netlist_info
-        from metamapper.node import Nodes
 
         app_dir = os.path.dirname(app)
 
@@ -870,13 +871,13 @@ def main():
     app=app.replace('/bin/design_top.json','')
     app=app.replace('/aha/Halide-to-Hardware/apps/hardware_benchmarks/','')
 
-    print(f'--- garnet.py GARNET BUILD ({app})')
+    print(f'--- GARNET-BUILD ({app})')
     garnet = Garnet(args)
 
     # VERILOG
     # FIXME verilog could be inside loop (below). Should verilog be inside loop?
     if args.verilog:
-        print('--- garnet.py GARNET VERILOG')
+        print('--- GARNET VERILOG')
         build_verilog(args, garnet)
 
     print(f"args.daemon={args.daemon}", flush=True)
@@ -919,13 +920,13 @@ def main():
 
         do_pnr = app_specified and not args.virtualize
         if do_pnr:
-            print(f"--- - garnet.py PNR ({app})", flush=True)
+            print(f"--- GARNET-PNR   ({app})", flush=True)
             # FIXME how is args.app not redundant/unnecessary here?
             pnr(garnet, args, args.app)
 
         # BITSTREAM
         elif args.virtualize and len(args.app) > 0:
-            print(f"--- - garnet.py BITSTREAM ({app})", flush=True)
+            print(f"--- GARNET-BITSTREAM ({app})", flush=True)
             group_size = args.virtualize_group_size
             result = garnet.compile_virtualize(args.app, group_size)
             for c_id, bitstream in result.items():
@@ -935,7 +936,7 @@ def main():
         # WRITE REGS TO CONFIG.JSON
         from passes.collateral_pass.config_register import get_interconnect_regs, get_core_registers
         if args.dump_config_reg:
-            print(f"--- - garnet.py DUMP_CONFIG ({app})", flush=True)
+            print(f"--- GARNET-DUMP-CONFIG ({app})", flush=True)
             ic = garnet.interconnect
             ic_reg = get_interconnect_regs(ic)
             core_reg = get_core_registers(ic)

--- a/tests/test_memory_core/build_tb.py
+++ b/tests/test_memory_core/build_tb.py
@@ -1980,6 +1980,29 @@ def software_gold(app_name, matrix_tmp_dir, give_tensor=False, print_inputs=None
         output_matrix = numpy.maximum(0, (numpy.matmul(b_mat, c_mat_trans, dtype=numpy.int16, casting='unsafe')))
         output_format = "CSF"
         output_name = "X"
+    elif "spmv.gv" in app_name:
+        b_mat = get_tensor(input_name='B', shapes=[shapes_[0], shapes_[1]], give_tensor=give_tensor, tmp_dir=matrix_tmp_dir,
+                           dump=matrix_tmp_dir, suffix=suffix, clean=clean, tensor_ordering=tensor_orderings['B'],
+                           sparsity=0.5)
+        c_mat = get_tensor(input_name='c', shapes=[shapes_[1]], give_tensor=give_tensor, tmp_dir=matrix_tmp_dir,
+                           dump=matrix_tmp_dir, suffix=suffix, clean=False, tensor_ordering=tensor_orderings['c'],
+                           sparsity=0.0, format='UNC')
+        # First transpose c_mat
+        input_dims['c'] = tuple(c_mat.shape)
+        output_matrix = numpy.matmul(b_mat, c_mat, dtype=numpy.int16, casting='unsafe')
+        output_format = "CSF"
+        output_name = "x"
+    elif 'spmv' in app_name and "relu" in app_name:
+        b_mat = get_tensor(input_name='B', shapes=[shapes_[0], shapes_[1]], give_tensor=give_tensor, tmp_dir=matrix_tmp_dir,
+                           dump=matrix_tmp_dir, suffix=suffix, clean=clean, tensor_ordering=tensor_orderings['B'],
+                           sparsity=0.5)
+        c_mat = get_tensor(input_name='c', shapes=[shapes_[1]], give_tensor=give_tensor, tmp_dir=matrix_tmp_dir,
+                           dump=matrix_tmp_dir, suffix=suffix, clean=False, tensor_ordering=tensor_orderings['c'],
+                           sparsity=0.0, format='UNC')
+        input_dims['c'] = tuple(c_mat.shape)
+        output_matrix = numpy.maximum(0,(numpy.matmul(b_mat, c_mat, dtype=numpy.int16, casting='unsafe')))
+        output_format = "CSF"
+        output_name = "x"
     elif 'matmul_ijk.gv' in app_name:
         # PASSES
         # to glb


### PR DESCRIPTION
This is the third of three pull requests that add daemon functionality to garnet.py, by way of the new python class `GarnetDaemon`, introduced in this pull.

#### GARNET DAEMON

The `GarnetDaemon` class enables daemon capability for a python program, tailored specifically for our `garnet.py` chip builder. In particular, we can use a daemon-enabled `garnet.py` to save time when using `garnet.py` to do PNR for multiple applications mapped onto the same Garnet build.

#### PNR USING GARNET DAEMON

Previously, PNR for an app required two stages: 1) build the (garnet) circuit and 2) place/route the app onto the circuit. A second PNR, for a second app, would go through the same two stages, even when/if the garnet circuit produced is the same for both apps.

This new daemon-based PNR builds the garnet circuit just *once*, then runs in the background, waiting to use the circuit for one or more requesting apps to do their PNR.
```
    % aha pnr app1 --daemon launch
        => 100 sec to build garnet circuit
        =>  50 sec to do PNR for app1

    % aha pnr app2 --daemon use
        =>  0 sec to build garnet circuit (reuses prev circuit)
        => 50 sec to do PNR for app2

    % aha pnr app3 --daemon use ...
    % aha pnr app4 --daemon use ...
```

Below are before-and-after timings for our "daily" regression tests (with after-daemon times in parens). The daemon reduces total runtime by about one third, from 2972 seconds (50 min) down to 2080 seconds (35 min).
```
Step                Total  (d)     Map  (d)    PNR   (d)    Test (d)
------------------- -----------   ---------   ----------   ---------
garnet               709  (709)
apps/pointwise       218  (215)    51  (51)    141 (138)    26  (26)
apps/pointwise       190   (99)    42  (42)    138  (47)    10  (10)
tests/ushift         204  (113)    41  (41)    139  (48)    24  (24)
tests/arith          207  (114)    41  (41)    140  (47)    26  (26)
tests/absolute       201  (110)    40  (40)    137  (46)    24  (24)
tests/scomp          222  (132)    41  (41)    157  (67)    24  (24)
tests/ucomp          223  (130)    41  (41)    159  (66)    23  (23)
tests/uminmax        205  (112)    41  (41)    138  (45)    26  (26)
tests/rom            201  (113)    41  (41)    135  (47)    25  (25)
tests/conv_1_2       197  (116)    41  (41)    130  (49)    26  (26)
tests/conv_2_1       195  (117)    41  (41)    128  (50)    26  (26)
------------------- -----------   ---------   ----------   ---------
TOTAL               2972 (2080)   461 (461)   1542 (650)   260 (260)
```

PNR makes use of a version of `garnet.py` enhanced with daemon capabilities by way of the "GarnetDaemon" class in `daemon.py`. I.e. when you do
```
    aha pnr my-app --width 28 --height 16 --daemon launch
```
the `aha pnr` wrapper does something like
```
   garnet.py --daemon launch
         --no-pd --interconnect-only
         --input-app ${app_dir}/bin/design_top.json
         --input-file ${app_dir}/bin/input${ext}
         --output-file ${app_dir}/bin/${args_app_name}.bs
         --gold-file ${app_dir}/bin/gold${ext}
         --input-broadcast-branch-factor 2
         --input-broadcast-max-leaves 16
         --rv --sparse-cgra --sparse-cgra-combined --pipeline-pnr
         --width 28 --height 16 &
```

You can use '--daemon help' to find the latest info about how to use the daemon.
```
    % garnet.py --daemon help

    DESCRIPTION:
      garnet.py can run as a daemon to save you time when generating bitstreams
      for multiple apps using the same garnet circuit. Use the "launch" command
      to build a circuit and keep state in the background. The "use-daemon" command
      reuses the background state to more quickly do pnr and bitstream generation.

          --daemon launch -> process args and launch a daemon
          --daemon use    -> use existing daemon to process args
          --daemon wait   -> wait for daemon to finish processing args
          --daemon kill   -> kill the daemon
          --daemon status -> print daemon status and exit
          --daemon force  -> same as kill + launch

    EXAMPLE:
        garnet.py --daemon kill
        garnet.py --width 28 --height 16 --verilog ...
        garnet.py <app1-pnr-args> --daemon launch
        garnet.py <app2-pnr-args> --daemon use
        garnet.py <app3-pnr-args> --daemon use
        garnet.py <app4-pnr-args> --daemon use
        ...
        garnet.py --daemon kill

    NOTE! 'daemon.use' width and height must match 'daemon.launch'!!!
    NOTE 2: cannot use the same daemon for verilog *and* pnr (not sure why).
```
