### PR TITLE
Eliminate annoying and USELESS garnet.py warnings / preamble

### DIFF
--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-#########################################################################
-# FYI THIS SCRIPT IS NO LONGER USED MAYBE. INSTEAD, WE USE THE VCOMPARE #
-# FUNCTION DEFINED INTERNALLY IN $AHA_REPO/aha/bin/rtl-goldcheck.sh     #
-#########################################################################
-
 cmd=$0; HELP="
 DESCRIPTION
   Compare two verilog files, ignoring non-functional diffs mostly ish.
@@ -16,13 +11,6 @@ EXAMPLES
 [ "$1" == "--help" ] && echo "$HELP" && exit
 [ "$1" == "" ] && echo "$HELP" && exit
 
-f1=$1; f2=$2
-
-#########################################################################
-# FYI THIS SCRIPT IS NO LONGER USED MAYBE. INSTEAD, WE USE THE VCOMPARE #
-# FUNCTION DEFINED INTERNALLY IN $AHA_REPO/aha/bin/rtl-goldcheck.sh     #
-#########################################################################
-
 # Need 'sed s/unq...' to handle the case where both designs are
 # exactly the same but different "unq" suffixes e.g.
 #     < Register_unq3 Register_inst0 (
@@ -31,29 +19,17 @@ f1=$1; f2=$2
 # Need 's/_O._value_O/...' because generator seems e.g. to randomly assign
 # the equivalent values 'PE_onyx_inst_onyxpeintf_O3_value_O' and '...O4_value_O' :(
 
-#########################################################################
-# FYI THIS SCRIPT IS NO LONGER USED MAYBE. INSTEAD, WE USE THE VCOMPARE #
-# FUNCTION DEFINED INTERNALLY IN $AHA_REPO/aha/bin/rtl-goldcheck.sh     #
-#########################################################################
+
+#     sed 's/clk_gate_unq/clk_gate/'    | # Treat clk_gate_unq same as clk_gate :(
 
 function vcompare {
     cat $1 |
-    sed 's/_O._value_O/_Ox_value_O/g' | # Treat all zeroes as equivalent
-    sed 's/,$//'         | # No trailing commas
-    sed 's/_unq[0-9*]//' | # Canonicalize unq's
-    sed '/^\s*$/d'       | # No blank lines
-    sort                 | # Out-of-order is okay
+    sed 's/_O._value_O/_Ox_value_O/g'                    | # Treat all zeroes as equivalent
+    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
+    sed 's/,$//'           | # No trailing commas
+    sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
+    sed '/^\s*$/d'         | # No blank lines
+    sort                   | # Out-of-order is okay
     cat
 }
-printf "\n"
-echo "Comparing `vcompare $f1 | wc -l` lines of $f1"
-echo "versus    `vcompare $f2 | wc -l` lines of $f2"
-printf "\n"
-
-echo "diff $f1 $f2"
-diff -Bb -I Date <(vcompare $f1) <(vcompare $f2)
-
-#########################################################################
-# FYI THIS SCRIPT IS NO LONGER USED MAYBE. INSTEAD, WE USE THE VCOMPARE #
-# FUNCTION DEFINED INTERNALLY IN $AHA_REPO/aha/bin/rtl-goldcheck.sh     #
-#########################################################################
+diff -Bb -I Date <(vcompare $1) <(vcompare $2)

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+#########################################################################
+# FYI THIS SCRIPT IS NO LONGER USED MAYBE. INSTEAD, WE USE THE VCOMPARE #
+# FUNCTION DEFINED INTERNALLY IN $AHA_REPO/aha/bin/rtl-goldcheck.sh     #
+#########################################################################
+
 cmd=$0; HELP="
 DESCRIPTION
   Compare two verilog files, ignoring non-functional diffs mostly ish.
@@ -11,6 +16,13 @@ EXAMPLES
 [ "$1" == "--help" ] && echo "$HELP" && exit
 [ "$1" == "" ] && echo "$HELP" && exit
 
+f1=$1; f2=$2
+
+#########################################################################
+# FYI THIS SCRIPT IS NO LONGER USED MAYBE. INSTEAD, WE USE THE VCOMPARE #
+# FUNCTION DEFINED INTERNALLY IN $AHA_REPO/aha/bin/rtl-goldcheck.sh     #
+#########################################################################
+
 # Need 'sed s/unq...' to handle the case where both designs are
 # exactly the same but different "unq" suffixes e.g.
 #     < Register_unq3 Register_inst0 (
@@ -19,17 +31,29 @@ EXAMPLES
 # Need 's/_O._value_O/...' because generator seems e.g. to randomly assign
 # the equivalent values 'PE_onyx_inst_onyxpeintf_O3_value_O' and '...O4_value_O' :(
 
