### PR TITLE
Better pruning of docker images for gen_rtl.sh

### DIFF
--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -30,6 +30,16 @@ env:
 
 steps:
 
+- label: 'setup'
+  commands:
+  - echo "git pull latest to prevent later collisions"
+  - echo "(each init step will try to do its own git pull latest...)
+  - echo '(assumes all steps use the same host)'
+  - docker pull latest
+- wait
+
+
+
 #####################################################################################
 # Two quick RTL checks. Set soft fail so RTL failure does not fail integration tests.
 

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -35,7 +35,7 @@ steps:
   - echo "git pull latest to prevent later collisions"
   - echo "(each init step will try to do its own git pull latest...)"
   - echo "(assumes all steps use the same host)"
-  - docker pull latest
+  - docker pull stanfordaha/garnet:latest
 - wait
 
 

--- a/.buildkite/pipelines/pmg.yml
+++ b/.buildkite/pipelines/pmg.yml
@@ -33,8 +33,8 @@ steps:
 - label: 'setup'
   commands:
   - echo "git pull latest to prevent later collisions"
-  - echo "(each init step will try to do its own git pull latest...)
-  - echo '(assumes all steps use the same host)'
+  - echo "(each init step will try to do its own git pull latest...)"
+  - echo "(assumes all steps use the same host)"
   - docker pull latest
 - wait
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -96,14 +96,6 @@ if [ "$use_container" == True ]; then
       mkdir -p aha; cd aha
       ########################################################################
 
-      # Prune docker images...
-      echo '--- gen_rtl docker prune BEGIN' `date +%H:%M`
-      docker image prune -f -a --filter "until=6h" --filter=label='description=garnet' || true
-
-      echo ""; echo "After pruning:"; echo ""
-      docker images; echo ""
-      docker ps    ; echo ""
-
       # Choose a docker image; can set via "rtl_docker_image" parameter
       default_image="stanfordaha/garnet:latest"
 
@@ -144,6 +136,15 @@ if [ "$use_container" == True ]; then
 
       # MAKE SURE the docker container gets killed when this script dies.
       trap "docker kill $container_name" EXIT
+
+      # Prune images *after* starting container (will refuse to kill image w/ active container)
+      echo '--- gen_rtl docker prune BEGIN' `date +%H:%M`
+      docker image prune -f -a --filter "until=6h" --filter=label='description=garnet' || true
+
+      echo ""; echo "After pruning:"; echo ""
+      docker images; echo ""
+      docker ps    ; echo ""
+      echo '--- Continuing...'
 
       if [ "$use_local_garnet" == True ]; then
         docker exec $container_name /bin/bash -c "rm -rf /aha/garnet"

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -137,13 +137,14 @@ if [ "$use_container" == True ]; then
       # MAKE SURE the docker container gets killed when this script dies.
       trap "docker kill $container_name" EXIT
 
-      # Prune images *after* starting container (will refuse to kill image w/ active container)
-      echo '--- gen_rtl docker prune BEGIN' `date +%H:%M`
-      docker image prune -f -a --filter "until=6h" --filter=label='description=garnet' || true
+      # Delete all dangling images created more than 6 hours ago.
+      # Notice that we prune images *after* starting container (pruner
+      # will refuse to kill image w/ active container)
 
-      echo ""; echo "After pruning:"; echo ""
-      docker images; echo ""
-      docker ps    ; echo ""
+      echo '--- gen_rtl docker prune BEGIN' `date +%H:%M`
+      printf "\nBefore pruning:\n\n";  docker images; echo "";  docker ps; echo ""
+      docker image prune -f -a --filter "until=6h" --filter=label='description=garnet' || true
+      printf "\nAfter pruning:\n\n";   docker images; echo "";  docker ps; echo ""
       echo '--- Continuing...'
 
       if [ "$use_local_garnet" == True ]; then


### PR DESCRIPTION
`pmg.yml` changes:
* BEFORE: each of three tests (ptile,mtile,gtile) competed to delete and reload the same docker image "garnet:latest"
* AFTER: docker image loaded *once* in a separate "setup" step before launching the three tests

`gen_rtl.sh` changes:
* BEFORE: each test would do a "docker prune" *before* launching a container, thus potentially deleting the very image that the container would use
* AFTER: "docker prune" happens *after* container launch, giving container the opportunity to reuse an existing image and preventing the prune from deleting that image (because container is using it)
