### PR TITLE
prevent unnecessary fail in fullchip summary step

### DIFF
--- a/.buildkite/pipeline_fullchip.yml
+++ b/.buildkite/pipeline_fullchip.yml
@@ -209,5 +209,7 @@ steps:
   commands:
   - 'mflowgen/bin/buildcheck.sh $$GOLD --show-all-errors |& tee $$GOLD/buildcheck.out;
      echo ""; echo "+++ SIZE HISTORY"; echo "";
-     test -f /build/size-history && cat /build/size-history;
+     test -f /build/size-history || echo Sorry, could not find size history;
+     test -f /build/size-history || exit 0;
+     cat /build/size-history;
     '


### PR DESCRIPTION
Quick fix corrects long-standing problem where the full-chip TSMC build completes successfully, but the final "summary" step of the build throws an error because of a missing comparison file. Here are before-and-after comparisons:

#### BEFORE: Summary step fails<br />https://buildkite.com/tapeout-aha/fullchip/builds/550


#### AFTER: Summary step completes successfully<br />https://buildkite.com/tapeout-aha/fullchip/builds/556