-
-#     sed 's/clk_gate_unq/clk_gate/'    | # Treat clk_gate_unq same as clk_gate :(
+#########################################################################
+# FYI THIS SCRIPT IS NO LONGER USED MAYBE. INSTEAD, WE USE THE VCOMPARE #
+# FUNCTION DEFINED INTERNALLY IN $AHA_REPO/aha/bin/rtl-goldcheck.sh     #
+#########################################################################
 
 function vcompare {
     cat $1 |
-    sed 's/_O._value_O/_Ox_value_O/g'                    | # Treat all zeroes as equivalent
-    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
-    sed 's/,$//'           | # No trailing commas
-    sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
-    sed '/^\s*$/d'         | # No blank lines
-    sort                   | # Out-of-order is okay
+    sed 's/_O._value_O/_Ox_value_O/g' | # Treat all zeroes as equivalent
+    sed 's/,$//'         | # No trailing commas
+    sed 's/_unq[0-9*]//' | # Canonicalize unq's
+    sed '/^\s*$/d'       | # No blank lines
+    sort                 | # Out-of-order is okay
     cat
 }
-diff -Bb -I Date <(vcompare $1) <(vcompare $2)
+printf "\n"
+echo "Comparing `vcompare $f1 | wc -l` lines of $f1"
+echo "versus    `vcompare $f2 | wc -l` lines of $f2"
+printf "\n"
+
+echo "diff $f1 $f2"
+diff -Bb -I Date <(vcompare $f1) <(vcompare $f2)
+
+#########################################################################
+# FYI THIS SCRIPT IS NO LONGER USED MAYBE. INSTEAD, WE USE THE VCOMPARE #
+# FUNCTION DEFINED INTERNALLY IN $AHA_REPO/aha/bin/rtl-goldcheck.sh     #
+#########################################################################

--- a/memory_core/memtile_util.py
+++ b/memory_core/memtile_util.py
@@ -1,5 +1,9 @@
 import os
-from gemstone.common.testers import BasicTester
+
+# from gemstone.common.testers import BasicTester
+# 'testers' sends trash to stdout on import :(
+# ...so let's only load later on demand
+
 from canal.util import IOSide
 import magma
 import mantle
@@ -920,6 +924,7 @@ class NetlistBuilder():
             print(f"TIME:\tic_circuit\t{after_time - before_time}")
 
     def get_tester(self):
+        from gemstone.common.testers import BasicTester
         assert self._interconnect is not None, "Need to define the interconnect first..."
         # self._circuit = self._interconnect.circuit()
         self._tester = BasicTester(self._circuit, self._circuit.clk, self._circuit.reset)

--- a/passes/power_domain/pd_pass.py
+++ b/passes/power_domain/pd_pass.py
@@ -29,15 +29,14 @@ class PowerDomainConfigReg(Configurable):
         assert turn_off in {0, 1, True, False}
         return [0, int(turn_off)]
 
+def add_power_domain(interconnect: Interconnect):
 
-__AND_GATE = magma.DefineFromVerilog("""
+    __AND_GATE = magma.DefineFromVerilog("""
 module and_cell(input A, input B, output Z);
 AN_CELL inst(.A1(A), .A2(B), .Z(Z));
 endmodule
 """)[0]
 
-
-def add_power_domain(interconnect: Interconnect):
     # add features first
     for (x, y) in interconnect.tile_circuits:
         tile = interconnect.tile_circuits[(x, y)]


### PR DESCRIPTION
This fixes the bug/annoyance where every `garnet.py` invocation results in the following useless preamble
```
  Failed to import libraries for results parsing.  Capabilities may be limited.
  Generating LALR tables
  WARNING: 183 shift/reduce conflicts
```

Example BEFORE:
```
    % python garnet/garnet.py --help
    Failed to import libraries for results parsing.  Capabilities may be limited.
    Generating LALR tables
    WARNING: 183 shift/reduce conflicts
    usage: garnet.py [-h] [--width WIDTH] [--height HEIGHT]
                     [--pipeline_config_interval PIPELINE_CONFIG_INTERVAL]
                     [--glb_tile_mem_size GLB_TILE_MEM_SIZE] [--input-app APP]
                     ...
...

AFTER:
```
    % python garnet/garnet.py --help
       usage: garnet.py [-h] [--width WIDTH] [--height HEIGHT]
                     [--pipeline_config_interval PIPELINE_CONFIG_INTERVAL]
                     [--glb_tile_mem_size GLB_TILE_MEM_SIZE] [--input-app APP]
                     ...
```
