### PR TITLE
Remove 3000 lint errors

### DIFF
--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -91,65 +91,65 @@ def construct():
     # Create nodes
     #-----------------------------------------------------------------------
 
-    this_dir = os.path.dirname( os.path.abspath( __file__))
+    this_dir = os.path.dirname(os.path.abspath(__file__))
 
     # ADK step
 
-    g.set_adk( adk_name)
+    g.set_adk(adk_name)
     adk = g.get_adk_step()
 
     # Custom steps
-    rtl                  = Step( this_dir + '/../common/rtl')
-    genlibdb_constraints = Step( this_dir + '/../common/custom-genlibdb-constraints')
-    constraints          = Step( this_dir + '/constraints')
-    custom_init          = Step( this_dir + '/custom-init')
-    custom_genus_scripts = Step( this_dir + '/custom-genus-scripts')
-    custom_flowgen_setup = Step( this_dir + '/custom-flowgen-setup')
+    rtl                  = Step(this_dir + '/../common/rtl')
+    genlibdb_constraints = Step(this_dir + '/../common/custom-genlibdb-constraints')
+    constraints          = Step(this_dir + '/constraints')
+    custom_init          = Step(this_dir + '/custom-init')
+    custom_genus_scripts = Step(this_dir + '/custom-genus-scripts')
+    custom_flowgen_setup = Step(this_dir + '/custom-flowgen-setup')
     if adk_name == 'tsmc16':
-        gen_sram             = Step( this_dir + '/../common/gen_sram_macro_amber')
-        custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber')
-        custom_power         = Step( this_dir + '/../common/custom-power-leaf-amber')
+        gen_sram             = Step(this_dir + '/../common/gen_sram_macro_amber')
+        custom_lvs           = Step(this_dir + '/custom-lvs-rules-amber')
+        custom_power         = Step(this_dir + '/../common/custom-power-leaf-amber')
     else:
-        gen_sram             = Step( this_dir + '/../common/gen_sram_macro')
-        custom_lvs           = Step( this_dir + '/custom-lvs-rules')
-        custom_power         = Step( this_dir + '/../common/custom-power-leaf')
-    testbench            = Step( this_dir + '/../common/testbench')
-    application          = Step( this_dir + '/../common/application')
-    lib2db               = Step( this_dir + '/../common/synopsys-dc-lib2db')
+        gen_sram             = Step(this_dir + '/../common/gen_sram_macro')
+        custom_lvs           = Step(this_dir + '/custom-lvs-rules')
+        custom_power         = Step(this_dir + '/../common/custom-power-leaf')
+    testbench            = Step(this_dir + '/../common/testbench')
+    application          = Step(this_dir + '/../common/application')
+    lib2db               = Step(this_dir + '/../common/synopsys-dc-lib2db')
     if want_drc_pm:
-        drc_pm             = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
+        drc_pm             = Step(this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
     if synth_power:
-        post_synth_power     = Step( this_dir + '/../common/tile-post-synth-power')
-    post_pnr_power       = Step( this_dir + '/../common/tile-post-pnr-power')
+        post_synth_power     = Step(this_dir + '/../common/tile-post-synth-power')
+    post_pnr_power       = Step(this_dir + '/../common/tile-post-pnr-power')
 
     # Power aware setup
     if pwr_aware:
-        power_domains = Step( this_dir + '/../common/power-domains')
-        pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls')
+        power_domains = Step(this_dir + '/../common/power-domains')
+        pwr_aware_gls = Step(this_dir + '/../common/pwr-aware-gls')
 
     # Default steps
-    info           = Step( 'info',                           default=True)
-    synth          = Step( 'cadence-genus-synthesis',        default=True)
-    iflow          = Step( 'cadence-innovus-flowsetup',      default=True)
-    init           = Step( 'cadence-innovus-init',           default=True)
-    power          = Step( 'cadence-innovus-power',          default=True)
-    place          = Step( 'cadence-innovus-place',          default=True)
-    cts            = Step( 'cadence-innovus-cts',            default=True)
-    postcts_hold   = Step( 'cadence-innovus-postcts_hold',   default=True)
-    route          = Step( 'cadence-innovus-route',          default=True)
-    postroute      = Step( 'cadence-innovus-postroute',      default=True)
-    postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True)
-    signoff        = Step( 'cadence-innovus-signoff',        default=True)
-    pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True)
-    genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True)
+    info           = Step('info',                           default=True)
+    synth          = Step('cadence-genus-synthesis',        default=True)
+    iflow          = Step('cadence-innovus-flowsetup',      default=True)
+    init           = Step('cadence-innovus-init',           default=True)
+    power          = Step('cadence-innovus-power',          default=True)
+    place          = Step('cadence-innovus-place',          default=True)
+    cts            = Step('cadence-innovus-cts',            default=True)
+    postcts_hold   = Step('cadence-innovus-postcts_hold',   default=True)
+    route          = Step('cadence-innovus-route',          default=True)
+    postroute      = Step('cadence-innovus-postroute',      default=True)
+    postroute_hold = Step('cadence-innovus-postroute_hold', default=True)
+    signoff        = Step('cadence-innovus-signoff',        default=True)
+    pt_signoff     = Step('synopsys-pt-timing-signoff',     default=True)
+    genlibdb       = Step('synopsys-ptpx-genlibdb',         default=True)
 
     if which("calibre") is not None:
-        drc            = Step( 'mentor-calibre-drc',             default=True)
-        lvs            = Step( 'mentor-calibre-lvs',             default=True)
+        drc            = Step('mentor-calibre-drc',             default=True)
+        lvs            = Step('mentor-calibre-lvs',             default=True)
     else:
-        drc            = Step( 'cadence-pegasus-drc',            default=True)
-        lvs            = Step( 'cadence-pegasus-lvs',            default=True)
-    debugcalibre   = Step( 'cadence-innovus-debug-calibre',  default=True)
+        drc            = Step('cadence-pegasus-drc',            default=True)
+        lvs            = Step('cadence-pegasus-lvs',            default=True)
+    debugcalibre   = Step('cadence-innovus-debug-calibre',  default=True)
 
 
     # Extra DC input
@@ -158,69 +158,69 @@ def construct():
 
     # Add sram macro inputs to downstream nodes
 
-    synth.extend_inputs( ['sram_tt.lib', 'sram.lef'])
+    synth.extend_inputs(['sram_tt.lib', 'sram.lef'])
 
-    pt_signoff.extend_inputs( ['sram_tt.db'])
-    genlibdb.extend_inputs( ['sram_tt.lib', 'sram_tt.db'])
+    pt_signoff.extend_inputs(['sram_tt.db'])
+    genlibdb.extend_inputs(['sram_tt.lib', 'sram_tt.db'])
 
     # These steps need timing and lef info for srams
 
     sram_steps = \
       [iflow, init, power, place, cts, postcts_hold, route, postroute, postroute_hold, signoff]
     for step in sram_steps:
-        step.extend_inputs( ['sram_tt.lib', 'sram_ff.lib', 'sram.lef'])
+        step.extend_inputs(['sram_tt.lib', 'sram_ff.lib', 'sram.lef'])
 
     # Need the sram gds to merge into the final layout
 
-    signoff.extend_inputs( ['sram.gds'])
+    signoff.extend_inputs(['sram.gds'])
 
     # Need SRAM spice file for LVS
 
-    lvs.extend_inputs( ['sram.spi'])
+    lvs.extend_inputs(['sram.spi'])
 
     # Add extra input edges to innovus steps that need custom tweaks
 
-    init.extend_inputs( custom_init.all_outputs())
-    power.extend_inputs( custom_power.all_outputs())
+    init.extend_inputs(custom_init.all_outputs())
+    power.extend_inputs(custom_power.all_outputs())
 
     # Add extra input edges to genlibdb for loop-breaking constraints
 
-    genlibdb.extend_inputs( genlibdb_constraints.all_outputs())
-    synth.extend_inputs( custom_genus_scripts.all_outputs())
-    iflow.extend_inputs( custom_flowgen_setup.all_outputs())
+    genlibdb.extend_inputs(genlibdb_constraints.all_outputs())
+    synth.extend_inputs(custom_genus_scripts.all_outputs())
+    iflow.extend_inputs(custom_flowgen_setup.all_outputs())
 
-    synth.extend_outputs( ["sdc"])
-    iflow.extend_inputs( ["sdc"])
-    init.extend_inputs( ["sdc"])
-    power.extend_inputs( ["sdc"])
-    place.extend_inputs( ["sdc"])
-    cts.extend_inputs( ["sdc"])
+    synth.extend_outputs(["sdc"])
+    iflow.extend_inputs(["sdc"])
+    init.extend_inputs(["sdc"])
+    power.extend_inputs(["sdc"])
+    place.extend_inputs(["sdc"])
+    cts.extend_inputs(["sdc"])
 
     # Add graph inputs and outputs so this can be used in hierarchical flows
 
     # Inputs
-    g.add_input( 'design.v', rtl.i('design.v'))
+    g.add_input('design.v', rtl.i('design.v'))
 
     # Outputs
-    g.add_output( 'Tile_MemCore_tt.lib',      genlibdb.o('design.lib'))
-    g.add_output( 'Tile_MemCore_tt.db',       genlibdb.o('design.db'))
-    g.add_output( 'Tile_MemCore.lef',         signoff.o('design.lef'))
-    g.add_output( 'Tile_MemCore.gds',         signoff.o('design-merged.gds'))
-    g.add_output( 'Tile_MemCore.sdf',         signoff.o('design.sdf'))
-    g.add_output( 'Tile_MemCore.vcs.v',       signoff.o('design.vcs.v'))
-    g.add_output( 'Tile_MemCore.vcs.pg.v',    signoff.o('design.vcs.pg.v'))
-    g.add_output( 'Tile_MemCore.spef.gz',     signoff.o('design.spef.gz'))
-    g.add_output( 'Tile_MemCore.pt.sdc',      signoff.o('design.pt.sdc'))
-    g.add_output( 'Tile_MemCore.lvs.v',       lvs.o('design_merged.lvs.v'))
-    g.add_output( 'sram.spi',                 gen_sram.o('sram.spi'))
-    g.add_output( 'sram.v',                   gen_sram.o('sram.v'))
-    g.add_output( 'sram_pwr.v',               gen_sram.o('sram_pwr.v'))
-    g.add_output( 'sram_tt.db',               gen_sram.o('sram_tt.db'))
-    g.add_output( 'sram_tt.lib',              gen_sram.o('sram_tt.lib'))
+    g.add_output('Tile_MemCore_tt.lib',      genlibdb.o('design.lib'))
+    g.add_output('Tile_MemCore_tt.db',       genlibdb.o('design.db'))
+    g.add_output('Tile_MemCore.lef',         signoff.o('design.lef'))
+    g.add_output('Tile_MemCore.gds',         signoff.o('design-merged.gds'))
+    g.add_output('Tile_MemCore.sdf',         signoff.o('design.sdf'))
+    g.add_output('Tile_MemCore.vcs.v',       signoff.o('design.vcs.v'))
+    g.add_output('Tile_MemCore.vcs.pg.v',    signoff.o('design.vcs.pg.v'))
+    g.add_output('Tile_MemCore.spef.gz',     signoff.o('design.spef.gz'))
+    g.add_output('Tile_MemCore.pt.sdc',      signoff.o('design.pt.sdc'))
+    g.add_output('Tile_MemCore.lvs.v',       lvs.o('design_merged.lvs.v'))
+    g.add_output('sram.spi',                 gen_sram.o('sram.spi'))
+    g.add_output('sram.v',                   gen_sram.o('sram.v'))
+    g.add_output('sram_pwr.v',               gen_sram.o('sram_pwr.v'))
+    g.add_output('sram_tt.db',               gen_sram.o('sram_tt.db'))
+    g.add_output('sram_tt.lib',              gen_sram.o('sram_tt.lib'))
 
-    order = synth.get_param( 'order')
-    order.append( 'copy_sdc.tcl')
-    synth.set_param( 'order', order)
+    order = synth.get_param('order')
+    order.append('copy_sdc.tcl')
+    synth.set_param('order', order)
 
     # TSMC needs streamout *without* the (new) default -uniquify flag
     # This strips off the unwanted flag
@@ -259,44 +259,44 @@ def construct():
     # Graph -- Add nodes
     #-----------------------------------------------------------------------
 
-    g.add_step( info)
-    g.add_step( rtl)
-    g.add_step( gen_sram)
-    g.add_step( constraints)
-    g.add_step( synth)
-    g.add_step( custom_genus_scripts)
-    g.add_step( iflow)
-    g.add_step( custom_flowgen_setup)
-    g.add_step( init)
-    g.add_step( custom_init)
-    g.add_step( power)
-    g.add_step( custom_power)
-    g.add_step( place)
-    g.add_step( cts)
-    g.add_step( postcts_hold)
-    g.add_step( route)
-    g.add_step( postroute)
-    g.add_step( postroute_hold)
-    g.add_step( signoff)
-    g.add_step( pt_signoff)
-    g.add_step( genlibdb_constraints)
-    g.add_step( genlibdb)
-    g.add_step( lib2db)
-    g.add_step( drc)
-    g.add_step( lvs)
-    g.add_step( custom_lvs)
-    g.add_step( debugcalibre)
+    g.add_step(info)
+    g.add_step(rtl)
+    g.add_step(gen_sram)
+    g.add_step(constraints)
+    g.add_step(synth)
+    g.add_step(custom_genus_scripts)
+    g.add_step(iflow)
+    g.add_step(custom_flowgen_setup)
+    g.add_step(init)
+    g.add_step(custom_init)
+    g.add_step(power)
+    g.add_step(custom_power)
+    g.add_step(place)
+    g.add_step(cts)
+    g.add_step(postcts_hold)
+    g.add_step(route)
+    g.add_step(postroute)
+    g.add_step(postroute_hold)
+    g.add_step(signoff)
+    g.add_step(pt_signoff)
+    g.add_step(genlibdb_constraints)
+    g.add_step(genlibdb)
+    g.add_step(lib2db)
+    g.add_step(drc)
+    g.add_step(lvs)
+    g.add_step(custom_lvs)
+    g.add_step(debugcalibre)
 
-    g.add_step( application)
-    g.add_step( testbench)
+    g.add_step(application)
+    g.add_step(testbench)
     if synth_power:
-        g.add_step( post_synth_power)
-    g.add_step( post_pnr_power)
+        g.add_step(post_synth_power)
+    g.add_step(post_pnr_power)
 
     # Power aware step
     if pwr_aware:
-        g.add_step( power_domains)
-        g.add_step( pwr_aware_gls)
+        g.add_step(power_domains)
+        g.add_step(pwr_aware_gls)
 
     #-----------------------------------------------------------------------
     # Graph -- Add edges
@@ -304,159 +304,160 @@ def construct():
 
     # Connect by name
 
-    g.connect_by_name( adk,      gen_sram)
-    g.connect_by_name( adk,      synth)
-    g.connect_by_name( adk,      iflow)
-    g.connect_by_name( adk,      init)
-    g.connect_by_name( adk,      power)
-    g.connect_by_name( adk,      place)
-    g.connect_by_name( adk,      cts)
-    g.connect_by_name( adk,      postcts_hold)
-    g.connect_by_name( adk,      route)
-    g.connect_by_name( adk,      postroute)
-    g.connect_by_name( adk,      postroute_hold)
-    g.connect_by_name( adk,      signoff)
-    g.connect_by_name( adk,      drc)
-    g.connect_by_name( adk,      lvs)
+    g.connect_by_name(adk,      gen_sram)
+    g.connect_by_name(adk,      synth)
+    g.connect_by_name(adk,      iflow)
+    g.connect_by_name(adk,      init)
+    g.connect_by_name(adk,      power)
+    g.connect_by_name(adk,      place)
+    g.connect_by_name(adk,      cts)
+    g.connect_by_name(adk,      postcts_hold)
+    g.connect_by_name(adk,      route)
+    g.connect_by_name(adk,      postroute)
+    g.connect_by_name(adk,      postroute_hold)
+    g.connect_by_name(adk,      signoff)
+    g.connect_by_name(adk,      drc)
+    g.connect_by_name(adk,      lvs)
 
-    g.connect_by_name( gen_sram,      synth)
-    g.connect_by_name( gen_sram,      iflow)
-    g.connect_by_name( gen_sram,      init)
-    g.connect_by_name( gen_sram,      power)
-    g.connect_by_name( gen_sram,      place)
-    g.connect_by_name( gen_sram,      cts)
-    g.connect_by_name( gen_sram,      postcts_hold)
-    g.connect_by_name( gen_sram,      route)
-    g.connect_by_name( gen_sram,      postroute)
-    g.connect_by_name( gen_sram,      postroute_hold)
-    g.connect_by_name( gen_sram,      signoff)
-    g.connect_by_name( gen_sram,      genlibdb)
-    g.connect_by_name( gen_sram,      pt_signoff)
-    g.connect_by_name( gen_sram,      drc)
-    g.connect_by_name( gen_sram,      lvs)
+    g.connect_by_name(gen_sram,      synth)
+    g.connect_by_name(gen_sram,      iflow)
+    g.connect_by_name(gen_sram,      init)
+    g.connect_by_name(gen_sram,      power)
+    g.connect_by_name(gen_sram,      place)
+    g.connect_by_name(gen_sram,      cts)
+    g.connect_by_name(gen_sram,      postcts_hold)
+    g.connect_by_name(gen_sram,      route)
+    g.connect_by_name(gen_sram,      postroute)
+    g.connect_by_name(gen_sram,      postroute_hold)
+    g.connect_by_name(gen_sram,      signoff)
+    g.connect_by_name(gen_sram,      genlibdb)
+    g.connect_by_name(gen_sram,      pt_signoff)
+    g.connect_by_name(gen_sram,      drc)
+    g.connect_by_name(gen_sram,      lvs)
 
-    g.connect_by_name( rtl,         synth)
-    g.connect_by_name( constraints, synth)
-    g.connect_by_name( custom_genus_scripts, synth)
+    g.connect_by_name(rtl,         synth)
+    g.connect_by_name(constraints, synth)
+    g.connect_by_name(custom_genus_scripts, synth)
 
-    g.connect_by_name( synth,       iflow)
-    g.connect_by_name( synth,       init)
-    g.connect_by_name( synth,       power)
-    g.connect_by_name( synth,       place)
-    g.connect_by_name( synth,       cts)
-    g.connect_by_name( custom_flowgen_setup, iflow)
+    g.connect_by_name(synth,       iflow)
+    g.connect_by_name(synth,       init)
+    g.connect_by_name(synth,       power)
+    g.connect_by_name(synth,       place)
+    g.connect_by_name(synth,       cts)
+    g.connect_by_name(custom_flowgen_setup, iflow)
 
-    g.connect_by_name( iflow,    init)
-    g.connect_by_name( iflow,    power)
-    g.connect_by_name( iflow,    place)
-    g.connect_by_name( iflow,    cts)
-    g.connect_by_name( iflow,    postcts_hold)
-    g.connect_by_name( iflow,    route)
-    g.connect_by_name( iflow,    postroute)
-    g.connect_by_name( iflow,    postroute_hold)
-    g.connect_by_name( iflow,    signoff)
+    g.connect_by_name(iflow,    init)
+    g.connect_by_name(iflow,    power)
+    g.connect_by_name(iflow,    place)
+    g.connect_by_name(iflow,    cts)
+    g.connect_by_name(iflow,    postcts_hold)
+    g.connect_by_name(iflow,    route)
+    g.connect_by_name(iflow,    postroute)
+    g.connect_by_name(iflow,    postroute_hold)
+    g.connect_by_name(iflow,    signoff)
 
-    g.connect_by_name( custom_init,  init)
-    g.connect_by_name( custom_power, power)
-    g.connect_by_name( custom_lvs,   lvs)
+    g.connect_by_name(custom_init,  init)
+    g.connect_by_name(custom_power, power)
+    g.connect_by_name(custom_lvs,   lvs)
 
-    g.connect_by_name( init,           power)
-    g.connect_by_name( power,          place)
-    g.connect_by_name( place,          cts)
-    g.connect_by_name( cts,            postcts_hold)
-    g.connect_by_name( postcts_hold,   route)
-    g.connect_by_name( route,          postroute)
-    g.connect_by_name( postroute,      postroute_hold)
-    g.connect_by_name( postroute_hold, signoff)
-    g.connect_by_name( signoff,        drc)
-    g.connect_by_name( signoff,        lvs)
+    g.connect_by_name(init,           power)
+    g.connect_by_name(power,          place)
+    g.connect_by_name(place,          cts)
+    g.connect_by_name(cts,            postcts_hold)
+    g.connect_by_name(postcts_hold,   route)
+    g.connect_by_name(route,          postroute)
+    g.connect_by_name(postroute,      postroute_hold)
+    g.connect_by_name(postroute_hold, signoff)
+    g.connect_by_name(signoff,        drc)
+    g.connect_by_name(signoff,        lvs)
     g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
     g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
-    g.connect_by_name( signoff,              genlibdb)
-    g.connect_by_name( adk,                  genlibdb)
-    g.connect_by_name( genlibdb_constraints, genlibdb)
+    g.connect_by_name(signoff,              genlibdb)
+    g.connect_by_name(adk,                  genlibdb)
+    g.connect_by_name(genlibdb_constraints, genlibdb)
 
-    g.connect_by_name( genlibdb,             lib2db)
+    g.connect_by_name(genlibdb,             lib2db)
 
-    g.connect_by_name( adk,          pt_signoff)
-    g.connect_by_name( signoff,      pt_signoff)
+    g.connect_by_name(adk,          pt_signoff)
+    g.connect_by_name(signoff,      pt_signoff)
 
-    g.connect_by_name( application, testbench)
+    g.connect_by_name(application, testbench)
     if synth_power:
-        g.connect_by_name( application, post_synth_power)
-        g.connect_by_name( gen_sram,    post_synth_power)
-        g.connect_by_name( synth,       post_synth_power)
-        g.connect_by_name( testbench,   post_synth_power)
-    g.connect_by_name( application, post_pnr_power)
-    g.connect_by_name( gen_sram,    post_pnr_power)
-    g.connect_by_name( signoff,     post_pnr_power)
-    g.connect_by_name( pt_signoff,  post_pnr_power)
-    g.connect_by_name( testbench,   post_pnr_power)
+        g.connect_by_name(application, post_synth_power)
+        g.connect_by_name(gen_sram,    post_synth_power)
+        g.connect_by_name(synth,       post_synth_power)
+        g.connect_by_name(testbench,   post_synth_power)
+    g.connect_by_name(application, post_pnr_power)
+    g.connect_by_name(gen_sram,    post_pnr_power)
+    g.connect_by_name(signoff,     post_pnr_power)
+    g.connect_by_name(pt_signoff,  post_pnr_power)
+    g.connect_by_name(testbench,   post_pnr_power)
 
-    g.connect_by_name( adk,      debugcalibre)
-    g.connect_by_name( synth,    debugcalibre)
-    g.connect_by_name( iflow,    debugcalibre)
-    g.connect_by_name( signoff,  debugcalibre)
-    g.connect_by_name( drc,      debugcalibre)
-    g.connect_by_name( lvs,      debugcalibre)
+    g.connect_by_name(adk,      debugcalibre)
+    g.connect_by_name(synth,    debugcalibre)
+    g.connect_by_name(iflow,    debugcalibre)
+    g.connect_by_name(signoff,  debugcalibre)
+    g.connect_by_name(drc,      debugcalibre)
+    g.connect_by_name(lvs,      debugcalibre)
 
     # Pwr aware steps:
     if pwr_aware:
-        g.connect_by_name( power_domains,        synth)
-        g.connect_by_name( power_domains,        init)
-        g.connect_by_name( power_domains,        power)
-        g.connect_by_name( power_domains,        place)
-        g.connect_by_name( power_domains,        cts)
-        g.connect_by_name( power_domains,        postcts_hold)
-        g.connect_by_name( power_domains,        route)
-        g.connect_by_name( power_domains,        postroute)
-        g.connect_by_name( power_domains,        postroute_hold)
-        g.connect_by_name( power_domains,        signoff)
-        g.connect_by_name( adk,                  pwr_aware_gls)
-        g.connect_by_name( gen_sram,             pwr_aware_gls)
-        g.connect_by_name( signoff,              pwr_aware_gls)
+        g.connect_by_name(power_domains,        synth)
+        g.connect_by_name(power_domains,        init)
+        g.connect_by_name(power_domains,        power)
+        g.connect_by_name(power_domains,        place)
+        g.connect_by_name(power_domains,        cts)
+        g.connect_by_name(power_domains,        postcts_hold)
+        g.connect_by_name(power_domains,        route)
+        g.connect_by_name(power_domains,        postroute)
+        g.connect_by_name(power_domains,        postroute_hold)
+        g.connect_by_name(power_domains,        signoff)
+        g.connect_by_name(adk,                  pwr_aware_gls)
+        g.connect_by_name(gen_sram,             pwr_aware_gls)
+        g.connect_by_name(signoff,              pwr_aware_gls)
         #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
 
     # New step, added for gf12
     if want_drc_pm:
-        g.add_step( drc_pm)
-        g.connect_by_name( adk,           drc_pm)
-        g.connect_by_name( gen_sram,      drc_pm)
-        g.connect_by_name( signoff,       drc_pm)
+        g.add_step(drc_pm)
+        g.connect_by_name(adk,           drc_pm)
+        g.connect_by_name(gen_sram,      drc_pm)
+        g.connect_by_name(signoff,       drc_pm)
         g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
-        g.connect_by_name( drc_pm,        debugcalibre)
+        g.connect_by_name(drc_pm,        debugcalibre)
 
-    g.connect_by_name( iflow,    genlibdb)
+    g.connect_by_name(iflow,    genlibdb)
 
     #-----------------------------------------------------------------------
     # Parameterize
     #-----------------------------------------------------------------------
 
-    g.update_params( parameters)
+    g.update_params(parameters)
 
     # Update PWR_AWARE variable
-    synth.update_params( { 'PWR_AWARE': parameters['PWR_AWARE']}, True)
-    init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE']}, True)
-    power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE']}, True)
+    synth.update_params({'PWR_AWARE': parameters['PWR_AWARE']}, True)
+    init.update_params({'PWR_AWARE': parameters['PWR_AWARE']}, True)
+    power.update_params({'PWR_AWARE': parameters['PWR_AWARE']}, True)
 
     # Used in floorplan.tcl
-    init.update_params(  { 'adk': parameters['adk']}, True)
+    init.update_params({'adk': parameters['adk']}, True)
 
     if pwr_aware:
-        pwr_aware_gls.update_params( { 'design_name': parameters['design_name']}, True)
+        pwr_aware_gls.update_params({'design_name': parameters['design_name']}, True)
 
-        init.extend_postconditions(         ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
-        place.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
-        cts.extend_postconditions(          ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
-        postcts_hold.extend_postconditions( ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
-        route.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
-        postroute.extend_postconditions(    ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
-        signoff.extend_postconditions(      ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
+        assertion = ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"]
+        init.extend_postconditions(assertion)
+        place.extend_postconditions(assertion)
+        cts.extend_postconditions(assertion)
+        postcts_hold.extend_postconditions(assertion)
+        route.extend_postconditions(assertion)
+        postroute.extend_postconditions(assertion)
+        signoff.extend_postconditions(assertion)
 
 
     # Core density target param
-    init.update_params( { 'core_density_target': parameters['core_density_target']}, True)
+    init.update_params({'core_density_target': parameters['core_density_target']}, True)
 
 
     # Disable pwr aware flow
@@ -470,97 +471,97 @@ def construct():
     # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
 
     order = init.get_param('order') # get the default script run order
-    path_group_idx = order.index( 'make-path-groups.tcl') 
-    order.insert( path_group_idx + 1, 'additional-path-groups.tcl')
-    pin_idx = order.index( 'pin-assignments.tcl') # find pin-assignments.tcl
-    order.insert( pin_idx + 1, 'edge-blockages.tcl') # add here
-    init.update_params( { 'order': order})
+    path_group_idx = order.index('make-path-groups.tcl') 
+    order.insert(path_group_idx + 1, 'additional-path-groups.tcl')
+    pin_idx = order.index('pin-assignments.tcl') # find pin-assignments.tcl
+    order.insert(pin_idx + 1, 'edge-blockages.tcl') # add here
+    init.update_params({'order': order})
 
     # Adding new input for genlibdb node to run
 
     order = genlibdb.get_param('order') # get the default script run order
-    extraction_idx = order.index( 'extract_model.tcl') # find extract_model.tcl
-    order.insert( extraction_idx, 'genlibdb-constraints.tcl') # add here
-    genlibdb.update_params( { 'order': order})
+    extraction_idx = order.index('extract_model.tcl') # find extract_model.tcl
+    order.insert(extraction_idx, 'genlibdb-constraints.tcl') # add here
+    genlibdb.update_params({'order': order})
 
     # genlibdb -- Remove 'write-interface-timing.tcl' beacuse it takes
     # very long and is not necessary
     order = genlibdb.get_param('order')
-    order.remove( 'write-interface-timing.tcl')
-    genlibdb.update_params( { 'order': order})
+    order.remove('write-interface-timing.tcl')
+    genlibdb.update_params({'order': order})
 
     # Pwr aware steps:
     if pwr_aware:
         # init node
         order = init.get_param('order')
-        read_idx = order.index( 'floorplan.tcl') # find floorplan.tcl
-        order.insert( read_idx + 1, 'mem-load-upf.tcl') # add here
-        order.insert( read_idx + 2, 'mem-pd-params.tcl') # add here
-        order.insert( read_idx + 3, 'pd-aon-floorplan.tcl') # add here
-        order.insert( read_idx + 4, 'add-endcaps-welltaps-setup.tcl') # add here
-        order.insert( read_idx + 5, 'pd-add-endcaps-welltaps.tcl') # add here
-        order.insert( read_idx + 6, 'add-power-switches.tcl') # add here
+        read_idx = order.index('floorplan.tcl') # find floorplan.tcl
+        order.insert(read_idx + 1, 'mem-load-upf.tcl') # add here
+        order.insert(read_idx + 2, 'mem-pd-params.tcl') # add here
+        order.insert(read_idx + 3, 'pd-aon-floorplan.tcl') # add here
+        order.insert(read_idx + 4, 'add-endcaps-welltaps-setup.tcl') # add here
+        order.insert(read_idx + 5, 'pd-add-endcaps-welltaps.tcl') # add here
+        order.insert(read_idx + 6, 'add-power-switches.tcl') # add here
         order.remove('add-endcaps-welltaps.tcl')
         order.append('check-clamp-logic-structure.tcl')
-        init.update_params( { 'order': order})
+        init.update_params({'order': order})
 
         # synth node (needs parm 'adk_allow_sdf_regs')
         order = synth.get_param('order')
-        order.insert( 0, 'mem-pd-params.tcl')        # add params file
-        synth.update_params( { 'order': order})
+        order.insert(0, 'mem-pd-params.tcl')        # add params file
+        synth.update_params({'order': order})
 
         # power node
         order = power.get_param('order')
-        order.insert( 0, 'pd-globalnetconnect.tcl') # add new pd-globalnetconnect
+        order.insert(0, 'pd-globalnetconnect.tcl') # add new pd-globalnetconnect
         order.remove('globalnetconnect.tcl')         # remove old globalnetconnect
-        order.insert( 0, 'mem-pd-params.tcl')       # add params file
-        power.update_params( { 'order': order})
+        order.insert(0, 'mem-pd-params.tcl')       # add params file
+        power.update_params({'order': order})
 
         # place node
         order = place.get_param('order')
-        read_idx = order.index( 'main.tcl') # find main.tcl
+        read_idx = order.index('main.tcl') # find main.tcl
         order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
         order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
         order.append('check-clamp-logic-structure.tcl')
-        place.update_params( { 'order': order})
+        place.update_params({'order': order})
 
         # cts node
         order = cts.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        cts.update_params( { 'order': order})
+        cts.update_params({'order': order})
 
         # postcts_hold node
         order = postcts_hold.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        postcts_hold.update_params( { 'order': order})
+        postcts_hold.update_params({'order': order})
 
         # route node
         order = route.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        route.update_params( { 'order': order})
+        route.update_params({'order': order})
 
         # postroute node
         order = postroute.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        postroute.update_params( { 'order': order})
+        postroute.update_params({'order': order})
 
         # postroute-hold node
         order = postroute_hold.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
-        postroute_hold.update_params( { 'order': order})
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
+        postroute_hold.update_params({'order': order})
 
         # signoff node
         order = signoff.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        read_idx = order.index( 'generate-results.tcl') # find generate_results.tcl
+        read_idx = order.index('generate-results.tcl') # find generate_results.tcl
 
         order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
-        signoff.update_params( { 'order': order})
+        signoff.update_params({'order': order})
 
     return g
 

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -12,561 +12,561 @@ from common.get_sys_adk import get_sys_adk
 
 def construct():
 
-  g = Graph()
-
-  #-----------------------------------------------------------------------
-  # Parameters
-  #-----------------------------------------------------------------------
-
-  adk_name = get_sys_adk()  # E.g. 'gf12-adk' or 'tsmc16'
-  adk_view = 'multivt'
-  pwr_aware = True
-
-  if pwr_aware:
-      adk_view = adk_view + '-pm'
-
-  synth_power = False
-  if os.environ.get('SYNTH_POWER') == 'True':
-      synth_power = True
-  # power domains do not work with post-synth power
-  if synth_power:
-      pwr_aware = False
-
-  want_drc_pm      = True
-
-  # TSMC override(s)
-  if adk_name == 'tsmc16':
-      adk_view    = 'multicorner-multivt'
-      want_drc_pm = False
-
-  if adk_name == 'tsmc16':
-      read_hdl_defines = 'TSMC16'
-  elif adk_name == 'gf12-adk':
-      read_hdl_defines = 'GF12'
-  else:
-      read_hdl_defines = ''
-
-  parameters = {
-    'construct_path'      : __file__,
-    'design_name'         : 'Tile_MemCore',
-    'clock_period'        : 1.1,
-    'adk'                 : adk_name,
-    'adk_view'            : adk_view,
-    # Synthesis
-    'flatten_effort'      : 3,
-    'topographical'       : True,
-    'read_hdl_defines'    : read_hdl_defines,
-    # SRAM macros
-    'num_words'           : 512,
-    'word_size'           : 32,
-    'mux_size'            : 4,
-    'partial_write'       : False,
-    # Hold target slack
-    'hold_target_slack'   : 0.030,
-    # Utilization target
-    'core_density_target' : 0.68,
-    # RTL Generation
-    'interconnect_only'   : False,
-    'rtl_docker_image'    : 'default', # Current default is 'stanfordaha/garnet:latest'
-    # Power Domains
-    'PWR_AWARE'         : pwr_aware,
-    # Power analysis
-    "use_sdf"           : False, # uses sdf but not the way it is in xrun node
-    'app_to_run'        : 'tests/conv_3_3',
-    'saif_instance'     : 'testbench/dut',
-    'testbench_name'    : 'testbench',
-    'strip_path'        : 'testbench/dut',
-    'drc_env_setup'     : 'drcenv-block.sh'
-  }
-
-  # TSMC overrides
-  if adk_name == 'tsmc16': parameters.update({
-    'corner'              : "tt0p8v25c",
-    'bc_corner'           : "ffg0p88v125c",
-    'hold_target_slack'   : 0.015,
-    'interconnect_only'   : True,
-  })
-
-  #-----------------------------------------------------------------------
-  # Create nodes
-  #-----------------------------------------------------------------------
-
-  this_dir = os.path.dirname( os.path.abspath( __file__ ) )
-
-  # ADK step
-
-  g.set_adk( adk_name )
-  adk = g.get_adk_step()
-
-  # Custom steps
-  rtl                  = Step( this_dir + '/../common/rtl'                          )
-  genlibdb_constraints = Step( this_dir + '/../common/custom-genlibdb-constraints'  )
-  constraints          = Step( this_dir + '/constraints'                            )
-  custom_init          = Step( this_dir + '/custom-init'                            )
-  custom_genus_scripts = Step( this_dir + '/custom-genus-scripts'                   )
-  custom_flowgen_setup = Step( this_dir + '/custom-flowgen-setup'                   )
-  if adk_name == 'tsmc16':
-    gen_sram             = Step( this_dir + '/../common/gen_sram_macro_amber'         )
-    custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber'                 )
-    custom_power         = Step( this_dir + '/../common/custom-power-leaf-amber'      )
-  else:
-    gen_sram             = Step( this_dir + '/../common/gen_sram_macro'               )
-    custom_lvs           = Step( this_dir + '/custom-lvs-rules'                       )
-    custom_power         = Step( this_dir + '/../common/custom-power-leaf'            )
-  testbench            = Step( this_dir + '/../common/testbench'                    )
-  application          = Step( this_dir + '/../common/application'                  )
-  lib2db               = Step( this_dir + '/../common/synopsys-dc-lib2db'           )
-  if want_drc_pm:
-    drc_pm             = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm' )
-  if synth_power:
-    post_synth_power     = Step( this_dir + '/../common/tile-post-synth-power'     )
-  post_pnr_power       = Step( this_dir + '/../common/tile-post-pnr-power'         )
-
-  # Power aware setup
-  if pwr_aware:
-    power_domains = Step( this_dir + '/../common/power-domains' )
-    pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls' )
-
-  # Default steps
-  info           = Step( 'info',                           default=True )
-  synth          = Step( 'cadence-genus-synthesis',        default=True )
-  iflow          = Step( 'cadence-innovus-flowsetup',      default=True )
-  init           = Step( 'cadence-innovus-init',           default=True )
-  power          = Step( 'cadence-innovus-power',          default=True )
-  place          = Step( 'cadence-innovus-place',          default=True )
-  cts            = Step( 'cadence-innovus-cts',            default=True )
-  postcts_hold   = Step( 'cadence-innovus-postcts_hold',   default=True )
-  route          = Step( 'cadence-innovus-route',          default=True )
-  postroute      = Step( 'cadence-innovus-postroute',      default=True )
-  postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
-  signoff        = Step( 'cadence-innovus-signoff',        default=True )
-  pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
-  genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
-
-  if which("calibre") is not None:
-      drc            = Step( 'mentor-calibre-drc',             default=True )
-      lvs            = Step( 'mentor-calibre-lvs',             default=True )
-  else:
-      drc            = Step( 'cadence-pegasus-drc',            default=True )
-      lvs            = Step( 'cadence-pegasus-lvs',            default=True )
-  debugcalibre   = Step( 'cadence-innovus-debug-calibre',  default=True )
-
-
-  # Extra DC input
-  synth.extend_inputs(["common.tcl"])
-  synth.extend_inputs(["simple_common.tcl"])
-
-  # Add sram macro inputs to downstream nodes
-
-  synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
-
-  pt_signoff.extend_inputs( ['sram_tt.db'] )
-  genlibdb.extend_inputs( ['sram_tt.lib', 'sram_tt.db'] )
-
-  # These steps need timing and lef info for srams
-
-  sram_steps = \
-    [iflow, init, power, place, cts, postcts_hold, route, postroute, postroute_hold, signoff]
-  for step in sram_steps:
-    step.extend_inputs( ['sram_tt.lib', 'sram_ff.lib', 'sram.lef'] )
-
-  # Need the sram gds to merge into the final layout
-
-  signoff.extend_inputs( ['sram.gds'] )
-
-  # Need SRAM spice file for LVS
-
-  lvs.extend_inputs( ['sram.spi'] )
-
-  # Add extra input edges to innovus steps that need custom tweaks
-
-  init.extend_inputs( custom_init.all_outputs() )
-  power.extend_inputs( custom_power.all_outputs() )
-
-  # Add extra input edges to genlibdb for loop-breaking constraints
-
-  genlibdb.extend_inputs( genlibdb_constraints.all_outputs() )
-  synth.extend_inputs( custom_genus_scripts.all_outputs() )
-  iflow.extend_inputs( custom_flowgen_setup.all_outputs() )
-
-  synth.extend_outputs( ["sdc"] )
-  iflow.extend_inputs( ["sdc"] )
-  init.extend_inputs( ["sdc"] )
-  power.extend_inputs( ["sdc"] )
-  place.extend_inputs( ["sdc"] )
-  cts.extend_inputs( ["sdc"] )
-  
-  # Add graph inputs and outputs so this can be used in hierarchical flows
-
-  # Inputs
-  g.add_input( 'design.v', rtl.i('design.v') )
-
-  # Outputs
-  g.add_output( 'Tile_MemCore_tt.lib',      genlibdb.o('design.lib')       )
-  g.add_output( 'Tile_MemCore_tt.db',       genlibdb.o('design.db')        )
-  g.add_output( 'Tile_MemCore.lef',         signoff.o('design.lef')        )
-  g.add_output( 'Tile_MemCore.gds',         signoff.o('design-merged.gds') )
-  g.add_output( 'Tile_MemCore.sdf',         signoff.o('design.sdf')        )
-  g.add_output( 'Tile_MemCore.vcs.v',       signoff.o('design.vcs.v')      )
-  g.add_output( 'Tile_MemCore.vcs.pg.v',    signoff.o('design.vcs.pg.v')   )
-  g.add_output( 'Tile_MemCore.spef.gz',     signoff.o('design.spef.gz')    )
-  g.add_output( 'Tile_MemCore.pt.sdc',      signoff.o('design.pt.sdc')     )
-  g.add_output( 'Tile_MemCore.lvs.v',       lvs.o('design_merged.lvs.v')   )
-  g.add_output( 'sram.spi',                 gen_sram.o('sram.spi')         )
-  g.add_output( 'sram.v',                   gen_sram.o('sram.v')           )
-  g.add_output( 'sram_pwr.v',               gen_sram.o('sram_pwr.v')       )
-  g.add_output( 'sram_tt.db',               gen_sram.o('sram_tt.db')       )
-  g.add_output( 'sram_tt.lib',              gen_sram.o('sram_tt.lib')      )
-
-  order = synth.get_param( 'order' )
-  order.append( 'copy_sdc.tcl' )
-  synth.set_param( 'order', order )
-
-  # TSMC needs streamout *without* the (new) default -uniquify flag
-  # This strips off the unwanted flag
-  from common.streamout_no_uniquify import streamout_no_uniquify
-  if adk_name == "tsmc16": streamout_no_uniquify(iflow)
-
-  # Power aware setup
-  if pwr_aware:
-
-      # Need mem-pd-params so adk.tcl can access parm 'adk_allow_sdf_regs'
-      # (mem-pd-params come from already-connected 'power-domains' node)
-      synth.extend_inputs([
-        'mem-pd-params.tcl',
-        'designer-interface.tcl', 
-        'upf_Tile_MemCore.tcl', 
-        'mem-constraints.tcl', 
-        'mem-constraints-2.tcl', 
-        'dc-dont-use-constraints.tcl'])
-
-      init.extend_inputs(['check-clamp-logic-structure.tcl', 'upf_Tile_MemCore.tcl', 'mem-load-upf.tcl', 'dont-touch-constraints.tcl', 'mem-pd-params.tcl', 'pd-aon-floorplan.tcl', 'add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'add-power-switches.tcl'])
-      place.extend_inputs(['check-clamp-logic-structure.tcl', 'place-dont-use-constraints.tcl', 'add-aon-tie-cells.tcl'])
-
-      # Need mem-pd-params for parm 'vdd_m3_stripe_sparsity'
-      # pd-globalnetconnect, mem-pd-params come from 'power-domains' node
-      power.extend_inputs(['pd-globalnetconnect.tcl', 'mem-pd-params.tcl'] )
-
-      cts.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'])
-      postcts_hold.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
-      route.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
-      postroute.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
-      postroute_hold.extend_inputs(['conn-aon-cells-vdd.tcl'] )
-      signoff.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl'] )
-      pwr_aware_gls.extend_inputs(['design.vcs.pg.v', 'sram_pwr.v'])
-
-  #-----------------------------------------------------------------------
-  # Graph -- Add nodes
-  #-----------------------------------------------------------------------
-
-  g.add_step( info                 )
-  g.add_step( rtl                  )
-  g.add_step( gen_sram             )
-  g.add_step( constraints          )
-  g.add_step( synth                )
-  g.add_step( custom_genus_scripts )
-  g.add_step( iflow                )
-  g.add_step( custom_flowgen_setup )
-  g.add_step( init                 )
-  g.add_step( custom_init          )
-  g.add_step( power                )
-  g.add_step( custom_power         )
-  g.add_step( place                )
-  g.add_step( cts                  )
-  g.add_step( postcts_hold         )
-  g.add_step( route                )
-  g.add_step( postroute            )
-  g.add_step( postroute_hold       )
-  g.add_step( signoff              )
-  g.add_step( pt_signoff           )
-  g.add_step( genlibdb_constraints )
-  g.add_step( genlibdb             )
-  g.add_step( lib2db               )
-  g.add_step( drc                  )
-  g.add_step( lvs                  )
-  g.add_step( custom_lvs           )
-  g.add_step( debugcalibre         )
-
-  g.add_step( application          )
-  g.add_step( testbench            )
-  if synth_power:
-    g.add_step( post_synth_power   )
-  g.add_step( post_pnr_power       )
-
-  # Power aware step
-  if pwr_aware:
-      g.add_step( power_domains    )
-      g.add_step( pwr_aware_gls    )
-
-  #-----------------------------------------------------------------------
-  # Graph -- Add edges
-  #-----------------------------------------------------------------------
-
-  # Connect by name
-
-  g.connect_by_name( adk,      gen_sram       )
-  g.connect_by_name( adk,      synth          )
-  g.connect_by_name( adk,      iflow          )
-  g.connect_by_name( adk,      init           )
-  g.connect_by_name( adk,      power          )
-  g.connect_by_name( adk,      place          )
-  g.connect_by_name( adk,      cts            )
-  g.connect_by_name( adk,      postcts_hold   )
-  g.connect_by_name( adk,      route          )
-  g.connect_by_name( adk,      postroute      )
-  g.connect_by_name( adk,      postroute_hold )
-  g.connect_by_name( adk,      signoff        )
-  g.connect_by_name( adk,      drc            )
-  g.connect_by_name( adk,      lvs            )
-
-  g.connect_by_name( gen_sram,      synth          )
-  g.connect_by_name( gen_sram,      iflow          )
-  g.connect_by_name( gen_sram,      init           )
-  g.connect_by_name( gen_sram,      power          )
-  g.connect_by_name( gen_sram,      place          )
-  g.connect_by_name( gen_sram,      cts            )
-  g.connect_by_name( gen_sram,      postcts_hold   )
-  g.connect_by_name( gen_sram,      route          )
-  g.connect_by_name( gen_sram,      postroute      )
-  g.connect_by_name( gen_sram,      postroute_hold )
-  g.connect_by_name( gen_sram,      signoff        )
-  g.connect_by_name( gen_sram,      genlibdb       )
-  g.connect_by_name( gen_sram,      pt_signoff     )
-  g.connect_by_name( gen_sram,      drc            )
-  g.connect_by_name( gen_sram,      lvs            )
-
-  g.connect_by_name( rtl,         synth     )
-  g.connect_by_name( constraints, synth     )
-  g.connect_by_name( custom_genus_scripts, synth )
-
-  g.connect_by_name( synth,       iflow        )
-  g.connect_by_name( synth,       init         )
-  g.connect_by_name( synth,       power        )
-  g.connect_by_name( synth,       place        )
-  g.connect_by_name( synth,       cts          )
-  g.connect_by_name( custom_flowgen_setup, iflow )
-
-  g.connect_by_name( iflow,    init           )
-  g.connect_by_name( iflow,    power          )
-  g.connect_by_name( iflow,    place          )
-  g.connect_by_name( iflow,    cts            )
-  g.connect_by_name( iflow,    postcts_hold   )
-  g.connect_by_name( iflow,    route          )
-  g.connect_by_name( iflow,    postroute      )
-  g.connect_by_name( iflow,    postroute_hold )
-  g.connect_by_name( iflow,    signoff        )
-
-  g.connect_by_name( custom_init,  init     )
-  g.connect_by_name( custom_power, power    )
-  g.connect_by_name( custom_lvs,   lvs      )
-
-  g.connect_by_name( init,           power          )
-  g.connect_by_name( power,          place          )
-  g.connect_by_name( place,          cts            )
-  g.connect_by_name( cts,            postcts_hold   )
-  g.connect_by_name( postcts_hold,   route          )
-  g.connect_by_name( route,          postroute      )
-  g.connect_by_name( postroute,      postroute_hold )
-  g.connect_by_name( postroute_hold, signoff        )
-  g.connect_by_name( signoff,        drc            )
-  g.connect_by_name( signoff,        lvs            )
-  g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
-  g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
-
-  g.connect_by_name( signoff,              genlibdb )
-  g.connect_by_name( adk,                  genlibdb )
-  g.connect_by_name( genlibdb_constraints, genlibdb )
-  
-  g.connect_by_name( genlibdb,             lib2db   )
-
-  g.connect_by_name( adk,          pt_signoff   )
-  g.connect_by_name( signoff,      pt_signoff   )
-
-  g.connect_by_name( application, testbench       )
-  if synth_power:
-      g.connect_by_name( application, post_synth_power )
-      g.connect_by_name( gen_sram,    post_synth_power )
-      g.connect_by_name( synth,       post_synth_power )
-      g.connect_by_name( testbench,   post_synth_power )
-  g.connect_by_name( application, post_pnr_power )
-  g.connect_by_name( gen_sram,    post_pnr_power )
-  g.connect_by_name( signoff,     post_pnr_power )
-  g.connect_by_name( pt_signoff,  post_pnr_power )
-  g.connect_by_name( testbench,   post_pnr_power )
-
-  g.connect_by_name( adk,      debugcalibre )
-  g.connect_by_name( synth,    debugcalibre )
-  g.connect_by_name( iflow,    debugcalibre )
-  g.connect_by_name( signoff,  debugcalibre )
-  g.connect_by_name( drc,      debugcalibre )
-  g.connect_by_name( lvs,      debugcalibre )
-
-  # Pwr aware steps:
-  if pwr_aware:
-      g.connect_by_name( power_domains,        synth          )
-      g.connect_by_name( power_domains,        init           )
-      g.connect_by_name( power_domains,        power          )
-      g.connect_by_name( power_domains,        place          )
-      g.connect_by_name( power_domains,        cts            )
-      g.connect_by_name( power_domains,        postcts_hold   )
-      g.connect_by_name( power_domains,        route          )
-      g.connect_by_name( power_domains,        postroute      )
-      g.connect_by_name( power_domains,        postroute_hold )
-      g.connect_by_name( power_domains,        signoff        )
-      g.connect_by_name( adk,                  pwr_aware_gls)
-      g.connect_by_name( gen_sram,             pwr_aware_gls)
-      g.connect_by_name( signoff,              pwr_aware_gls)
-      #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
-
-  # New step, added for gf12
-  if want_drc_pm:
-      g.add_step( drc_pm )
-      g.connect_by_name( adk,           drc_pm         )
-      g.connect_by_name( gen_sram,      drc_pm         )
-      g.connect_by_name( signoff,       drc_pm         )
-      g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
-      g.connect_by_name( drc_pm,        debugcalibre   )
-
-  g.connect_by_name( iflow,    genlibdb       )
-
-  #-----------------------------------------------------------------------
-  # Parameterize
-  #-----------------------------------------------------------------------
-
-  g.update_params( parameters )
-
-  # Update PWR_AWARE variable
-  synth.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-  init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-  power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-
-  # Used in floorplan.tcl
-  init.update_params(  { 'adk': parameters['adk'] }, True )
-
-  if pwr_aware:
-      pwr_aware_gls.update_params( { 'design_name': parameters['design_name'] }, True )
-     
-      init.extend_postconditions(         ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-      place.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-      cts.extend_postconditions(          ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-      postcts_hold.extend_postconditions( ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-      route.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-      postroute.extend_postconditions(    ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-      signoff.extend_postconditions(      ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-   
-
-  # Core density target param
-  init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
-
-
-  # Disable pwr aware flow
-  #init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, allow_new=True )
-  #power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, allow_new=True  )
-
-  # Since we are adding an additional input script to the generic Innovus
-  # steps, we modify the order parameter for that node which determines
-  # which scripts get run and when they get run.
-
-  # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
-
-  order = init.get_param('order') # get the default script run order
-  path_group_idx = order.index( 'make-path-groups.tcl' ) 
-  order.insert( path_group_idx + 1, 'additional-path-groups.tcl' )
-  pin_idx = order.index( 'pin-assignments.tcl' ) # find pin-assignments.tcl
-  order.insert( pin_idx + 1, 'edge-blockages.tcl' ) # add here
-  init.update_params( { 'order': order } )
-  
-  # Adding new input for genlibdb node to run
-
-  order = genlibdb.get_param('order') # get the default script run order
-  extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
-  order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
-  genlibdb.update_params( { 'order': order } )
-
-  # genlibdb -- Remove 'write-interface-timing.tcl' beacuse it takes
-  # very long and is not necessary
-  order = genlibdb.get_param('order')
-  order.remove( 'write-interface-timing.tcl' )
-  genlibdb.update_params( { 'order': order } )
-
-  # Pwr aware steps:
-  if pwr_aware:
-      # init node
-      order = init.get_param('order')
-      read_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
-      order.insert( read_idx + 1, 'mem-load-upf.tcl' ) # add here
-      order.insert( read_idx + 2, 'mem-pd-params.tcl') # add here
-      order.insert( read_idx + 3, 'pd-aon-floorplan.tcl' ) # add here
-      order.insert( read_idx + 4, 'add-endcaps-welltaps-setup.tcl' ) # add here
-      order.insert( read_idx + 5, 'pd-add-endcaps-welltaps.tcl' ) # add here
-      order.insert( read_idx + 6, 'add-power-switches.tcl' ) # add here
-      order.remove('add-endcaps-welltaps.tcl')
-      order.append('check-clamp-logic-structure.tcl')
-      init.update_params( { 'order': order } )
-
-      # synth node (needs parm 'adk_allow_sdf_regs')
-      order = synth.get_param('order')
-      order.insert( 0, 'mem-pd-params.tcl' )        # add params file
-      synth.update_params( { 'order': order } )
-
-      # power node
-      order = power.get_param('order')
-      order.insert( 0, 'pd-globalnetconnect.tcl' ) # add new pd-globalnetconnect
-      order.remove('globalnetconnect.tcl')         # remove old globalnetconnect
-      order.insert( 0, 'mem-pd-params.tcl' )       # add params file
-      power.update_params( { 'order': order } )
-
-      # place node
-      order = place.get_param('order')
-      read_idx = order.index( 'main.tcl' ) # find main.tcl
-      order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
-      order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
-      order.append('check-clamp-logic-structure.tcl')
-      place.update_params( { 'order': order } )
-
-      # cts node
-      order = cts.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      order.append('check-clamp-logic-structure.tcl')
-      cts.update_params( { 'order': order } )
-
-      # postcts_hold node
-      order = postcts_hold.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      order.append('check-clamp-logic-structure.tcl')
-      postcts_hold.update_params( { 'order': order } )
-
-      # route node
-      order = route.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      order.append('check-clamp-logic-structure.tcl')
-      route.update_params( { 'order': order } )
-
-      # postroute node
-      order = postroute.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      order.append('check-clamp-logic-structure.tcl')
-      postroute.update_params( { 'order': order } )
-
-      # postroute-hold node
-      order = postroute_hold.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      postroute_hold.update_params( { 'order': order } )
-
-      # signoff node
-      order = signoff.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      order.append('check-clamp-logic-structure.tcl')
-      read_idx = order.index( 'generate-results.tcl' ) # find generate_results.tcl
-
-      order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
-      signoff.update_params( { 'order': order } )
-
-  return g
+    g = Graph()
+
+    #-----------------------------------------------------------------------
+    # Parameters
+    #-----------------------------------------------------------------------
+
+    adk_name = get_sys_adk()  # E.g. 'gf12-adk' or 'tsmc16'
+    adk_view = 'multivt'
+    pwr_aware = True
+
+    if pwr_aware:
+        adk_view = adk_view + '-pm'
+
+    synth_power = False
+    if os.environ.get('SYNTH_POWER') == 'True':
+        synth_power = True
+    # power domains do not work with post-synth power
+    if synth_power:
+        pwr_aware = False
+
+    want_drc_pm      = True
+
+    # TSMC override(s)
+    if adk_name == 'tsmc16':
+        adk_view    = 'multicorner-multivt'
+        want_drc_pm = False
+
+    if adk_name == 'tsmc16':
+        read_hdl_defines = 'TSMC16'
+    elif adk_name == 'gf12-adk':
+        read_hdl_defines = 'GF12'
+    else:
+        read_hdl_defines = ''
+
+    parameters = {
+      'construct_path'      : __file__,
+      'design_name'         : 'Tile_MemCore',
+      'clock_period'        : 1.1,
+      'adk'                 : adk_name,
+      'adk_view'            : adk_view,
+      # Synthesis
+      'flatten_effort'      : 3,
+      'topographical'       : True,
+      'read_hdl_defines'    : read_hdl_defines,
+      # SRAM macros
+      'num_words'           : 512,
+      'word_size'           : 32,
+      'mux_size'            : 4,
+      'partial_write'       : False,
+      # Hold target slack
+      'hold_target_slack'   : 0.030,
+      # Utilization target
+      'core_density_target' : 0.68,
+      # RTL Generation
+      'interconnect_only'   : False,
+      'rtl_docker_image'    : 'default', # Current default is 'stanfordaha/garnet:latest'
+      # Power Domains
+      'PWR_AWARE'         : pwr_aware,
+      # Power analysis
+      "use_sdf"           : False, # uses sdf but not the way it is in xrun node
+      'app_to_run'        : 'tests/conv_3_3',
+      'saif_instance'     : 'testbench/dut',
+      'testbench_name'    : 'testbench',
+      'strip_path'        : 'testbench/dut',
+      'drc_env_setup'     : 'drcenv-block.sh'
+    }
+
+    # TSMC overrides
+    if adk_name == 'tsmc16': parameters.update({
+      'corner'              : "tt0p8v25c",
+      'bc_corner'           : "ffg0p88v125c",
+      'hold_target_slack'   : 0.015,
+      'interconnect_only'   : True,
+    })
+
+    #-----------------------------------------------------------------------
+    # Create nodes
+    #-----------------------------------------------------------------------
+
+    this_dir = os.path.dirname( os.path.abspath( __file__ ) )
+
+    # ADK step
+
+    g.set_adk( adk_name )
+    adk = g.get_adk_step()
+
+    # Custom steps
+    rtl                  = Step( this_dir + '/../common/rtl'                          )
+    genlibdb_constraints = Step( this_dir + '/../common/custom-genlibdb-constraints'  )
+    constraints          = Step( this_dir + '/constraints'                            )
+    custom_init          = Step( this_dir + '/custom-init'                            )
+    custom_genus_scripts = Step( this_dir + '/custom-genus-scripts'                   )
+    custom_flowgen_setup = Step( this_dir + '/custom-flowgen-setup'                   )
+    if adk_name == 'tsmc16':
+        gen_sram             = Step( this_dir + '/../common/gen_sram_macro_amber'         )
+        custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber'                 )
+        custom_power         = Step( this_dir + '/../common/custom-power-leaf-amber'      )
+    else:
+        gen_sram             = Step( this_dir + '/../common/gen_sram_macro'               )
+        custom_lvs           = Step( this_dir + '/custom-lvs-rules'                       )
+        custom_power         = Step( this_dir + '/../common/custom-power-leaf'            )
+    testbench            = Step( this_dir + '/../common/testbench'                    )
+    application          = Step( this_dir + '/../common/application'                  )
+    lib2db               = Step( this_dir + '/../common/synopsys-dc-lib2db'           )
+    if want_drc_pm:
+        drc_pm             = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm' )
+    if synth_power:
+        post_synth_power     = Step( this_dir + '/../common/tile-post-synth-power'     )
+    post_pnr_power       = Step( this_dir + '/../common/tile-post-pnr-power'         )
+
+    # Power aware setup
+    if pwr_aware:
+        power_domains = Step( this_dir + '/../common/power-domains' )
+        pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls' )
+
+    # Default steps
+    info           = Step( 'info',                           default=True )
+    synth          = Step( 'cadence-genus-synthesis',        default=True )
+    iflow          = Step( 'cadence-innovus-flowsetup',      default=True )
+    init           = Step( 'cadence-innovus-init',           default=True )
+    power          = Step( 'cadence-innovus-power',          default=True )
+    place          = Step( 'cadence-innovus-place',          default=True )
+    cts            = Step( 'cadence-innovus-cts',            default=True )
+    postcts_hold   = Step( 'cadence-innovus-postcts_hold',   default=True )
+    route          = Step( 'cadence-innovus-route',          default=True )
+    postroute      = Step( 'cadence-innovus-postroute',      default=True )
+    postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
+    signoff        = Step( 'cadence-innovus-signoff',        default=True )
+    pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
+    genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
+
+    if which("calibre") is not None:
+        drc            = Step( 'mentor-calibre-drc',             default=True )
+        lvs            = Step( 'mentor-calibre-lvs',             default=True )
+    else:
+        drc            = Step( 'cadence-pegasus-drc',            default=True )
+        lvs            = Step( 'cadence-pegasus-lvs',            default=True )
+    debugcalibre   = Step( 'cadence-innovus-debug-calibre',  default=True )
+
+
+    # Extra DC input
+    synth.extend_inputs(["common.tcl"])
+    synth.extend_inputs(["simple_common.tcl"])
+
+    # Add sram macro inputs to downstream nodes
+
+    synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
+
+    pt_signoff.extend_inputs( ['sram_tt.db'] )
+    genlibdb.extend_inputs( ['sram_tt.lib', 'sram_tt.db'] )
+
+    # These steps need timing and lef info for srams
+
+    sram_steps = \
+      [iflow, init, power, place, cts, postcts_hold, route, postroute, postroute_hold, signoff]
+    for step in sram_steps:
+        step.extend_inputs( ['sram_tt.lib', 'sram_ff.lib', 'sram.lef'] )
+
+    # Need the sram gds to merge into the final layout
+
+    signoff.extend_inputs( ['sram.gds'] )
+
+    # Need SRAM spice file for LVS
+
+    lvs.extend_inputs( ['sram.spi'] )
+
+    # Add extra input edges to innovus steps that need custom tweaks
+
+    init.extend_inputs( custom_init.all_outputs() )
+    power.extend_inputs( custom_power.all_outputs() )
+
+    # Add extra input edges to genlibdb for loop-breaking constraints
+
+    genlibdb.extend_inputs( genlibdb_constraints.all_outputs() )
+    synth.extend_inputs( custom_genus_scripts.all_outputs() )
+    iflow.extend_inputs( custom_flowgen_setup.all_outputs() )
+
+    synth.extend_outputs( ["sdc"] )
+    iflow.extend_inputs( ["sdc"] )
+    init.extend_inputs( ["sdc"] )
+    power.extend_inputs( ["sdc"] )
+    place.extend_inputs( ["sdc"] )
+    cts.extend_inputs( ["sdc"] )
+
+    # Add graph inputs and outputs so this can be used in hierarchical flows
+
+    # Inputs
+    g.add_input( 'design.v', rtl.i('design.v') )
+
+    # Outputs
+    g.add_output( 'Tile_MemCore_tt.lib',      genlibdb.o('design.lib')       )
+    g.add_output( 'Tile_MemCore_tt.db',       genlibdb.o('design.db')        )
+    g.add_output( 'Tile_MemCore.lef',         signoff.o('design.lef')        )
+    g.add_output( 'Tile_MemCore.gds',         signoff.o('design-merged.gds') )
+    g.add_output( 'Tile_MemCore.sdf',         signoff.o('design.sdf')        )
+    g.add_output( 'Tile_MemCore.vcs.v',       signoff.o('design.vcs.v')      )
+    g.add_output( 'Tile_MemCore.vcs.pg.v',    signoff.o('design.vcs.pg.v')   )
+    g.add_output( 'Tile_MemCore.spef.gz',     signoff.o('design.spef.gz')    )
+    g.add_output( 'Tile_MemCore.pt.sdc',      signoff.o('design.pt.sdc')     )
+    g.add_output( 'Tile_MemCore.lvs.v',       lvs.o('design_merged.lvs.v')   )
+    g.add_output( 'sram.spi',                 gen_sram.o('sram.spi')         )
+    g.add_output( 'sram.v',                   gen_sram.o('sram.v')           )
+    g.add_output( 'sram_pwr.v',               gen_sram.o('sram_pwr.v')       )
+    g.add_output( 'sram_tt.db',               gen_sram.o('sram_tt.db')       )
+    g.add_output( 'sram_tt.lib',              gen_sram.o('sram_tt.lib')      )
+
+    order = synth.get_param( 'order' )
+    order.append( 'copy_sdc.tcl' )
+    synth.set_param( 'order', order )
+
+    # TSMC needs streamout *without* the (new) default -uniquify flag
+    # This strips off the unwanted flag
+    from common.streamout_no_uniquify import streamout_no_uniquify
+    if adk_name == "tsmc16": streamout_no_uniquify(iflow)
+
+    # Power aware setup
+    if pwr_aware:
+
+        # Need mem-pd-params so adk.tcl can access parm 'adk_allow_sdf_regs'
+        # (mem-pd-params come from already-connected 'power-domains' node)
+        synth.extend_inputs([
+          'mem-pd-params.tcl',
+          'designer-interface.tcl', 
+          'upf_Tile_MemCore.tcl', 
+          'mem-constraints.tcl', 
+          'mem-constraints-2.tcl', 
+          'dc-dont-use-constraints.tcl'])
+
+        init.extend_inputs(['check-clamp-logic-structure.tcl', 'upf_Tile_MemCore.tcl', 'mem-load-upf.tcl', 'dont-touch-constraints.tcl', 'mem-pd-params.tcl', 'pd-aon-floorplan.tcl', 'add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'add-power-switches.tcl'])
+        place.extend_inputs(['check-clamp-logic-structure.tcl', 'place-dont-use-constraints.tcl', 'add-aon-tie-cells.tcl'])
+
+        # Need mem-pd-params for parm 'vdd_m3_stripe_sparsity'
+        # pd-globalnetconnect, mem-pd-params come from 'power-domains' node
+        power.extend_inputs(['pd-globalnetconnect.tcl', 'mem-pd-params.tcl'] )
+
+        cts.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'])
+        postcts_hold.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
+        route.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
+        postroute.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
+        postroute_hold.extend_inputs(['conn-aon-cells-vdd.tcl'] )
+        signoff.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl'] )
+        pwr_aware_gls.extend_inputs(['design.vcs.pg.v', 'sram_pwr.v'])
+
+    #-----------------------------------------------------------------------
+    # Graph -- Add nodes
+    #-----------------------------------------------------------------------
+
+    g.add_step( info                 )
+    g.add_step( rtl                  )
+    g.add_step( gen_sram             )
+    g.add_step( constraints          )
+    g.add_step( synth                )
+    g.add_step( custom_genus_scripts )
+    g.add_step( iflow                )
+    g.add_step( custom_flowgen_setup )
+    g.add_step( init                 )
+    g.add_step( custom_init          )
+    g.add_step( power                )
+    g.add_step( custom_power         )
+    g.add_step( place                )
+    g.add_step( cts                  )
+    g.add_step( postcts_hold         )
+    g.add_step( route                )
+    g.add_step( postroute            )
+    g.add_step( postroute_hold       )
+    g.add_step( signoff              )
+    g.add_step( pt_signoff           )
+    g.add_step( genlibdb_constraints )
+    g.add_step( genlibdb             )
+    g.add_step( lib2db               )
+    g.add_step( drc                  )
+    g.add_step( lvs                  )
+    g.add_step( custom_lvs           )
+    g.add_step( debugcalibre         )
+
+    g.add_step( application          )
+    g.add_step( testbench            )
+    if synth_power:
+        g.add_step( post_synth_power   )
+    g.add_step( post_pnr_power       )
+
+    # Power aware step
+    if pwr_aware:
+        g.add_step( power_domains    )
+        g.add_step( pwr_aware_gls    )
+
+    #-----------------------------------------------------------------------
+    # Graph -- Add edges
+    #-----------------------------------------------------------------------
+
+    # Connect by name
+
+    g.connect_by_name( adk,      gen_sram       )
+    g.connect_by_name( adk,      synth          )
+    g.connect_by_name( adk,      iflow          )
+    g.connect_by_name( adk,      init           )
+    g.connect_by_name( adk,      power          )
+    g.connect_by_name( adk,      place          )
+    g.connect_by_name( adk,      cts            )
+    g.connect_by_name( adk,      postcts_hold   )
+    g.connect_by_name( adk,      route          )
+    g.connect_by_name( adk,      postroute      )
+    g.connect_by_name( adk,      postroute_hold )
+    g.connect_by_name( adk,      signoff        )
+    g.connect_by_name( adk,      drc            )
+    g.connect_by_name( adk,      lvs            )
+
+    g.connect_by_name( gen_sram,      synth          )
+    g.connect_by_name( gen_sram,      iflow          )
+    g.connect_by_name( gen_sram,      init           )
+    g.connect_by_name( gen_sram,      power          )
+    g.connect_by_name( gen_sram,      place          )
+    g.connect_by_name( gen_sram,      cts            )
+    g.connect_by_name( gen_sram,      postcts_hold   )
+    g.connect_by_name( gen_sram,      route          )
+    g.connect_by_name( gen_sram,      postroute      )
+    g.connect_by_name( gen_sram,      postroute_hold )
+    g.connect_by_name( gen_sram,      signoff        )
+    g.connect_by_name( gen_sram,      genlibdb       )
+    g.connect_by_name( gen_sram,      pt_signoff     )
+    g.connect_by_name( gen_sram,      drc            )
+    g.connect_by_name( gen_sram,      lvs            )
+
+    g.connect_by_name( rtl,         synth     )
+    g.connect_by_name( constraints, synth     )
+    g.connect_by_name( custom_genus_scripts, synth )
+
+    g.connect_by_name( synth,       iflow        )
+    g.connect_by_name( synth,       init         )
+    g.connect_by_name( synth,       power        )
+    g.connect_by_name( synth,       place        )
+    g.connect_by_name( synth,       cts          )
+    g.connect_by_name( custom_flowgen_setup, iflow )
+
+    g.connect_by_name( iflow,    init           )
+    g.connect_by_name( iflow,    power          )
+    g.connect_by_name( iflow,    place          )
+    g.connect_by_name( iflow,    cts            )
+    g.connect_by_name( iflow,    postcts_hold   )
+    g.connect_by_name( iflow,    route          )
+    g.connect_by_name( iflow,    postroute      )
+    g.connect_by_name( iflow,    postroute_hold )
+    g.connect_by_name( iflow,    signoff        )
+
+    g.connect_by_name( custom_init,  init     )
+    g.connect_by_name( custom_power, power    )
+    g.connect_by_name( custom_lvs,   lvs      )
+
+    g.connect_by_name( init,           power          )
+    g.connect_by_name( power,          place          )
+    g.connect_by_name( place,          cts            )
+    g.connect_by_name( cts,            postcts_hold   )
+    g.connect_by_name( postcts_hold,   route          )
+    g.connect_by_name( route,          postroute      )
+    g.connect_by_name( postroute,      postroute_hold )
+    g.connect_by_name( postroute_hold, signoff        )
+    g.connect_by_name( signoff,        drc            )
+    g.connect_by_name( signoff,        lvs            )
+    g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
+    g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
+
+    g.connect_by_name( signoff,              genlibdb )
+    g.connect_by_name( adk,                  genlibdb )
+    g.connect_by_name( genlibdb_constraints, genlibdb )
+
+    g.connect_by_name( genlibdb,             lib2db   )
+
+    g.connect_by_name( adk,          pt_signoff   )
+    g.connect_by_name( signoff,      pt_signoff   )
+
+    g.connect_by_name( application, testbench       )
+    if synth_power:
+        g.connect_by_name( application, post_synth_power )
+        g.connect_by_name( gen_sram,    post_synth_power )
+        g.connect_by_name( synth,       post_synth_power )
+        g.connect_by_name( testbench,   post_synth_power )
+    g.connect_by_name( application, post_pnr_power )
+    g.connect_by_name( gen_sram,    post_pnr_power )
+    g.connect_by_name( signoff,     post_pnr_power )
+    g.connect_by_name( pt_signoff,  post_pnr_power )
+    g.connect_by_name( testbench,   post_pnr_power )
+
+    g.connect_by_name( adk,      debugcalibre )
+    g.connect_by_name( synth,    debugcalibre )
+    g.connect_by_name( iflow,    debugcalibre )
+    g.connect_by_name( signoff,  debugcalibre )
+    g.connect_by_name( drc,      debugcalibre )
+    g.connect_by_name( lvs,      debugcalibre )
+
+    # Pwr aware steps:
+    if pwr_aware:
+        g.connect_by_name( power_domains,        synth          )
+        g.connect_by_name( power_domains,        init           )
+        g.connect_by_name( power_domains,        power          )
+        g.connect_by_name( power_domains,        place          )
+        g.connect_by_name( power_domains,        cts            )
+        g.connect_by_name( power_domains,        postcts_hold   )
+        g.connect_by_name( power_domains,        route          )
+        g.connect_by_name( power_domains,        postroute      )
+        g.connect_by_name( power_domains,        postroute_hold )
+        g.connect_by_name( power_domains,        signoff        )
+        g.connect_by_name( adk,                  pwr_aware_gls)
+        g.connect_by_name( gen_sram,             pwr_aware_gls)
+        g.connect_by_name( signoff,              pwr_aware_gls)
+        #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
+
+    # New step, added for gf12
+    if want_drc_pm:
+        g.add_step( drc_pm )
+        g.connect_by_name( adk,           drc_pm         )
+        g.connect_by_name( gen_sram,      drc_pm         )
+        g.connect_by_name( signoff,       drc_pm         )
+        g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
+        g.connect_by_name( drc_pm,        debugcalibre   )
+
+    g.connect_by_name( iflow,    genlibdb       )
+
+    #-----------------------------------------------------------------------
+    # Parameterize
+    #-----------------------------------------------------------------------
+
+    g.update_params( parameters )
+
+    # Update PWR_AWARE variable
+    synth.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
+    init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
+    power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
+
+    # Used in floorplan.tcl
+    init.update_params(  { 'adk': parameters['adk'] }, True )
+
+    if pwr_aware:
+        pwr_aware_gls.update_params( { 'design_name': parameters['design_name'] }, True )
+
+        init.extend_postconditions(         ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        place.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        cts.extend_postconditions(          ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        postcts_hold.extend_postconditions( ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        route.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        postroute.extend_postconditions(    ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        signoff.extend_postconditions(      ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+
+
+    # Core density target param
+    init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
+
+
+    # Disable pwr aware flow
+    #init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, allow_new=True )
+    #power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, allow_new=True  )
+
+    # Since we are adding an additional input script to the generic Innovus
+    # steps, we modify the order parameter for that node which determines
+    # which scripts get run and when they get run.
+
+    # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
+
+    order = init.get_param('order') # get the default script run order
+    path_group_idx = order.index( 'make-path-groups.tcl' ) 
+    order.insert( path_group_idx + 1, 'additional-path-groups.tcl' )
+    pin_idx = order.index( 'pin-assignments.tcl' ) # find pin-assignments.tcl
+    order.insert( pin_idx + 1, 'edge-blockages.tcl' ) # add here
+    init.update_params( { 'order': order } )
+
+    # Adding new input for genlibdb node to run
+
+    order = genlibdb.get_param('order') # get the default script run order
+    extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
+    order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
+    genlibdb.update_params( { 'order': order } )
+
+    # genlibdb -- Remove 'write-interface-timing.tcl' beacuse it takes
+    # very long and is not necessary
+    order = genlibdb.get_param('order')
+    order.remove( 'write-interface-timing.tcl' )
+    genlibdb.update_params( { 'order': order } )
+
+    # Pwr aware steps:
+    if pwr_aware:
+        # init node
+        order = init.get_param('order')
+        read_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
+        order.insert( read_idx + 1, 'mem-load-upf.tcl' ) # add here
+        order.insert( read_idx + 2, 'mem-pd-params.tcl') # add here
+        order.insert( read_idx + 3, 'pd-aon-floorplan.tcl' ) # add here
+        order.insert( read_idx + 4, 'add-endcaps-welltaps-setup.tcl' ) # add here
+        order.insert( read_idx + 5, 'pd-add-endcaps-welltaps.tcl' ) # add here
+        order.insert( read_idx + 6, 'add-power-switches.tcl' ) # add here
+        order.remove('add-endcaps-welltaps.tcl')
+        order.append('check-clamp-logic-structure.tcl')
+        init.update_params( { 'order': order } )
+
+        # synth node (needs parm 'adk_allow_sdf_regs')
+        order = synth.get_param('order')
+        order.insert( 0, 'mem-pd-params.tcl' )        # add params file
+        synth.update_params( { 'order': order } )
+
+        # power node
+        order = power.get_param('order')
+        order.insert( 0, 'pd-globalnetconnect.tcl' ) # add new pd-globalnetconnect
+        order.remove('globalnetconnect.tcl')         # remove old globalnetconnect
+        order.insert( 0, 'mem-pd-params.tcl' )       # add params file
+        power.update_params( { 'order': order } )
+
+        # place node
+        order = place.get_param('order')
+        read_idx = order.index( 'main.tcl' ) # find main.tcl
+        order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
+        order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
+        order.append('check-clamp-logic-structure.tcl')
+        place.update_params( { 'order': order } )
+
+        # cts node
+        order = cts.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.append('check-clamp-logic-structure.tcl')
+        cts.update_params( { 'order': order } )
+
+        # postcts_hold node
+        order = postcts_hold.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.append('check-clamp-logic-structure.tcl')
+        postcts_hold.update_params( { 'order': order } )
+
+        # route node
+        order = route.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.append('check-clamp-logic-structure.tcl')
+        route.update_params( { 'order': order } )
+
+        # postroute node
+        order = postroute.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.append('check-clamp-logic-structure.tcl')
+        postroute.update_params( { 'order': order } )
+
+        # postroute-hold node
+        order = postroute_hold.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        postroute_hold.update_params( { 'order': order } )
+
+        # signoff node
+        order = signoff.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.append('check-clamp-logic-structure.tcl')
+        read_idx = order.index( 'generate-results.tcl' ) # find generate_results.tcl
+
+        order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
+        signoff.update_params( { 'order': order } )
+
+    return g
 
 
 if __name__ == '__main__':
-  g = construct()
+    g = construct()
 #  g.plot()
 
 

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
-#=========================================================================
+# =========================================================================
 # construct.py
-#=========================================================================
+# =========================================================================
 # Author :
 # Date   :
 
@@ -14,9 +14,9 @@ def construct():
 
     g = Graph()
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Parameters
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     adk_name = get_sys_adk()  # E.g. 'gf12-adk' or 'tsmc16'
     adk_view = 'multivt'
@@ -87,9 +87,9 @@ def construct():
       'interconnect_only'   : True,
     })
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Create nodes
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     this_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -268,9 +268,9 @@ def construct():
         signoff.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl'])
         pwr_aware_gls.extend_inputs(['design.vcs.pg.v', 'sram_pwr.v'])
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Graph -- Add nodes
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     g.add_step(info)
     g.add_step(rtl)
@@ -311,9 +311,9 @@ def construct():
         g.add_step(power_domains)
         g.add_step(pwr_aware_gls)
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Graph -- Add edges
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     # Connect by name
 
@@ -436,7 +436,7 @@ def construct():
         g.connect_by_name(adk, pwr_aware_gls)
         g.connect_by_name(gen_sram, pwr_aware_gls)
         g.connect_by_name(signoff, pwr_aware_gls)
-        #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
+        # g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
 
     # New step, added for gf12
     if want_drc_pm:
@@ -450,9 +450,9 @@ def construct():
 
     g.connect_by_name(iflow, genlibdb)
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Parameterize
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     g.update_params(parameters)
 
@@ -482,8 +482,8 @@ def construct():
 
 
     # Disable pwr aware flow
-    #init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, allow_new=True )
-    #power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, allow_new=True  )
+    # init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, allow_new=True )
+    # power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, allow_new=True  )
 
     # Since we are adding an additional input script to the generic Innovus
     # steps, we modify the order parameter for that node which determines

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -128,28 +128,35 @@ def construct():
         pwr_aware_gls = Step(this_dir + '/../common/pwr-aware-gls')
 
     # Default steps
-    info           = Step('info',                           default=True)
-    synth          = Step('cadence-genus-synthesis',        default=True)
-    iflow          = Step('cadence-innovus-flowsetup',      default=True)
-    init           = Step('cadence-innovus-init',           default=True)
-    power          = Step('cadence-innovus-power',          default=True)
-    place          = Step('cadence-innovus-place',          default=True)
-    cts            = Step('cadence-innovus-cts',            default=True)
-    postcts_hold   = Step('cadence-innovus-postcts_hold',   default=True)
-    route          = Step('cadence-innovus-route',          default=True)
-    postroute      = Step('cadence-innovus-postroute',      default=True)
-    postroute_hold = Step('cadence-innovus-postroute_hold', default=True)
-    signoff        = Step('cadence-innovus-signoff',        default=True)
-    pt_signoff     = Step('synopsys-pt-timing-signoff',     default=True)
-    genlibdb       = Step('synopsys-ptpx-genlibdb',         default=True)
+
+    def default_step(step_name):
+        return Step(step_name, default=True)
+
+    # Turn off formatting b/c want these columns to line up
+    # autopep8: off
+    info           = default_step('info')                       # noqa
+    synth          = default_step('cadence-genus-synthesis')    # noqa
+    iflow          = default_step('cadence-innovus-flowsetup')  # noqa
+    init           = default_step('cadence-innovus-init')       # noqa
+    power          = default_step('cadence-innovus-power')      # noqa
+    place          = default_step('cadence-innovus-place')      # noqa
+    cts            = default_step('cadence-innovus-cts')        # noqa
+    postcts_hold   = default_step('cadence-innovus-postcts_hold')    # noqa
+    route          = default_step('cadence-innovus-route')           # noqa
+    postroute      = default_step('cadence-innovus-postroute')       # noqa
+    postroute_hold = default_step('cadence-innovus-postroute_hold')  # noqa
+    signoff        = default_step('cadence-innovus-signoff')         # noqa
+    pt_signoff     = default_step('synopsys-pt-timing-signoff')      # noqa
+    genlibdb       = default_step('synopsys-ptpx-genlibdb')          # noqa
+    # autopep8: on
 
     if which("calibre") is not None:
-        drc            = Step('mentor-calibre-drc',             default=True)
-        lvs            = Step('mentor-calibre-lvs',             default=True)
+        drc = default_step('mentor-calibre-drc')
+        lvs = default_step('mentor-calibre-lvs')
     else:
-        drc            = Step('cadence-pegasus-drc',            default=True)
-        lvs            = Step('cadence-pegasus-lvs',            default=True)
-    debugcalibre   = Step('cadence-innovus-debug-calibre',  default=True)
+        drc = default_step('cadence-pegasus-drc')
+        lvs = default_step('cadence-pegasus-lvs')
+    debugcalibre = default_step('cadence-innovus-debug-calibre')
 
 
     # Extra DC input
@@ -201,22 +208,28 @@ def construct():
     # Inputs
     g.add_input('design.v', rtl.i('design.v'))
 
+    # Turn off formatting b/c want below columns to line up (is this bad?)
+    # autopep8: off
+
     # Outputs
-    g.add_output('Tile_MemCore_tt.lib',      genlibdb.o('design.lib'))
-    g.add_output('Tile_MemCore_tt.db',       genlibdb.o('design.db'))
-    g.add_output('Tile_MemCore.lef',         signoff.o('design.lef'))
-    g.add_output('Tile_MemCore.gds',         signoff.o('design-merged.gds'))
-    g.add_output('Tile_MemCore.sdf',         signoff.o('design.sdf'))
-    g.add_output('Tile_MemCore.vcs.v',       signoff.o('design.vcs.v'))
-    g.add_output('Tile_MemCore.vcs.pg.v',    signoff.o('design.vcs.pg.v'))
-    g.add_output('Tile_MemCore.spef.gz',     signoff.o('design.spef.gz'))
-    g.add_output('Tile_MemCore.pt.sdc',      signoff.o('design.pt.sdc'))
-    g.add_output('Tile_MemCore.lvs.v',       lvs.o('design_merged.lvs.v'))
-    g.add_output('sram.spi',                 gen_sram.o('sram.spi'))
-    g.add_output('sram.v',                   gen_sram.o('sram.v'))
-    g.add_output('sram_pwr.v',               gen_sram.o('sram_pwr.v'))
-    g.add_output('sram_tt.db',               gen_sram.o('sram_tt.db'))
-    g.add_output('sram_tt.lib',              gen_sram.o('sram_tt.lib'))
+    g.add_output('Tile_MemCore_tt.lib',    genlibdb.o('design.lib'))        # noqa
+    g.add_output('Tile_MemCore_tt.db',     genlibdb.o('design.db'))         # noqa
+    g.add_output('Tile_MemCore.lef',       signoff.o('design.lef'))         # noqa
+    g.add_output('Tile_MemCore.gds',       signoff.o('design-merged.gds'))  # noqa
+    g.add_output('Tile_MemCore.sdf',       signoff.o('design.sdf'))         # noqa
+    g.add_output('Tile_MemCore.vcs.v',     signoff.o('design.vcs.v'))       # noqa
+    g.add_output('Tile_MemCore.vcs.pg.v',  signoff.o('design.vcs.pg.v'))    # noqa
+    g.add_output('Tile_MemCore.spef.gz',   signoff.o('design.spef.gz'))     # noqa
+    g.add_output('Tile_MemCore.pt.sdc',    signoff.o('design.pt.sdc'))      # noqa
+    g.add_output('Tile_MemCore.lvs.v',     lvs.o('design_merged.lvs.v'))    # noqa
+
+    g.add_output('sram.spi',               gen_sram.o('sram.spi'))          # noqa
+    g.add_output('sram.v',                 gen_sram.o('sram.v'))            # noqa
+    g.add_output('sram_pwr.v',             gen_sram.o('sram_pwr.v'))        # noqa
+    g.add_output('sram_tt.db',             gen_sram.o('sram_tt.db'))        # noqa
+    g.add_output('sram_tt.lib',            gen_sram.o('sram_tt.lib'))       # noqa
+
+    # autopep8: on
 
     order = synth.get_param('order')
     order.append('copy_sdc.tcl')
@@ -304,130 +317,138 @@ def construct():
 
     # Connect by name
 
-    g.connect_by_name(adk,      gen_sram)
-    g.connect_by_name(adk,      synth)
-    g.connect_by_name(adk,      iflow)
-    g.connect_by_name(adk,      init)
-    g.connect_by_name(adk,      power)
-    g.connect_by_name(adk,      place)
-    g.connect_by_name(adk,      cts)
-    g.connect_by_name(adk,      postcts_hold)
-    g.connect_by_name(adk,      route)
-    g.connect_by_name(adk,      postroute)
-    g.connect_by_name(adk,      postroute_hold)
-    g.connect_by_name(adk,      signoff)
-    g.connect_by_name(adk,      drc)
-    g.connect_by_name(adk,      lvs)
+    g.connect_by_name(adk, gen_sram)
+    g.connect_by_name(adk, synth)
+    g.connect_by_name(adk, iflow)
+    g.connect_by_name(adk, init)
+    g.connect_by_name(adk, power)
+    g.connect_by_name(adk, place)
+    g.connect_by_name(adk, cts)
+    g.connect_by_name(adk, postcts_hold)
+    g.connect_by_name(adk, route)
+    g.connect_by_name(adk, postroute)
+    g.connect_by_name(adk, postroute_hold)
+    g.connect_by_name(adk, signoff)
+    g.connect_by_name(adk, drc)
+    g.connect_by_name(adk, lvs)
 
-    g.connect_by_name(gen_sram,      synth)
-    g.connect_by_name(gen_sram,      iflow)
-    g.connect_by_name(gen_sram,      init)
-    g.connect_by_name(gen_sram,      power)
-    g.connect_by_name(gen_sram,      place)
-    g.connect_by_name(gen_sram,      cts)
-    g.connect_by_name(gen_sram,      postcts_hold)
-    g.connect_by_name(gen_sram,      route)
-    g.connect_by_name(gen_sram,      postroute)
-    g.connect_by_name(gen_sram,      postroute_hold)
-    g.connect_by_name(gen_sram,      signoff)
-    g.connect_by_name(gen_sram,      genlibdb)
-    g.connect_by_name(gen_sram,      pt_signoff)
-    g.connect_by_name(gen_sram,      drc)
-    g.connect_by_name(gen_sram,      lvs)
+    g.connect_by_name(gen_sram, synth)
+    g.connect_by_name(gen_sram, iflow)
+    g.connect_by_name(gen_sram, init)
+    g.connect_by_name(gen_sram, power)
+    g.connect_by_name(gen_sram, place)
+    g.connect_by_name(gen_sram, cts)
+    g.connect_by_name(gen_sram, postcts_hold)
+    g.connect_by_name(gen_sram, route)
+    g.connect_by_name(gen_sram, postroute)
+    g.connect_by_name(gen_sram, postroute_hold)
+    g.connect_by_name(gen_sram, signoff)
+    g.connect_by_name(gen_sram, genlibdb)
+    g.connect_by_name(gen_sram, pt_signoff)
+    g.connect_by_name(gen_sram, drc)
+    g.connect_by_name(gen_sram, lvs)
 
-    g.connect_by_name(rtl,         synth)
+    g.connect_by_name(rtl, synth)
     g.connect_by_name(constraints, synth)
     g.connect_by_name(custom_genus_scripts, synth)
 
-    g.connect_by_name(synth,       iflow)
-    g.connect_by_name(synth,       init)
-    g.connect_by_name(synth,       power)
-    g.connect_by_name(synth,       place)
-    g.connect_by_name(synth,       cts)
+    g.connect_by_name(synth, iflow)
+    g.connect_by_name(synth, init)
+    g.connect_by_name(synth, power)
+    g.connect_by_name(synth, place)
+    g.connect_by_name(synth, cts)
     g.connect_by_name(custom_flowgen_setup, iflow)
 
-    g.connect_by_name(iflow,    init)
-    g.connect_by_name(iflow,    power)
-    g.connect_by_name(iflow,    place)
-    g.connect_by_name(iflow,    cts)
-    g.connect_by_name(iflow,    postcts_hold)
-    g.connect_by_name(iflow,    route)
-    g.connect_by_name(iflow,    postroute)
-    g.connect_by_name(iflow,    postroute_hold)
-    g.connect_by_name(iflow,    signoff)
+    g.connect_by_name(iflow, init)
+    g.connect_by_name(iflow, power)
+    g.connect_by_name(iflow, place)
+    g.connect_by_name(iflow, cts)
+    g.connect_by_name(iflow, postcts_hold)
+    g.connect_by_name(iflow, route)
+    g.connect_by_name(iflow, postroute)
+    g.connect_by_name(iflow, postroute_hold)
+    g.connect_by_name(iflow, signoff)
 
-    g.connect_by_name(custom_init,  init)
+    g.connect_by_name(custom_init, init)
     g.connect_by_name(custom_power, power)
-    g.connect_by_name(custom_lvs,   lvs)
+    g.connect_by_name(custom_lvs, lvs)
 
-    g.connect_by_name(init,           power)
-    g.connect_by_name(power,          place)
-    g.connect_by_name(place,          cts)
-    g.connect_by_name(cts,            postcts_hold)
-    g.connect_by_name(postcts_hold,   route)
-    g.connect_by_name(route,          postroute)
-    g.connect_by_name(postroute,      postroute_hold)
+    g.connect_by_name(init, power)
+    g.connect_by_name(power, place)
+    g.connect_by_name(place, cts)
+    g.connect_by_name(cts, postcts_hold)
+    g.connect_by_name(postcts_hold, route)
+    g.connect_by_name(route, postroute)
+    g.connect_by_name(postroute, postroute_hold)
     g.connect_by_name(postroute_hold, signoff)
-    g.connect_by_name(signoff,        drc)
-    g.connect_by_name(signoff,        lvs)
+    g.connect_by_name(signoff, drc)
+    g.connect_by_name(signoff, lvs)
+
     g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
     g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
-    g.connect_by_name(signoff,              genlibdb)
-    g.connect_by_name(adk,                  genlibdb)
+    g.connect_by_name(signoff, genlibdb)
+    g.connect_by_name(adk, genlibdb)
     g.connect_by_name(genlibdb_constraints, genlibdb)
 
-    g.connect_by_name(genlibdb,             lib2db)
+    g.connect_by_name(genlibdb, lib2db)
 
-    g.connect_by_name(adk,          pt_signoff)
-    g.connect_by_name(signoff,      pt_signoff)
+    g.connect_by_name(adk, pt_signoff)
+    g.connect_by_name(signoff, pt_signoff)
 
     g.connect_by_name(application, testbench)
-    if synth_power:
-        g.connect_by_name(application, post_synth_power)
-        g.connect_by_name(gen_sram,    post_synth_power)
-        g.connect_by_name(synth,       post_synth_power)
-        g.connect_by_name(testbench,   post_synth_power)
-    g.connect_by_name(application, post_pnr_power)
-    g.connect_by_name(gen_sram,    post_pnr_power)
-    g.connect_by_name(signoff,     post_pnr_power)
-    g.connect_by_name(pt_signoff,  post_pnr_power)
-    g.connect_by_name(testbench,   post_pnr_power)
 
-    g.connect_by_name(adk,      debugcalibre)
-    g.connect_by_name(synth,    debugcalibre)
-    g.connect_by_name(iflow,    debugcalibre)
-    g.connect_by_name(signoff,  debugcalibre)
-    g.connect_by_name(drc,      debugcalibre)
-    g.connect_by_name(lvs,      debugcalibre)
+    def reverse_connect(node1, node2):
+        g.connect_by_name(node2, node1)
+
+    if synth_power:
+        reverse_connect(post_synth_power, application)
+        reverse_connect(post_synth_power, gen_sram)
+        reverse_connect(post_synth_power, synth)
+        reverse_connect(post_synth_power, testbench)
+
+    reverse_connect(post_pnr_power, application)
+    reverse_connect(post_pnr_power, gen_sram)
+    reverse_connect(post_pnr_power, signoff)
+    reverse_connect(post_pnr_power, pt_signoff)
+    reverse_connect(post_pnr_power, testbench)
+
+    reverse_connect(debugcalibre, adk)
+    reverse_connect(debugcalibre, synth)
+    reverse_connect(debugcalibre, iflow)
+    reverse_connect(debugcalibre, signoff)
+    reverse_connect(debugcalibre, drc)
+    reverse_connect(debugcalibre, lvs)
 
     # Pwr aware steps:
     if pwr_aware:
-        g.connect_by_name(power_domains,        synth)
-        g.connect_by_name(power_domains,        init)
-        g.connect_by_name(power_domains,        power)
-        g.connect_by_name(power_domains,        place)
-        g.connect_by_name(power_domains,        cts)
-        g.connect_by_name(power_domains,        postcts_hold)
-        g.connect_by_name(power_domains,        route)
-        g.connect_by_name(power_domains,        postroute)
-        g.connect_by_name(power_domains,        postroute_hold)
-        g.connect_by_name(power_domains,        signoff)
-        g.connect_by_name(adk,                  pwr_aware_gls)
-        g.connect_by_name(gen_sram,             pwr_aware_gls)
-        g.connect_by_name(signoff,              pwr_aware_gls)
+        g.connect_by_name(power_domains, synth)
+        g.connect_by_name(power_domains, init)
+        g.connect_by_name(power_domains, power)
+        g.connect_by_name(power_domains, place)
+        g.connect_by_name(power_domains, cts)
+        g.connect_by_name(power_domains, postcts_hold)
+        g.connect_by_name(power_domains, route)
+        g.connect_by_name(power_domains, postroute)
+        g.connect_by_name(power_domains, postroute_hold)
+        g.connect_by_name(power_domains, signoff)
+
+        g.connect_by_name(adk, pwr_aware_gls)
+        g.connect_by_name(gen_sram, pwr_aware_gls)
+        g.connect_by_name(signoff, pwr_aware_gls)
         #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
 
     # New step, added for gf12
     if want_drc_pm:
         g.add_step(drc_pm)
-        g.connect_by_name(adk,           drc_pm)
-        g.connect_by_name(gen_sram,      drc_pm)
-        g.connect_by_name(signoff,       drc_pm)
-        g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
-        g.connect_by_name(drc_pm,        debugcalibre)
+        g.connect_by_name(adk, drc_pm)
+        g.connect_by_name(gen_sram, drc_pm)
+        g.connect_by_name(signoff, drc_pm)
 
-    g.connect_by_name(iflow,    genlibdb)
+        g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
+        g.connect_by_name(drc_pm, debugcalibre)
+
+    g.connect_by_name(iflow, genlibdb)
 
     #-----------------------------------------------------------------------
     # Parameterize

--- a/mflowgen/Tile_MemCore/construct.py
+++ b/mflowgen/Tile_MemCore/construct.py
@@ -91,65 +91,65 @@ def construct():
     # Create nodes
     #-----------------------------------------------------------------------
 
-    this_dir = os.path.dirname( os.path.abspath( __file__ ) )
+    this_dir = os.path.dirname( os.path.abspath( __file__))
 
     # ADK step
 
-    g.set_adk( adk_name )
+    g.set_adk( adk_name)
     adk = g.get_adk_step()
 
     # Custom steps
-    rtl                  = Step( this_dir + '/../common/rtl'                          )
-    genlibdb_constraints = Step( this_dir + '/../common/custom-genlibdb-constraints'  )
-    constraints          = Step( this_dir + '/constraints'                            )
-    custom_init          = Step( this_dir + '/custom-init'                            )
-    custom_genus_scripts = Step( this_dir + '/custom-genus-scripts'                   )
-    custom_flowgen_setup = Step( this_dir + '/custom-flowgen-setup'                   )
+    rtl                  = Step( this_dir + '/../common/rtl')
+    genlibdb_constraints = Step( this_dir + '/../common/custom-genlibdb-constraints')
+    constraints          = Step( this_dir + '/constraints')
+    custom_init          = Step( this_dir + '/custom-init')
+    custom_genus_scripts = Step( this_dir + '/custom-genus-scripts')
+    custom_flowgen_setup = Step( this_dir + '/custom-flowgen-setup')
     if adk_name == 'tsmc16':
-        gen_sram             = Step( this_dir + '/../common/gen_sram_macro_amber'         )
-        custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber'                 )
-        custom_power         = Step( this_dir + '/../common/custom-power-leaf-amber'      )
+        gen_sram             = Step( this_dir + '/../common/gen_sram_macro_amber')
+        custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber')
+        custom_power         = Step( this_dir + '/../common/custom-power-leaf-amber')
     else:
-        gen_sram             = Step( this_dir + '/../common/gen_sram_macro'               )
-        custom_lvs           = Step( this_dir + '/custom-lvs-rules'                       )
-        custom_power         = Step( this_dir + '/../common/custom-power-leaf'            )
-    testbench            = Step( this_dir + '/../common/testbench'                    )
-    application          = Step( this_dir + '/../common/application'                  )
-    lib2db               = Step( this_dir + '/../common/synopsys-dc-lib2db'           )
+        gen_sram             = Step( this_dir + '/../common/gen_sram_macro')
+        custom_lvs           = Step( this_dir + '/custom-lvs-rules')
+        custom_power         = Step( this_dir + '/../common/custom-power-leaf')
+    testbench            = Step( this_dir + '/../common/testbench')
+    application          = Step( this_dir + '/../common/application')
+    lib2db               = Step( this_dir + '/../common/synopsys-dc-lib2db')
     if want_drc_pm:
-        drc_pm             = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm' )
+        drc_pm             = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
     if synth_power:
-        post_synth_power     = Step( this_dir + '/../common/tile-post-synth-power'     )
-    post_pnr_power       = Step( this_dir + '/../common/tile-post-pnr-power'         )
+        post_synth_power     = Step( this_dir + '/../common/tile-post-synth-power')
+    post_pnr_power       = Step( this_dir + '/../common/tile-post-pnr-power')
 
     # Power aware setup
     if pwr_aware:
-        power_domains = Step( this_dir + '/../common/power-domains' )
-        pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls' )
+        power_domains = Step( this_dir + '/../common/power-domains')
+        pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls')
 
     # Default steps
-    info           = Step( 'info',                           default=True )
-    synth          = Step( 'cadence-genus-synthesis',        default=True )
-    iflow          = Step( 'cadence-innovus-flowsetup',      default=True )
-    init           = Step( 'cadence-innovus-init',           default=True )
-    power          = Step( 'cadence-innovus-power',          default=True )
-    place          = Step( 'cadence-innovus-place',          default=True )
-    cts            = Step( 'cadence-innovus-cts',            default=True )
-    postcts_hold   = Step( 'cadence-innovus-postcts_hold',   default=True )
-    route          = Step( 'cadence-innovus-route',          default=True )
-    postroute      = Step( 'cadence-innovus-postroute',      default=True )
-    postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
-    signoff        = Step( 'cadence-innovus-signoff',        default=True )
-    pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
-    genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
+    info           = Step( 'info',                           default=True)
+    synth          = Step( 'cadence-genus-synthesis',        default=True)
+    iflow          = Step( 'cadence-innovus-flowsetup',      default=True)
+    init           = Step( 'cadence-innovus-init',           default=True)
+    power          = Step( 'cadence-innovus-power',          default=True)
+    place          = Step( 'cadence-innovus-place',          default=True)
+    cts            = Step( 'cadence-innovus-cts',            default=True)
+    postcts_hold   = Step( 'cadence-innovus-postcts_hold',   default=True)
+    route          = Step( 'cadence-innovus-route',          default=True)
+    postroute      = Step( 'cadence-innovus-postroute',      default=True)
+    postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True)
+    signoff        = Step( 'cadence-innovus-signoff',        default=True)
+    pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True)
+    genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True)
 
     if which("calibre") is not None:
-        drc            = Step( 'mentor-calibre-drc',             default=True )
-        lvs            = Step( 'mentor-calibre-lvs',             default=True )
+        drc            = Step( 'mentor-calibre-drc',             default=True)
+        lvs            = Step( 'mentor-calibre-lvs',             default=True)
     else:
-        drc            = Step( 'cadence-pegasus-drc',            default=True )
-        lvs            = Step( 'cadence-pegasus-lvs',            default=True )
-    debugcalibre   = Step( 'cadence-innovus-debug-calibre',  default=True )
+        drc            = Step( 'cadence-pegasus-drc',            default=True)
+        lvs            = Step( 'cadence-pegasus-lvs',            default=True)
+    debugcalibre   = Step( 'cadence-innovus-debug-calibre',  default=True)
 
 
     # Extra DC input
@@ -158,69 +158,69 @@ def construct():
 
     # Add sram macro inputs to downstream nodes
 
-    synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
+    synth.extend_inputs( ['sram_tt.lib', 'sram.lef'])
 
-    pt_signoff.extend_inputs( ['sram_tt.db'] )
-    genlibdb.extend_inputs( ['sram_tt.lib', 'sram_tt.db'] )
+    pt_signoff.extend_inputs( ['sram_tt.db'])
+    genlibdb.extend_inputs( ['sram_tt.lib', 'sram_tt.db'])
 
     # These steps need timing and lef info for srams
 
     sram_steps = \
       [iflow, init, power, place, cts, postcts_hold, route, postroute, postroute_hold, signoff]
     for step in sram_steps:
-        step.extend_inputs( ['sram_tt.lib', 'sram_ff.lib', 'sram.lef'] )
+        step.extend_inputs( ['sram_tt.lib', 'sram_ff.lib', 'sram.lef'])
 
     # Need the sram gds to merge into the final layout
 
-    signoff.extend_inputs( ['sram.gds'] )
+    signoff.extend_inputs( ['sram.gds'])
 
     # Need SRAM spice file for LVS
 
-    lvs.extend_inputs( ['sram.spi'] )
+    lvs.extend_inputs( ['sram.spi'])
 
     # Add extra input edges to innovus steps that need custom tweaks
 
-    init.extend_inputs( custom_init.all_outputs() )
-    power.extend_inputs( custom_power.all_outputs() )
+    init.extend_inputs( custom_init.all_outputs())
+    power.extend_inputs( custom_power.all_outputs())
 
     # Add extra input edges to genlibdb for loop-breaking constraints
 
-    genlibdb.extend_inputs( genlibdb_constraints.all_outputs() )
-    synth.extend_inputs( custom_genus_scripts.all_outputs() )
-    iflow.extend_inputs( custom_flowgen_setup.all_outputs() )
+    genlibdb.extend_inputs( genlibdb_constraints.all_outputs())
+    synth.extend_inputs( custom_genus_scripts.all_outputs())
+    iflow.extend_inputs( custom_flowgen_setup.all_outputs())
 
-    synth.extend_outputs( ["sdc"] )
-    iflow.extend_inputs( ["sdc"] )
-    init.extend_inputs( ["sdc"] )
-    power.extend_inputs( ["sdc"] )
-    place.extend_inputs( ["sdc"] )
-    cts.extend_inputs( ["sdc"] )
+    synth.extend_outputs( ["sdc"])
+    iflow.extend_inputs( ["sdc"])
+    init.extend_inputs( ["sdc"])
+    power.extend_inputs( ["sdc"])
+    place.extend_inputs( ["sdc"])
+    cts.extend_inputs( ["sdc"])
 
     # Add graph inputs and outputs so this can be used in hierarchical flows
 
     # Inputs
-    g.add_input( 'design.v', rtl.i('design.v') )
+    g.add_input( 'design.v', rtl.i('design.v'))
 
     # Outputs
-    g.add_output( 'Tile_MemCore_tt.lib',      genlibdb.o('design.lib')       )
-    g.add_output( 'Tile_MemCore_tt.db',       genlibdb.o('design.db')        )
-    g.add_output( 'Tile_MemCore.lef',         signoff.o('design.lef')        )
-    g.add_output( 'Tile_MemCore.gds',         signoff.o('design-merged.gds') )
-    g.add_output( 'Tile_MemCore.sdf',         signoff.o('design.sdf')        )
-    g.add_output( 'Tile_MemCore.vcs.v',       signoff.o('design.vcs.v')      )
-    g.add_output( 'Tile_MemCore.vcs.pg.v',    signoff.o('design.vcs.pg.v')   )
-    g.add_output( 'Tile_MemCore.spef.gz',     signoff.o('design.spef.gz')    )
-    g.add_output( 'Tile_MemCore.pt.sdc',      signoff.o('design.pt.sdc')     )
-    g.add_output( 'Tile_MemCore.lvs.v',       lvs.o('design_merged.lvs.v')   )
-    g.add_output( 'sram.spi',                 gen_sram.o('sram.spi')         )
-    g.add_output( 'sram.v',                   gen_sram.o('sram.v')           )
-    g.add_output( 'sram_pwr.v',               gen_sram.o('sram_pwr.v')       )
-    g.add_output( 'sram_tt.db',               gen_sram.o('sram_tt.db')       )
-    g.add_output( 'sram_tt.lib',              gen_sram.o('sram_tt.lib')      )
+    g.add_output( 'Tile_MemCore_tt.lib',      genlibdb.o('design.lib'))
+    g.add_output( 'Tile_MemCore_tt.db',       genlibdb.o('design.db'))
+    g.add_output( 'Tile_MemCore.lef',         signoff.o('design.lef'))
+    g.add_output( 'Tile_MemCore.gds',         signoff.o('design-merged.gds'))
+    g.add_output( 'Tile_MemCore.sdf',         signoff.o('design.sdf'))
+    g.add_output( 'Tile_MemCore.vcs.v',       signoff.o('design.vcs.v'))
+    g.add_output( 'Tile_MemCore.vcs.pg.v',    signoff.o('design.vcs.pg.v'))
+    g.add_output( 'Tile_MemCore.spef.gz',     signoff.o('design.spef.gz'))
+    g.add_output( 'Tile_MemCore.pt.sdc',      signoff.o('design.pt.sdc'))
+    g.add_output( 'Tile_MemCore.lvs.v',       lvs.o('design_merged.lvs.v'))
+    g.add_output( 'sram.spi',                 gen_sram.o('sram.spi'))
+    g.add_output( 'sram.v',                   gen_sram.o('sram.v'))
+    g.add_output( 'sram_pwr.v',               gen_sram.o('sram_pwr.v'))
+    g.add_output( 'sram_tt.db',               gen_sram.o('sram_tt.db'))
+    g.add_output( 'sram_tt.lib',              gen_sram.o('sram_tt.lib'))
 
-    order = synth.get_param( 'order' )
-    order.append( 'copy_sdc.tcl' )
-    synth.set_param( 'order', order )
+    order = synth.get_param( 'order')
+    order.append( 'copy_sdc.tcl')
+    synth.set_param( 'order', order)
 
     # TSMC needs streamout *without* the (new) default -uniquify flag
     # This strips off the unwanted flag
@@ -245,58 +245,58 @@ def construct():
 
         # Need mem-pd-params for parm 'vdd_m3_stripe_sparsity'
         # pd-globalnetconnect, mem-pd-params come from 'power-domains' node
-        power.extend_inputs(['pd-globalnetconnect.tcl', 'mem-pd-params.tcl'] )
+        power.extend_inputs(['pd-globalnetconnect.tcl', 'mem-pd-params.tcl'])
 
         cts.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'])
-        postcts_hold.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
-        route.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
-        postroute.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'] )
-        postroute_hold.extend_inputs(['conn-aon-cells-vdd.tcl'] )
-        signoff.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl'] )
+        postcts_hold.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'])
+        route.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'])
+        postroute.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl'])
+        postroute_hold.extend_inputs(['conn-aon-cells-vdd.tcl'])
+        signoff.extend_inputs(['check-clamp-logic-structure.tcl', 'conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl'])
         pwr_aware_gls.extend_inputs(['design.vcs.pg.v', 'sram_pwr.v'])
 
     #-----------------------------------------------------------------------
     # Graph -- Add nodes
     #-----------------------------------------------------------------------
 
-    g.add_step( info                 )
-    g.add_step( rtl                  )
-    g.add_step( gen_sram             )
-    g.add_step( constraints          )
-    g.add_step( synth                )
-    g.add_step( custom_genus_scripts )
-    g.add_step( iflow                )
-    g.add_step( custom_flowgen_setup )
-    g.add_step( init                 )
-    g.add_step( custom_init          )
-    g.add_step( power                )
-    g.add_step( custom_power         )
-    g.add_step( place                )
-    g.add_step( cts                  )
-    g.add_step( postcts_hold         )
-    g.add_step( route                )
-    g.add_step( postroute            )
-    g.add_step( postroute_hold       )
-    g.add_step( signoff              )
-    g.add_step( pt_signoff           )
-    g.add_step( genlibdb_constraints )
-    g.add_step( genlibdb             )
-    g.add_step( lib2db               )
-    g.add_step( drc                  )
-    g.add_step( lvs                  )
-    g.add_step( custom_lvs           )
-    g.add_step( debugcalibre         )
+    g.add_step( info)
+    g.add_step( rtl)
+    g.add_step( gen_sram)
+    g.add_step( constraints)
+    g.add_step( synth)
+    g.add_step( custom_genus_scripts)
+    g.add_step( iflow)
+    g.add_step( custom_flowgen_setup)
+    g.add_step( init)
+    g.add_step( custom_init)
+    g.add_step( power)
+    g.add_step( custom_power)
+    g.add_step( place)
+    g.add_step( cts)
+    g.add_step( postcts_hold)
+    g.add_step( route)
+    g.add_step( postroute)
+    g.add_step( postroute_hold)
+    g.add_step( signoff)
+    g.add_step( pt_signoff)
+    g.add_step( genlibdb_constraints)
+    g.add_step( genlibdb)
+    g.add_step( lib2db)
+    g.add_step( drc)
+    g.add_step( lvs)
+    g.add_step( custom_lvs)
+    g.add_step( debugcalibre)
 
-    g.add_step( application          )
-    g.add_step( testbench            )
+    g.add_step( application)
+    g.add_step( testbench)
     if synth_power:
-        g.add_step( post_synth_power   )
-    g.add_step( post_pnr_power       )
+        g.add_step( post_synth_power)
+    g.add_step( post_pnr_power)
 
     # Power aware step
     if pwr_aware:
-        g.add_step( power_domains    )
-        g.add_step( pwr_aware_gls    )
+        g.add_step( power_domains)
+        g.add_step( pwr_aware_gls)
 
     #-----------------------------------------------------------------------
     # Graph -- Add edges
@@ -304,115 +304,115 @@ def construct():
 
     # Connect by name
 
-    g.connect_by_name( adk,      gen_sram       )
-    g.connect_by_name( adk,      synth          )
-    g.connect_by_name( adk,      iflow          )
-    g.connect_by_name( adk,      init           )
-    g.connect_by_name( adk,      power          )
-    g.connect_by_name( adk,      place          )
-    g.connect_by_name( adk,      cts            )
-    g.connect_by_name( adk,      postcts_hold   )
-    g.connect_by_name( adk,      route          )
-    g.connect_by_name( adk,      postroute      )
-    g.connect_by_name( adk,      postroute_hold )
-    g.connect_by_name( adk,      signoff        )
-    g.connect_by_name( adk,      drc            )
-    g.connect_by_name( adk,      lvs            )
+    g.connect_by_name( adk,      gen_sram)
+    g.connect_by_name( adk,      synth)
+    g.connect_by_name( adk,      iflow)
+    g.connect_by_name( adk,      init)
+    g.connect_by_name( adk,      power)
+    g.connect_by_name( adk,      place)
+    g.connect_by_name( adk,      cts)
+    g.connect_by_name( adk,      postcts_hold)
+    g.connect_by_name( adk,      route)
+    g.connect_by_name( adk,      postroute)
+    g.connect_by_name( adk,      postroute_hold)
+    g.connect_by_name( adk,      signoff)
+    g.connect_by_name( adk,      drc)
+    g.connect_by_name( adk,      lvs)
 
-    g.connect_by_name( gen_sram,      synth          )
-    g.connect_by_name( gen_sram,      iflow          )
-    g.connect_by_name( gen_sram,      init           )
-    g.connect_by_name( gen_sram,      power          )
-    g.connect_by_name( gen_sram,      place          )
-    g.connect_by_name( gen_sram,      cts            )
-    g.connect_by_name( gen_sram,      postcts_hold   )
-    g.connect_by_name( gen_sram,      route          )
-    g.connect_by_name( gen_sram,      postroute      )
-    g.connect_by_name( gen_sram,      postroute_hold )
-    g.connect_by_name( gen_sram,      signoff        )
-    g.connect_by_name( gen_sram,      genlibdb       )
-    g.connect_by_name( gen_sram,      pt_signoff     )
-    g.connect_by_name( gen_sram,      drc            )
-    g.connect_by_name( gen_sram,      lvs            )
+    g.connect_by_name( gen_sram,      synth)
+    g.connect_by_name( gen_sram,      iflow)
+    g.connect_by_name( gen_sram,      init)
+    g.connect_by_name( gen_sram,      power)
+    g.connect_by_name( gen_sram,      place)
+    g.connect_by_name( gen_sram,      cts)
+    g.connect_by_name( gen_sram,      postcts_hold)
+    g.connect_by_name( gen_sram,      route)
+    g.connect_by_name( gen_sram,      postroute)
+    g.connect_by_name( gen_sram,      postroute_hold)
+    g.connect_by_name( gen_sram,      signoff)
+    g.connect_by_name( gen_sram,      genlibdb)
+    g.connect_by_name( gen_sram,      pt_signoff)
+    g.connect_by_name( gen_sram,      drc)
+    g.connect_by_name( gen_sram,      lvs)
 
-    g.connect_by_name( rtl,         synth     )
-    g.connect_by_name( constraints, synth     )
-    g.connect_by_name( custom_genus_scripts, synth )
+    g.connect_by_name( rtl,         synth)
+    g.connect_by_name( constraints, synth)
+    g.connect_by_name( custom_genus_scripts, synth)
 
-    g.connect_by_name( synth,       iflow        )
-    g.connect_by_name( synth,       init         )
-    g.connect_by_name( synth,       power        )
-    g.connect_by_name( synth,       place        )
-    g.connect_by_name( synth,       cts          )
-    g.connect_by_name( custom_flowgen_setup, iflow )
+    g.connect_by_name( synth,       iflow)
+    g.connect_by_name( synth,       init)
+    g.connect_by_name( synth,       power)
+    g.connect_by_name( synth,       place)
+    g.connect_by_name( synth,       cts)
+    g.connect_by_name( custom_flowgen_setup, iflow)
 
-    g.connect_by_name( iflow,    init           )
-    g.connect_by_name( iflow,    power          )
-    g.connect_by_name( iflow,    place          )
-    g.connect_by_name( iflow,    cts            )
-    g.connect_by_name( iflow,    postcts_hold   )
-    g.connect_by_name( iflow,    route          )
-    g.connect_by_name( iflow,    postroute      )
-    g.connect_by_name( iflow,    postroute_hold )
-    g.connect_by_name( iflow,    signoff        )
+    g.connect_by_name( iflow,    init)
+    g.connect_by_name( iflow,    power)
+    g.connect_by_name( iflow,    place)
+    g.connect_by_name( iflow,    cts)
+    g.connect_by_name( iflow,    postcts_hold)
+    g.connect_by_name( iflow,    route)
+    g.connect_by_name( iflow,    postroute)
+    g.connect_by_name( iflow,    postroute_hold)
+    g.connect_by_name( iflow,    signoff)
 
-    g.connect_by_name( custom_init,  init     )
-    g.connect_by_name( custom_power, power    )
-    g.connect_by_name( custom_lvs,   lvs      )
+    g.connect_by_name( custom_init,  init)
+    g.connect_by_name( custom_power, power)
+    g.connect_by_name( custom_lvs,   lvs)
 
-    g.connect_by_name( init,           power          )
-    g.connect_by_name( power,          place          )
-    g.connect_by_name( place,          cts            )
-    g.connect_by_name( cts,            postcts_hold   )
-    g.connect_by_name( postcts_hold,   route          )
-    g.connect_by_name( route,          postroute      )
-    g.connect_by_name( postroute,      postroute_hold )
-    g.connect_by_name( postroute_hold, signoff        )
-    g.connect_by_name( signoff,        drc            )
-    g.connect_by_name( signoff,        lvs            )
+    g.connect_by_name( init,           power)
+    g.connect_by_name( power,          place)
+    g.connect_by_name( place,          cts)
+    g.connect_by_name( cts,            postcts_hold)
+    g.connect_by_name( postcts_hold,   route)
+    g.connect_by_name( route,          postroute)
+    g.connect_by_name( postroute,      postroute_hold)
+    g.connect_by_name( postroute_hold, signoff)
+    g.connect_by_name( signoff,        drc)
+    g.connect_by_name( signoff,        lvs)
     g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
     g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
-    g.connect_by_name( signoff,              genlibdb )
-    g.connect_by_name( adk,                  genlibdb )
-    g.connect_by_name( genlibdb_constraints, genlibdb )
+    g.connect_by_name( signoff,              genlibdb)
+    g.connect_by_name( adk,                  genlibdb)
+    g.connect_by_name( genlibdb_constraints, genlibdb)
 
-    g.connect_by_name( genlibdb,             lib2db   )
+    g.connect_by_name( genlibdb,             lib2db)
 
-    g.connect_by_name( adk,          pt_signoff   )
-    g.connect_by_name( signoff,      pt_signoff   )
+    g.connect_by_name( adk,          pt_signoff)
+    g.connect_by_name( signoff,      pt_signoff)
 
-    g.connect_by_name( application, testbench       )
+    g.connect_by_name( application, testbench)
     if synth_power:
-        g.connect_by_name( application, post_synth_power )
-        g.connect_by_name( gen_sram,    post_synth_power )
-        g.connect_by_name( synth,       post_synth_power )
-        g.connect_by_name( testbench,   post_synth_power )
-    g.connect_by_name( application, post_pnr_power )
-    g.connect_by_name( gen_sram,    post_pnr_power )
-    g.connect_by_name( signoff,     post_pnr_power )
-    g.connect_by_name( pt_signoff,  post_pnr_power )
-    g.connect_by_name( testbench,   post_pnr_power )
+        g.connect_by_name( application, post_synth_power)
+        g.connect_by_name( gen_sram,    post_synth_power)
+        g.connect_by_name( synth,       post_synth_power)
+        g.connect_by_name( testbench,   post_synth_power)
+    g.connect_by_name( application, post_pnr_power)
+    g.connect_by_name( gen_sram,    post_pnr_power)
+    g.connect_by_name( signoff,     post_pnr_power)
+    g.connect_by_name( pt_signoff,  post_pnr_power)
+    g.connect_by_name( testbench,   post_pnr_power)
 
-    g.connect_by_name( adk,      debugcalibre )
-    g.connect_by_name( synth,    debugcalibre )
-    g.connect_by_name( iflow,    debugcalibre )
-    g.connect_by_name( signoff,  debugcalibre )
-    g.connect_by_name( drc,      debugcalibre )
-    g.connect_by_name( lvs,      debugcalibre )
+    g.connect_by_name( adk,      debugcalibre)
+    g.connect_by_name( synth,    debugcalibre)
+    g.connect_by_name( iflow,    debugcalibre)
+    g.connect_by_name( signoff,  debugcalibre)
+    g.connect_by_name( drc,      debugcalibre)
+    g.connect_by_name( lvs,      debugcalibre)
 
     # Pwr aware steps:
     if pwr_aware:
-        g.connect_by_name( power_domains,        synth          )
-        g.connect_by_name( power_domains,        init           )
-        g.connect_by_name( power_domains,        power          )
-        g.connect_by_name( power_domains,        place          )
-        g.connect_by_name( power_domains,        cts            )
-        g.connect_by_name( power_domains,        postcts_hold   )
-        g.connect_by_name( power_domains,        route          )
-        g.connect_by_name( power_domains,        postroute      )
-        g.connect_by_name( power_domains,        postroute_hold )
-        g.connect_by_name( power_domains,        signoff        )
+        g.connect_by_name( power_domains,        synth)
+        g.connect_by_name( power_domains,        init)
+        g.connect_by_name( power_domains,        power)
+        g.connect_by_name( power_domains,        place)
+        g.connect_by_name( power_domains,        cts)
+        g.connect_by_name( power_domains,        postcts_hold)
+        g.connect_by_name( power_domains,        route)
+        g.connect_by_name( power_domains,        postroute)
+        g.connect_by_name( power_domains,        postroute_hold)
+        g.connect_by_name( power_domains,        signoff)
         g.connect_by_name( adk,                  pwr_aware_gls)
         g.connect_by_name( gen_sram,             pwr_aware_gls)
         g.connect_by_name( signoff,              pwr_aware_gls)
@@ -420,43 +420,43 @@ def construct():
 
     # New step, added for gf12
     if want_drc_pm:
-        g.add_step( drc_pm )
-        g.connect_by_name( adk,           drc_pm         )
-        g.connect_by_name( gen_sram,      drc_pm         )
-        g.connect_by_name( signoff,       drc_pm         )
+        g.add_step( drc_pm)
+        g.connect_by_name( adk,           drc_pm)
+        g.connect_by_name( gen_sram,      drc_pm)
+        g.connect_by_name( signoff,       drc_pm)
         g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
-        g.connect_by_name( drc_pm,        debugcalibre   )
+        g.connect_by_name( drc_pm,        debugcalibre)
 
-    g.connect_by_name( iflow,    genlibdb       )
+    g.connect_by_name( iflow,    genlibdb)
 
     #-----------------------------------------------------------------------
     # Parameterize
     #-----------------------------------------------------------------------
 
-    g.update_params( parameters )
+    g.update_params( parameters)
 
     # Update PWR_AWARE variable
-    synth.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-    init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-    power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
+    synth.update_params( { 'PWR_AWARE': parameters['PWR_AWARE']}, True)
+    init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE']}, True)
+    power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE']}, True)
 
     # Used in floorplan.tcl
-    init.update_params(  { 'adk': parameters['adk'] }, True )
+    init.update_params(  { 'adk': parameters['adk']}, True)
 
     if pwr_aware:
-        pwr_aware_gls.update_params( { 'design_name': parameters['design_name'] }, True )
+        pwr_aware_gls.update_params( { 'design_name': parameters['design_name']}, True)
 
-        init.extend_postconditions(         ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        place.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        cts.extend_postconditions(          ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        postcts_hold.extend_postconditions( ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        route.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        postroute.extend_postconditions(    ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        signoff.extend_postconditions(      ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        init.extend_postconditions(         ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
+        place.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
+        cts.extend_postconditions(          ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
+        postcts_hold.extend_postconditions( ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
+        route.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
+        postroute.extend_postconditions(    ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
+        signoff.extend_postconditions(      ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"])
 
 
     # Core density target param
-    init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
+    init.update_params( { 'core_density_target': parameters['core_density_target']}, True)
 
 
     # Disable pwr aware flow
@@ -470,97 +470,97 @@ def construct():
     # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
 
     order = init.get_param('order') # get the default script run order
-    path_group_idx = order.index( 'make-path-groups.tcl' ) 
-    order.insert( path_group_idx + 1, 'additional-path-groups.tcl' )
-    pin_idx = order.index( 'pin-assignments.tcl' ) # find pin-assignments.tcl
-    order.insert( pin_idx + 1, 'edge-blockages.tcl' ) # add here
-    init.update_params( { 'order': order } )
+    path_group_idx = order.index( 'make-path-groups.tcl') 
+    order.insert( path_group_idx + 1, 'additional-path-groups.tcl')
+    pin_idx = order.index( 'pin-assignments.tcl') # find pin-assignments.tcl
+    order.insert( pin_idx + 1, 'edge-blockages.tcl') # add here
+    init.update_params( { 'order': order})
 
     # Adding new input for genlibdb node to run
 
     order = genlibdb.get_param('order') # get the default script run order
-    extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
-    order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
-    genlibdb.update_params( { 'order': order } )
+    extraction_idx = order.index( 'extract_model.tcl') # find extract_model.tcl
+    order.insert( extraction_idx, 'genlibdb-constraints.tcl') # add here
+    genlibdb.update_params( { 'order': order})
 
     # genlibdb -- Remove 'write-interface-timing.tcl' beacuse it takes
     # very long and is not necessary
     order = genlibdb.get_param('order')
-    order.remove( 'write-interface-timing.tcl' )
-    genlibdb.update_params( { 'order': order } )
+    order.remove( 'write-interface-timing.tcl')
+    genlibdb.update_params( { 'order': order})
 
     # Pwr aware steps:
     if pwr_aware:
         # init node
         order = init.get_param('order')
-        read_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
-        order.insert( read_idx + 1, 'mem-load-upf.tcl' ) # add here
+        read_idx = order.index( 'floorplan.tcl') # find floorplan.tcl
+        order.insert( read_idx + 1, 'mem-load-upf.tcl') # add here
         order.insert( read_idx + 2, 'mem-pd-params.tcl') # add here
-        order.insert( read_idx + 3, 'pd-aon-floorplan.tcl' ) # add here
-        order.insert( read_idx + 4, 'add-endcaps-welltaps-setup.tcl' ) # add here
-        order.insert( read_idx + 5, 'pd-add-endcaps-welltaps.tcl' ) # add here
-        order.insert( read_idx + 6, 'add-power-switches.tcl' ) # add here
+        order.insert( read_idx + 3, 'pd-aon-floorplan.tcl') # add here
+        order.insert( read_idx + 4, 'add-endcaps-welltaps-setup.tcl') # add here
+        order.insert( read_idx + 5, 'pd-add-endcaps-welltaps.tcl') # add here
+        order.insert( read_idx + 6, 'add-power-switches.tcl') # add here
         order.remove('add-endcaps-welltaps.tcl')
         order.append('check-clamp-logic-structure.tcl')
-        init.update_params( { 'order': order } )
+        init.update_params( { 'order': order})
 
         # synth node (needs parm 'adk_allow_sdf_regs')
         order = synth.get_param('order')
-        order.insert( 0, 'mem-pd-params.tcl' )        # add params file
-        synth.update_params( { 'order': order } )
+        order.insert( 0, 'mem-pd-params.tcl')        # add params file
+        synth.update_params( { 'order': order})
 
         # power node
         order = power.get_param('order')
-        order.insert( 0, 'pd-globalnetconnect.tcl' ) # add new pd-globalnetconnect
+        order.insert( 0, 'pd-globalnetconnect.tcl') # add new pd-globalnetconnect
         order.remove('globalnetconnect.tcl')         # remove old globalnetconnect
-        order.insert( 0, 'mem-pd-params.tcl' )       # add params file
-        power.update_params( { 'order': order } )
+        order.insert( 0, 'mem-pd-params.tcl')       # add params file
+        power.update_params( { 'order': order})
 
         # place node
         order = place.get_param('order')
-        read_idx = order.index( 'main.tcl' ) # find main.tcl
+        read_idx = order.index( 'main.tcl') # find main.tcl
         order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
         order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
         order.append('check-clamp-logic-structure.tcl')
-        place.update_params( { 'order': order } )
+        place.update_params( { 'order': order})
 
         # cts node
         order = cts.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        cts.update_params( { 'order': order } )
+        cts.update_params( { 'order': order})
 
         # postcts_hold node
         order = postcts_hold.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        postcts_hold.update_params( { 'order': order } )
+        postcts_hold.update_params( { 'order': order})
 
         # route node
         order = route.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        route.update_params( { 'order': order } )
+        route.update_params( { 'order': order})
 
         # postroute node
         order = postroute.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        postroute.update_params( { 'order': order } )
+        postroute.update_params( { 'order': order})
 
         # postroute-hold node
         order = postroute_hold.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-        postroute_hold.update_params( { 'order': order } )
+        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
+        postroute_hold.update_params( { 'order': order})
 
         # signoff node
         order = signoff.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.insert( 0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        read_idx = order.index( 'generate-results.tcl' ) # find generate_results.tcl
+        read_idx = order.index( 'generate-results.tcl') # find generate_results.tcl
 
         order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
-        signoff.update_params( { 'order': order } )
+        signoff.update_params( { 'order': order})
 
     return g
 

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -12,548 +12,546 @@ from common.get_sys_adk import get_sys_adk
 
 def construct():
 
-  g = Graph()
-
-  #-----------------------------------------------------------------------
-  # Parameters
-  #-----------------------------------------------------------------------
-
-  adk_name = get_sys_adk()  # E.g. 'gf12-adk' or 'tsmc16'
-  adk_view = 'multivt'
-  pwr_aware = True
-
-  if pwr_aware:
-      adk_view = adk_view + '-pm'
-
-  flatten = 3
-  if os.environ.get('FLATTEN'):
-      flatten = os.environ.get('FLATTEN')
-
-  synth_power = False
-  if os.environ.get('SYNTH_POWER') == 'True':
-      synth_power = True
-  # power domains do not work with post-synth power
-  if synth_power:
-      pwr_aware = False
-
-  want_drc_pm      = True
-  want_custom_cts  = True
-
-  # TSMC override(s)
-  if adk_name == 'tsmc16':
-      adk_view         = 'multicorner-multivt'
-      want_drc_pm      = False
-      want_custom_cts  = False
-
-  if adk_name == 'tsmc16':
-      read_hdl_defines = 'TSMC16'
-  elif adk_name == 'gf12-adk':
-      read_hdl_defines = 'GF12'
-  else:
-      read_hdl_defines = ''
-
-  parameters = {
-    'construct_path'    : __file__,
-    'design_name'       : 'Tile_PE',
-    'clock_period'      : 1.1,
-    'adk'               : adk_name,
-    'adk_view'          : adk_view,
-    # Synthesis
-    'flatten_effort'    : flatten,
-    'topographical'     : True,
-    'read_hdl_defines'  : read_hdl_defines,
-    # RTL Generation
-    'interconnect_only' : False,
-    'rtl_docker_image'  : 'default', # Current default is 'stanfordaha/garnet:latest'
-    # Power Domains
-    'PWR_AWARE'         : pwr_aware,
-    'core_density_target': 0.6,
-    # Power analysis
-    "use_sdf"           : False, # uses sdf but not the way it is in xrun node
-    'app_to_run'        : 'tests/conv_3_3',
-    'saif_instance'     : 'testbench/dut',
-    'testbench_name'    : 'testbench',
-    'strip_path'        : 'testbench/dut',
-    'drc_env_setup'     : 'drcenv-block.sh'
-    }
-  # TSMC overrides
-  if adk_name == 'tsmc16': parameters.update({
-    'interconnect_only'  : True,
-    'core_density_target': 0.63,
-  })
-
-  # User-level option to change clock frequency
-  # E.g. 'export clock_period_PE="4.0"' to target 250MHz
-  # Optionally could restrict to bk only: if (os.getenv('USER') == "buildkite-agent")
-  cp=os.getenv('clock_period_PE')
-  if (cp != None):
-      print("@file_info: WARNING found env var 'clock_period_PE'")
-      print("@file_info: WARNING setting PE clock period to '%s'" % cp)
-      parameters['clock_period'] = cp;
-
-  #-----------------------------------------------------------------------
-  # Create nodes
-  #-----------------------------------------------------------------------
-
-  this_dir = os.path.dirname( os.path.abspath( __file__ ) )
-
-  # ADK step
-
-  g.set_adk( adk_name )
-  adk = g.get_adk_step()
-
-  # Custom steps
-
-  rtl                  = Step( this_dir + '/../common/rtl'                          )
-  constraints          = Step( this_dir + '/constraints'                            )
-  custom_init          = Step( this_dir + '/custom-init'                            )
-  custom_genus_scripts = Step( this_dir + '/custom-genus-scripts'                   )
-  custom_flowgen_setup = Step( this_dir + '/custom-flowgen-setup'                   )
-  if adk_name == 'tsmc16':
-    custom_power         = Step( this_dir + '/../common/custom-power-leaf-amber'      )
-  else:
-    custom_power         = Step( this_dir + '/../common/custom-power-leaf'            )
-  if want_custom_cts:
-    custom_cts           = Step( this_dir + '/custom-cts'                           )
-  short_fix            = Step( this_dir + '/../common/custom-short-fix'             )
-  genlibdb_constraints = Step( this_dir + '/../common/custom-genlibdb-constraints'  )
-  custom_timing_assert = Step( this_dir + '/../common/custom-timing-assert'         )
-  custom_dc_scripts    = Step( this_dir + '/custom-dc-scripts'                      )
-  testbench            = Step( this_dir + '/../common/testbench'                    )
-  application          = Step( this_dir + '/../common/application'                  )
-  lib2db               = Step( this_dir + '/../common/synopsys-dc-lib2db'           )
-  if want_drc_pm:
-    drc_pm               = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm' )
-  if synth_power:
-    post_synth_power     = Step( this_dir + '/../common/tile-post-synth-power'     )
-  post_pnr_power       = Step( this_dir + '/../common/tile-post-pnr-power'         )
-
-  # Power aware setup
-  power_domains = None
-  pwr_aware_gls = None
-  if pwr_aware:
-    power_domains = Step( this_dir + '/../common/power-domains' )
-    pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls' )
-
-  # Default steps
-  info         = Step( 'info',                          default=True )
-  synth        = Step( 'cadence-genus-synthesis',       default=True )
-  iflow        = Step( 'cadence-innovus-flowsetup',     default=True )
-  init         = Step( 'cadence-innovus-init',          default=True )
-  power        = Step( 'cadence-innovus-power',         default=True )
-  place        = Step( 'cadence-innovus-place',         default=True )
-  cts          = Step( 'cadence-innovus-cts',           default=True )
-  postcts_hold = Step( 'cadence-innovus-postcts_hold',  default=True )
-  route        = Step( 'cadence-innovus-route',         default=True )
-  postroute    = Step( 'cadence-innovus-postroute',     default=True )
-  signoff      = Step( 'cadence-innovus-signoff',       default=True )
-  pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
-  genlibdb     = Step( 'synopsys-ptpx-genlibdb',        default=True )
-
-  if which("calibre") is not None:
-      drc          = Step( 'mentor-calibre-drc',            default=True )
-      lvs          = Step( 'mentor-calibre-lvs',            default=True )
-  else:
-      drc          = Step( 'cadence-pegasus-drc',           default=True )
-      lvs          = Step( 'cadence-pegasus-lvs',           default=True )
-  debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
-
-  # Add custom timing scripts
-  custom_timing_steps = [ synth, postcts_hold, signoff ] # connects to these
-  for c_step in custom_timing_steps:
-    c_step.extend_inputs( custom_timing_assert.all_outputs() )
-
-  # Add extra input edges to innovus steps that need custom tweaks
-  init.extend_inputs( custom_init.all_outputs() )
-  power.extend_inputs( custom_power.all_outputs() )
-  genlibdb.extend_inputs( genlibdb_constraints.all_outputs() )
-  synth.extend_inputs( custom_genus_scripts.all_outputs() )
-  iflow.extend_inputs( custom_flowgen_setup.all_outputs() )
-
-  # Extra input to DC for constraints
-  synth.extend_inputs( ["common.tcl", "reporting.tcl", "generate-results.tcl", "scenarios.tcl", "report_alu.py", "parse_alu.py"] )
-  # Extra outputs from DC
-  synth.extend_outputs( ["sdc"] )
-  iflow.extend_inputs( ["scenarios.tcl", "sdc"] )
-  init.extend_inputs( ["sdc"] )
-  power.extend_inputs( ["sdc"] )
-  place.extend_inputs( ["sdc"] )
-  cts.extend_inputs( ["sdc"] )
-
-  order = synth.get_param( 'order' )
-  order.append( 'copy_sdc.tcl' )
-  synth.set_param( 'order', order )
-
-  # Power aware setup
-  if pwr_aware:
-
-      # Need pe-pd-params so adk.tcl can access parm 'adk_allow_sdf_regs'
-      # (pe-pd-params come from already-connected 'power-domains' node)
-      synth.extend_inputs([
-        'pe-pd-params.tcl',
-        'designer-interface.tcl', 
-        'upf_Tile_PE.tcl', 
-        'pe-constraints.tcl', 
-        'pe-constraints-2.tcl', 
-        'dc-dont-use-constraints.tcl'])
-
-      # Eventually want to extend this to GF as well...!
-      if adk_name == 'tsmc16':
-        synth.extend_inputs([ 'check-pdcr-address.sh' ])
-
-      init.extend_inputs(['upf_Tile_PE.tcl', 'pe-load-upf.tcl', 'dont-touch-constraints.tcl', 'pe-pd-params.tcl', 'pd-aon-floorplan.tcl', 'add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'add-power-switches.tcl', 'check-clamp-logic-structure.tcl'])
-
-      # Eventually want to extend this to GF as well...!
-      if adk_name == 'tsmc16':
-        init.extend_inputs([ 'check-pdcr-address.sh' ])
-
-      # Need pe-pd-params for parm 'vdd_m3_stripe_sparsity'
-      # pd-globalnetconnect, pe-pd-params come from 'power-domains' node
-      power.extend_inputs(['pd-globalnetconnect.tcl', 'pe-pd-params.tcl'] )
-
-      place.extend_inputs(['place-dont-use-constraints.tcl', 'check-clamp-logic-structure.tcl', 'add-aon-tie-cells.tcl'])
-      cts.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
-      postcts_hold.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
-      route.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
-      postroute.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
-      signoff.extend_inputs(['conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl', 'check-clamp-logic-structure.tcl'] )
-      pwr_aware_gls.extend_inputs(['design.vcs.pg.v'])
-  
-      # Eventually want to extend this to GF as well...!
-      if adk_name == 'tsmc16':
-        # Fix and repair PowerDomainConfigReg when/if magma decides to renumber it :(
-        synth.pre_extend_commands( ['./inputs/check-pdcr-address.sh'] )
-        init.pre_extend_commands(  ['./inputs/check-pdcr-address.sh'] )
-        pwr_aware_gls.pre_extend_commands( ['./assign-pdcr-address.sh'] )
-
-  # Add short_fix script(s) to list of available postroute scripts
-  postroute.extend_inputs( short_fix.all_outputs() )
-
-  # Add graph inputs and outputs so this can be used in hierarchical flows
-
-  # Inputs
-  g.add_input( 'design.v', rtl.i('design.v') )
-
-  # Outputs
-  g.add_output( 'Tile_PE_tt.lib',      genlibdb.o('design.lib')       )
-  g.add_output( 'Tile_PE_tt.db',       genlibdb.o('design.db')        )
-  g.add_output( 'Tile_PE.lef',         signoff.o('design.lef')        )
-  g.add_output( 'Tile_PE.gds',         signoff.o('design-merged.gds') )
-  g.add_output( 'Tile_PE.sdf',         signoff.o('design.sdf')        )
-  g.add_output( 'Tile_PE.vcs.v',       signoff.o('design.vcs.v')      )
-  g.add_output( 'Tile_PE.vcs.pg.v',    signoff.o('design.vcs.pg.v')   )
-  g.add_output( 'Tile_PE.spef.gz',     signoff.o('design.spef.gz')    )
-  g.add_output( 'Tile_PE.pt.sdc',      signoff.o('design.pt.sdc')     )
-  g.add_output( 'Tile_PE.lvs.v',       lvs.o('design_merged.lvs.v')   )
-
-  # TSMC needs streamout *without* the (new) default -uniquify flag
-  # This python method finds 'stream-out.tcl' and strips out that flag.
-  from common.streamout_no_uniquify import streamout_no_uniquify
-  if adk_name == "tsmc16": streamout_no_uniquify(iflow)
-
-  #-----------------------------------------------------------------------
-  # Graph -- Add nodes
-  #-----------------------------------------------------------------------
-
-  g.add_step( info                     )
-  g.add_step( rtl                      )
-  g.add_step( constraints              )
-  g.add_step( custom_dc_scripts        )
-  g.add_step( synth                    )
-  g.add_step( custom_timing_assert     )
-  g.add_step( custom_genus_scripts     )
-  g.add_step( iflow                    )
-  g.add_step( custom_flowgen_setup     )
-  g.add_step( init                     )
-  g.add_step( custom_init              )
-  g.add_step( power                    )
-  g.add_step( custom_power             )
-  g.add_step( place                    )
-  g.add_step( cts                      )
-  g.add_step( postcts_hold             )
-  g.add_step( route                    )
-  g.add_step( postroute                )
-  g.add_step( short_fix                )
-  g.add_step( signoff                  )
-  g.add_step( pt_signoff               )
-  g.add_step( genlibdb_constraints     )
-  g.add_step( genlibdb                 )
-  g.add_step( lib2db                   )
-  g.add_step( drc                      )
-  g.add_step( lvs                      )
-  g.add_step( debugcalibre             )
-
-  g.add_step( application              )
-  g.add_step( testbench                )
-  if synth_power:
-    g.add_step( post_synth_power       )
-  g.add_step( post_pnr_power           )
-
-  # Power aware step
-  if pwr_aware:
-      g.add_step( power_domains        )
-      g.add_step( pwr_aware_gls        )
-
-  #-----------------------------------------------------------------------
-  # Graph -- Add edges
-  #-----------------------------------------------------------------------
-
-  # Dynamically add edges
-
-  # Connect by name
-
-  g.connect_by_name( adk,      synth        )
-  g.connect_by_name( adk,      iflow        )
-  g.connect_by_name( adk,      init         )
-  g.connect_by_name( adk,      power        )
-  g.connect_by_name( adk,      place        )
-  g.connect_by_name( adk,      cts          )
-  g.connect_by_name( adk,      postcts_hold )
-  g.connect_by_name( adk,      route        )
-  g.connect_by_name( adk,      postroute    )
-  g.connect_by_name( adk,      signoff      )
-  g.connect_by_name( adk,      drc          )
-  g.connect_by_name( adk,      lvs          )
-
-  g.connect_by_name( rtl,         synth          )
-  g.connect_by_name( constraints, synth          )
-  g.connect_by_name( custom_genus_scripts, synth )
-  g.connect_by_name( constraints, iflow          )
-  g.connect_by_name( custom_dc_scripts, iflow    )
-
-  for c_step in custom_timing_steps:
-    g.connect_by_name( custom_timing_assert, c_step )
-
-  g.connect_by_name( synth,       iflow                )
-  g.connect_by_name( synth,       init                 )
-  g.connect_by_name( synth,       power                )
-  g.connect_by_name( synth,       place                )
-  g.connect_by_name( synth,       cts                  )
-  g.connect_by_name( synth,       custom_flowgen_setup )
-
-  g.connect_by_name( custom_flowgen_setup, iflow )
-  g.connect_by_name( iflow,    init         )
-  g.connect_by_name( iflow,    power        )
-  g.connect_by_name( iflow,    place        )
-  g.connect_by_name( iflow,    cts          )
-  g.connect_by_name( iflow,    postcts_hold )
-  g.connect_by_name( iflow,    route        )
-  g.connect_by_name( iflow,    postroute    )
-  g.connect_by_name( iflow,    signoff      )
-
-  g.connect_by_name( custom_init,  init     )
-  g.connect_by_name( custom_power, power    )
-
-  # Fetch short-fix script in prep for eventual use by postroute
-  g.connect_by_name( short_fix, postroute )
-
-  g.connect_by_name( init,         power        )
-  g.connect_by_name( power,        place        )
-  g.connect_by_name( place,        cts          )
-  g.connect_by_name( cts,          postcts_hold )
-  g.connect_by_name( postcts_hold, route        )
-  g.connect_by_name( route,        postroute    )
-  g.connect_by_name( postroute,    signoff      )
-
-  g.connect_by_name( signoff,      drc          )
-  g.connect_by_name( signoff,      lvs          )
-  g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
-  g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
-
-  g.connect_by_name( signoff,              genlibdb )
-  g.connect_by_name( adk,                  genlibdb )
-  g.connect_by_name( genlibdb_constraints, genlibdb )
-  
-  g.connect_by_name( genlibdb,             lib2db   )
-
-  g.connect_by_name( adk,          pt_signoff   )
-  g.connect_by_name( signoff,      pt_signoff   )
-
-  g.connect_by_name( application, testbench       )
-  if synth_power:
-      g.connect_by_name( application, post_synth_power )
-      g.connect_by_name( synth,       post_synth_power )
-      g.connect_by_name( testbench,   post_synth_power )
-  g.connect_by_name( application, post_pnr_power )
-  g.connect_by_name( signoff,     post_pnr_power )
-  g.connect_by_name( pt_signoff,  post_pnr_power )
-  g.connect_by_name( testbench,   post_pnr_power )
-
-  g.connect_by_name( adk,      debugcalibre )
-  g.connect_by_name( synth,    debugcalibre )
-  g.connect_by_name( iflow,    debugcalibre )
-  g.connect_by_name( signoff,  debugcalibre )
-  g.connect_by_name( drc,      debugcalibre )
-  g.connect_by_name( lvs,      debugcalibre )
-
-  # Pwr aware steps:
-  if pwr_aware:
-      g.connect_by_name( power_domains,        synth        )
-      g.connect_by_name( power_domains,        init         )
-      g.connect_by_name( power_domains,        power        )
-      g.connect_by_name( power_domains,        place        )
-      g.connect_by_name( power_domains,        cts          )
-      g.connect_by_name( power_domains,        postcts_hold )
-      g.connect_by_name( power_domains,        route        )
-      g.connect_by_name( power_domains,        postroute    )
-      g.connect_by_name( power_domains,        signoff      )
-      g.connect_by_name( adk,                  pwr_aware_gls)
-      g.connect_by_name( signoff,              pwr_aware_gls)
-      #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
-
-  # New 'custom_cts' step added for gf12
-  if want_custom_cts:
-    cts.extend_inputs( custom_cts.all_outputs() )
-    g.add_step(        custom_cts               )
-    g.connect_by_name( custom_cts,   cts        )
-
-  # New 'drc_pm' step, added for gf12
-  if want_drc_pm:
-      g.add_step( drc_pm )
-      g.connect_by_name( adk,           drc_pm         )
-      g.connect_by_name( signoff,       drc_pm         )
-      g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
-      g.connect_by_name( drc_pm,        debugcalibre   )
-
-  g.connect_by_name( iflow,    genlibdb       )
-
-  #-----------------------------------------------------------------------
-  # Parameterize
-  #-----------------------------------------------------------------------
-
-  g.update_params( parameters )
-
-  # Add custom timing scripts
-
-  for c_step in custom_timing_steps:
-    order = c_step.get_param( 'order' )
-    order.append( 'report-special-timing.tcl' )
-    c_step.set_param( 'order', order )
-    c_step.extend_postconditions( [{ 'pytest': 'inputs/test_timing.py' }] )
-
-  # Update PWR_AWARE variable
-  synth.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-  init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-  power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-
-  if pwr_aware:
-     init.update_params( { 'flatten_effort': parameters['flatten_effort'] }, True )
-     pwr_aware_gls.update_params( { 'design_name': parameters['design_name'] }, True )
-
-     init.extend_postconditions(         ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-     place.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-     cts.extend_postconditions(          ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-     postcts_hold.extend_postconditions( ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-     route.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-     postroute.extend_postconditions(    ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-     signoff.extend_postconditions(      ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-  # Since we are adding an additional input script to the generic Innovus
-  # steps, we modify the order parameter for that node which determines
-  # which scripts get run and when they get run.
-
-  init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
-  # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
-  # and 'additional-path-groups' after 'make_path_groups'
-
-  order = init.get_param('order') # get the default script run order
-  path_group_idx = order.index( 'make-path-groups.tcl' )
-  order.insert( path_group_idx + 1, 'additional-path-groups.tcl' )
-  pin_idx = order.index( 'pin-assignments.tcl' ) # find pin-assignments.tcl
-  order.insert( pin_idx + 1, 'edge-blockages.tcl' ) # add here
-  init.update_params( { 'order': order } )
-
-  # Adding new input for genlibdb node to run
-
-  # No longer conditional---amber and onyx now use same genlib mechanism
-  order = genlibdb.get_param('order') # get the default script run order
-  extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
-  order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
-  genlibdb.update_params( { 'order': order } )
-
-  # genlibdb -- Remove 'report-interface-timing.tcl' beacuse it takes
-  # very long and is not necessary
-  order = genlibdb.get_param('order')
-  order.remove( 'write-interface-timing.tcl' )
-  genlibdb.update_params( { 'order': order } )
-
-  # Pwr aware steps:
-  if pwr_aware:
-      # init node
-      order = init.get_param('order')
-      read_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
-
-      # 09/2022 reordered to load params (pe-pd-params) before using params (pe-load-upf)
-      order.insert( read_idx + 1, 'pe-pd-params.tcl' ) # add here
-      order.insert( read_idx + 2, 'pe-load-upf.tcl' ) # add here
-      order.insert( read_idx + 3, 'pd-aon-floorplan.tcl' ) # add here
-      order.insert( read_idx + 4, 'add-endcaps-welltaps-setup.tcl' ) # add here
-      order.insert( read_idx + 5, 'pd-add-endcaps-welltaps.tcl' ) # add here
-      order.insert( read_idx + 6, 'add-power-switches.tcl' ) # add here
-      order.remove('add-endcaps-welltaps.tcl')
-      order.append('check-clamp-logic-structure.tcl')
-      init.update_params( { 'order': order } )
-
-      # synth node (needs parm 'adk_allow_sdf_regs')
-      order = synth.get_param('order')
-      order.insert( 0, 'pe-pd-params.tcl' )        # add params file
-      synth.update_params( { 'order': order } )
-
-      # power node
-      order = power.get_param('order')
-      order.insert( 0, 'pd-globalnetconnect.tcl' ) # add new 'pd-globalnetconnect'
-      order.remove('globalnetconnect.tcl')         # remove old 'globalnetconnect'
-      order.insert( 0, 'pe-pd-params.tcl' )        # add params file
-      power.update_params( { 'order': order } )
-
-      # place node
-      order = place.get_param('order')
-      read_idx = order.index( 'main.tcl' ) # find main.tcl
-      order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
-      order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
-      order.append('check-clamp-logic-structure.tcl')
-      place.update_params( { 'order': order } )
-
-      # cts node
-      order = cts.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      order.append('check-clamp-logic-structure.tcl')
-      cts.update_params( { 'order': order } )
-
-      # postcts_hold node
-      order = postcts_hold.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      order.append('check-clamp-logic-structure.tcl')
-      postcts_hold.update_params( { 'order': order } )
-
-      # route node
-      order = route.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      order.append('check-clamp-logic-structure.tcl')
-      route.update_params( { 'order': order } )
-
-      # postroute node
-      order = postroute.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      order.append('check-clamp-logic-structure.tcl')
-      postroute.update_params( { 'order': order } )
-
-      # Add fix-shorts as the last thing to do in postroute
-      order = postroute.get_param('order') ; # get the default script run order
-      order.append('fix-shorts.tcl' )      ; # Add fix-shorts at the end
-      postroute.update_params( { 'order': order } ) ; # Update
-
-      # signoff node
-      order = signoff.get_param('order')
-      order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-      read_idx = order.index( 'generate-results.tcl' ) # find generate_results.tcl
-      order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
-      order.append('check-clamp-logic-structure.tcl')
-      signoff.update_params( { 'order': order } )
-      
-  return g
+    g = Graph()
+
+    #-----------------------------------------------------------------------
+    # Parameters
+    #-----------------------------------------------------------------------
+
+    adk_name = get_sys_adk()  # E.g. 'gf12-adk' or 'tsmc16'
+    adk_view = 'multivt'
+    pwr_aware = True
+
+    if pwr_aware:
+        adk_view = adk_view + '-pm'
+
+    flatten = 3
+    if os.environ.get('FLATTEN'):
+        flatten = os.environ.get('FLATTEN')
+
+    synth_power = False
+    if os.environ.get('SYNTH_POWER') == 'True':
+        synth_power = True
+    # power domains do not work with post-synth power
+    if synth_power:
+        pwr_aware = False
+
+    want_drc_pm      = True
+    want_custom_cts  = True
+
+    # TSMC override(s)
+    if adk_name == 'tsmc16':
+        adk_view         = 'multicorner-multivt'
+        want_drc_pm      = False
+        want_custom_cts  = False
+
+    if adk_name == 'tsmc16':
+        read_hdl_defines = 'TSMC16'
+    elif adk_name == 'gf12-adk':
+        read_hdl_defines = 'GF12'
+    else:
+        read_hdl_defines = ''
+
+    parameters = {
+      'construct_path'    : __file__,
+      'design_name'       : 'Tile_PE',
+      'clock_period'      : 1.1,
+      'adk'               : adk_name,
+      'adk_view'          : adk_view,
+      # Synthesis
+      'flatten_effort'    : flatten,
+      'topographical'     : True,
+      'read_hdl_defines'  : read_hdl_defines,
+      # RTL Generation
+      'interconnect_only' : False,
+      'rtl_docker_image'  : 'default', # Current default is 'stanfordaha/garnet:latest'
+      # Power Domains
+      'PWR_AWARE'         : pwr_aware,
+      'core_density_target': 0.6,
+      # Power analysis
+      "use_sdf"           : False, # uses sdf but not the way it is in xrun node
+      'app_to_run'        : 'tests/conv_3_3',
+      'saif_instance'     : 'testbench/dut',
+      'testbench_name'    : 'testbench',
+      'strip_path'        : 'testbench/dut',
+      'drc_env_setup'     : 'drcenv-block.sh'
+      }
+    # TSMC overrides
+    if adk_name == 'tsmc16': parameters.update({
+      'interconnect_only'  : True,
+      'core_density_target': 0.63,
+    })
+
+    # User-level option to change clock frequency
+    # E.g. 'export clock_period_PE="4.0"' to target 250MHz
+    # Optionally could restrict to bk only: if (os.getenv('USER') == "buildkite-agent")
+    cp=os.getenv('clock_period_PE')
+    if (cp != None):
+        print("@file_info: WARNING found env var 'clock_period_PE'")
+        print("@file_info: WARNING setting PE clock period to '%s'" % cp)
+        parameters['clock_period'] = cp;
+
+    #-----------------------------------------------------------------------
+    # Create nodes
+    #-----------------------------------------------------------------------
+
+    this_dir = os.path.dirname( os.path.abspath( __file__ ) )
+
+    # ADK step
+
+    g.set_adk( adk_name )
+    adk = g.get_adk_step()
+
+    # Custom steps
+
+    rtl                  = Step( this_dir + '/../common/rtl'                          )
+    constraints          = Step( this_dir + '/constraints'                            )
+    custom_init          = Step( this_dir + '/custom-init'                            )
+    custom_genus_scripts = Step( this_dir + '/custom-genus-scripts'                   )
+    custom_flowgen_setup = Step( this_dir + '/custom-flowgen-setup'                   )
+    if adk_name == 'tsmc16':
+        custom_power         = Step( this_dir + '/../common/custom-power-leaf-amber'      )
+    else:
+        custom_power         = Step( this_dir + '/../common/custom-power-leaf'            )
+    if want_custom_cts:
+        custom_cts           = Step( this_dir + '/custom-cts'                           )
+    short_fix            = Step( this_dir + '/../common/custom-short-fix'             )
+    genlibdb_constraints = Step( this_dir + '/../common/custom-genlibdb-constraints'  )
+    custom_timing_assert = Step( this_dir + '/../common/custom-timing-assert'         )
+    custom_dc_scripts    = Step( this_dir + '/custom-dc-scripts'                      )
+    testbench            = Step( this_dir + '/../common/testbench'                    )
+    application          = Step( this_dir + '/../common/application'                  )
+    lib2db               = Step( this_dir + '/../common/synopsys-dc-lib2db'           )
+    if want_drc_pm:
+        drc_pm               = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm' )
+    if synth_power:
+        post_synth_power     = Step( this_dir + '/../common/tile-post-synth-power'     )
+    post_pnr_power       = Step( this_dir + '/../common/tile-post-pnr-power'         )
+
+    # Power aware setup
+    power_domains = None
+    pwr_aware_gls = None
+    if pwr_aware:
+        power_domains = Step( this_dir + '/../common/power-domains' )
+        pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls' )
+
+    # Default steps
+    info         = Step( 'info',                          default=True )
+    synth        = Step( 'cadence-genus-synthesis',       default=True )
+    iflow        = Step( 'cadence-innovus-flowsetup',     default=True )
+    init         = Step( 'cadence-innovus-init',          default=True )
+    power        = Step( 'cadence-innovus-power',         default=True )
+    place        = Step( 'cadence-innovus-place',         default=True )
+    cts          = Step( 'cadence-innovus-cts',           default=True )
+    postcts_hold = Step( 'cadence-innovus-postcts_hold',  default=True )
+    route        = Step( 'cadence-innovus-route',         default=True )
+    postroute    = Step( 'cadence-innovus-postroute',     default=True )
+    signoff      = Step( 'cadence-innovus-signoff',       default=True )
+    pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
+    genlibdb     = Step( 'synopsys-ptpx-genlibdb',        default=True )
+
+    if which("calibre") is not None:
+        drc          = Step( 'mentor-calibre-drc',            default=True )
+        lvs          = Step( 'mentor-calibre-lvs',            default=True )
+    else:
+        drc          = Step( 'cadence-pegasus-drc',           default=True )
+        lvs          = Step( 'cadence-pegasus-lvs',           default=True )
+    debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
+
+    # Add custom timing scripts
+    custom_timing_steps = [ synth, postcts_hold, signoff ] # connects to these
+    for c_step in custom_timing_steps:
+        c_step.extend_inputs( custom_timing_assert.all_outputs() )
+
+    # Add extra input edges to innovus steps that need custom tweaks
+    init.extend_inputs( custom_init.all_outputs() )
+    power.extend_inputs( custom_power.all_outputs() )
+    genlibdb.extend_inputs( genlibdb_constraints.all_outputs() )
+    synth.extend_inputs( custom_genus_scripts.all_outputs() )
+    iflow.extend_inputs( custom_flowgen_setup.all_outputs() )
+
+    # Extra input to DC for constraints
+    synth.extend_inputs( ["common.tcl", "reporting.tcl", "generate-results.tcl", "scenarios.tcl", "report_alu.py", "parse_alu.py"] )
+    # Extra outputs from DC
+    synth.extend_outputs( ["sdc"] )
+    iflow.extend_inputs( ["scenarios.tcl", "sdc"] )
+    init.extend_inputs( ["sdc"] )
+    power.extend_inputs( ["sdc"] )
+    place.extend_inputs( ["sdc"] )
+    cts.extend_inputs( ["sdc"] )
+
+    order = synth.get_param( 'order' )
+    order.append( 'copy_sdc.tcl' )
+    synth.set_param( 'order', order )
+
+    # Power aware setup
+    if pwr_aware:
+
+        # Need pe-pd-params so adk.tcl can access parm 'adk_allow_sdf_regs'
+        # (pe-pd-params come from already-connected 'power-domains' node)
+        synth.extend_inputs([
+          'pe-pd-params.tcl',
+          'designer-interface.tcl', 
+          'upf_Tile_PE.tcl', 
+          'pe-constraints.tcl', 
+          'pe-constraints-2.tcl', 
+          'dc-dont-use-constraints.tcl'])
+
+        # Eventually want to extend this to GF as well...!
+        if adk_name == 'tsmc16':
+            synth.extend_inputs([ 'check-pdcr-address.sh' ])
+
+        init.extend_inputs(['upf_Tile_PE.tcl', 'pe-load-upf.tcl', 'dont-touch-constraints.tcl', 'pe-pd-params.tcl', 'pd-aon-floorplan.tcl', 'add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'add-power-switches.tcl', 'check-clamp-logic-structure.tcl'])
+
+        # Eventually want to extend this to GF as well...!
+        if adk_name == 'tsmc16':
+            init.extend_inputs([ 'check-pdcr-address.sh' ])
+
+        # Need pe-pd-params for parm 'vdd_m3_stripe_sparsity'
+        # pd-globalnetconnect, pe-pd-params come from 'power-domains' node
+        power.extend_inputs(['pd-globalnetconnect.tcl', 'pe-pd-params.tcl'] )
+
+        place.extend_inputs(['place-dont-use-constraints.tcl', 'check-clamp-logic-structure.tcl', 'add-aon-tie-cells.tcl'])
+        cts.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
+        postcts_hold.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
+        route.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
+        postroute.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
+        signoff.extend_inputs(['conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl', 'check-clamp-logic-structure.tcl'] )
+        pwr_aware_gls.extend_inputs(['design.vcs.pg.v'])
+
+        # Eventually want to extend this to GF as well...!
+        if adk_name == 'tsmc16':
+            # Fix and repair PowerDomainConfigReg when/if magma decides to renumber it :(
+            synth.pre_extend_commands( ['./inputs/check-pdcr-address.sh'] )
+            init.pre_extend_commands(  ['./inputs/check-pdcr-address.sh'] )
+            pwr_aware_gls.pre_extend_commands( ['./assign-pdcr-address.sh'] )
+
+    # Add short_fix script(s) to list of available postroute scripts
+    postroute.extend_inputs( short_fix.all_outputs() )
+
+    # Add graph inputs and outputs so this can be used in hierarchical flows
+
+    # Inputs
+    g.add_input( 'design.v', rtl.i('design.v') )
+
+    # Outputs
+    g.add_output( 'Tile_PE_tt.lib',      genlibdb.o('design.lib')       )
+    g.add_output( 'Tile_PE_tt.db',       genlibdb.o('design.db')        )
+    g.add_output( 'Tile_PE.lef',         signoff.o('design.lef')        )
+    g.add_output( 'Tile_PE.gds',         signoff.o('design-merged.gds') )
+    g.add_output( 'Tile_PE.sdf',         signoff.o('design.sdf')        )
+    g.add_output( 'Tile_PE.vcs.v',       signoff.o('design.vcs.v')      )
+    g.add_output( 'Tile_PE.vcs.pg.v',    signoff.o('design.vcs.pg.v')   )
+    g.add_output( 'Tile_PE.spef.gz',     signoff.o('design.spef.gz')    )
+    g.add_output( 'Tile_PE.pt.sdc',      signoff.o('design.pt.sdc')     )
+    g.add_output( 'Tile_PE.lvs.v',       lvs.o('design_merged.lvs.v')   )
+
+    # TSMC needs streamout *without* the (new) default -uniquify flag
+    # This python method finds 'stream-out.tcl' and strips out that flag.
+    from common.streamout_no_uniquify import streamout_no_uniquify
+    if adk_name == "tsmc16": streamout_no_uniquify(iflow)
+
+    #-----------------------------------------------------------------------
+    # Graph -- Add nodes
+    #-----------------------------------------------------------------------
+
+    g.add_step( info                     )
+    g.add_step( rtl                      )
+    g.add_step( constraints              )
+    g.add_step( custom_dc_scripts        )
+    g.add_step( synth                    )
+    g.add_step( custom_timing_assert     )
+    g.add_step( custom_genus_scripts     )
+    g.add_step( iflow                    )
+    g.add_step( custom_flowgen_setup     )
+    g.add_step( init                     )
+    g.add_step( custom_init              )
+    g.add_step( power                    )
+    g.add_step( custom_power             )
+    g.add_step( place                    )
+    g.add_step( cts                      )
+    g.add_step( postcts_hold             )
+    g.add_step( route                    )
+    g.add_step( postroute                )
+    g.add_step( short_fix                )
+    g.add_step( signoff                  )
+    g.add_step( pt_signoff               )
+    g.add_step( genlibdb_constraints     )
+    g.add_step( genlibdb                 )
+    g.add_step( lib2db                   )
+    g.add_step( drc                      )
+    g.add_step( lvs                      )
+    g.add_step( debugcalibre             )
+
+    g.add_step( application              )
+    g.add_step( testbench                )
+    if synth_power:
+        g.add_step( post_synth_power       )
+    g.add_step( post_pnr_power           )
+
+    # Power aware step
+    if pwr_aware:
+        g.add_step( power_domains        )
+        g.add_step( pwr_aware_gls        )
+
+    #-----------------------------------------------------------------------
+    # Graph -- Add edges
+    #-----------------------------------------------------------------------
+
+    # Dynamically add edges
+
+    # Connect by name
+
+    g.connect_by_name( adk,      synth        )
+    g.connect_by_name( adk,      iflow        )
+    g.connect_by_name( adk,      init         )
+    g.connect_by_name( adk,      power        )
+    g.connect_by_name( adk,      place        )
+    g.connect_by_name( adk,      cts          )
+    g.connect_by_name( adk,      postcts_hold )
+    g.connect_by_name( adk,      route        )
+    g.connect_by_name( adk,      postroute    )
+    g.connect_by_name( adk,      signoff      )
+    g.connect_by_name( adk,      drc          )
+    g.connect_by_name( adk,      lvs          )
+
+    g.connect_by_name( rtl,         synth          )
+    g.connect_by_name( constraints, synth          )
+    g.connect_by_name( custom_genus_scripts, synth )
+    g.connect_by_name( constraints, iflow          )
+    g.connect_by_name( custom_dc_scripts, iflow    )
+
+    for c_step in custom_timing_steps:
+        g.connect_by_name( custom_timing_assert, c_step )
+
+    g.connect_by_name( synth,       iflow                )
+    g.connect_by_name( synth,       init                 )
+    g.connect_by_name( synth,       power                )
+    g.connect_by_name( synth,       place                )
+    g.connect_by_name( synth,       cts                  )
+    g.connect_by_name( synth,       custom_flowgen_setup )
+
+    g.connect_by_name( custom_flowgen_setup, iflow )
+    g.connect_by_name( iflow,    init         )
+    g.connect_by_name( iflow,    power        )
+    g.connect_by_name( iflow,    place        )
+    g.connect_by_name( iflow,    cts          )
+    g.connect_by_name( iflow,    postcts_hold )
+    g.connect_by_name( iflow,    route        )
+    g.connect_by_name( iflow,    postroute    )
+    g.connect_by_name( iflow,    signoff      )
+
+    g.connect_by_name( custom_init,  init     )
+    g.connect_by_name( custom_power, power    )
+
+    # Fetch short-fix script in prep for eventual use by postroute
+    g.connect_by_name( short_fix, postroute )
+
+    g.connect_by_name( init,         power        )
+    g.connect_by_name( power,        place        )
+    g.connect_by_name( place,        cts          )
+    g.connect_by_name( cts,          postcts_hold )
+    g.connect_by_name( postcts_hold, route        )
+    g.connect_by_name( route,        postroute    )
+    g.connect_by_name( postroute,    signoff      )
+
+    g.connect_by_name( signoff,      drc          )
+    g.connect_by_name( signoff,      lvs          )
+    g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
+    g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
+
+    g.connect_by_name( signoff,              genlibdb )
+    g.connect_by_name( adk,                  genlibdb )
+    g.connect_by_name( genlibdb_constraints, genlibdb )
+
+    g.connect_by_name( genlibdb,             lib2db   )
+
+    g.connect_by_name( adk,          pt_signoff   )
+    g.connect_by_name( signoff,      pt_signoff   )
+
+    g.connect_by_name( application, testbench       )
+    if synth_power:
+        g.connect_by_name( application, post_synth_power )
+        g.connect_by_name( synth,       post_synth_power )
+        g.connect_by_name( testbench,   post_synth_power )
+    g.connect_by_name( application, post_pnr_power )
+    g.connect_by_name( signoff,     post_pnr_power )
+    g.connect_by_name( pt_signoff,  post_pnr_power )
+    g.connect_by_name( testbench,   post_pnr_power )
+
+    g.connect_by_name( adk,      debugcalibre )
+    g.connect_by_name( synth,    debugcalibre )
+    g.connect_by_name( iflow,    debugcalibre )
+    g.connect_by_name( signoff,  debugcalibre )
+    g.connect_by_name( drc,      debugcalibre )
+    g.connect_by_name( lvs,      debugcalibre )
+
+    # Pwr aware steps:
+    if pwr_aware:
+        g.connect_by_name( power_domains,        synth        )
+        g.connect_by_name( power_domains,        init         )
+        g.connect_by_name( power_domains,        power        )
+        g.connect_by_name( power_domains,        place        )
+        g.connect_by_name( power_domains,        cts          )
+        g.connect_by_name( power_domains,        postcts_hold )
+        g.connect_by_name( power_domains,        route        )
+        g.connect_by_name( power_domains,        postroute    )
+        g.connect_by_name( power_domains,        signoff      )
+        g.connect_by_name( adk,                  pwr_aware_gls)
+        g.connect_by_name( signoff,              pwr_aware_gls)
+        #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
+
+    # New 'custom_cts' step added for gf12
+    if want_custom_cts:
+        cts.extend_inputs( custom_cts.all_outputs() )
+        g.add_step(        custom_cts               )
+        g.connect_by_name( custom_cts,   cts        )
+
+    # New 'drc_pm' step, added for gf12
+    if want_drc_pm:
+        g.add_step( drc_pm )
+        g.connect_by_name( adk,           drc_pm         )
+        g.connect_by_name( signoff,       drc_pm         )
+        g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
+        g.connect_by_name( drc_pm,        debugcalibre   )
+
+    g.connect_by_name( iflow,    genlibdb       )
+
+    #-----------------------------------------------------------------------
+    # Parameterize
+    #-----------------------------------------------------------------------
+
+    g.update_params( parameters )
+
+    # Add custom timing scripts
+
+    for c_step in custom_timing_steps:
+        order = c_step.get_param( 'order' )
+        order.append( 'report-special-timing.tcl' )
+        c_step.set_param( 'order', order )
+        c_step.extend_postconditions( [{ 'pytest': 'inputs/test_timing.py' }] )
+
+    # Update PWR_AWARE variable
+    synth.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
+    init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
+    power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
+
+    if pwr_aware:
+        init.update_params( { 'flatten_effort': parameters['flatten_effort'] }, True )
+        pwr_aware_gls.update_params( { 'design_name': parameters['design_name'] }, True )
+
+        init.extend_postconditions(         ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        place.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        cts.extend_postconditions(          ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        postcts_hold.extend_postconditions( ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        route.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        postroute.extend_postconditions(    ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        signoff.extend_postconditions(      ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+    # Since we are adding an additional input script to the generic Innovus
+    # steps, we modify the order parameter for that node which determines
+    # which scripts get run and when they get run.
+
+    init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
+    # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
+    # and 'additional-path-groups' after 'make_path_groups'
+
+    order = init.get_param('order') # get the default script run order
+    path_group_idx = order.index( 'make-path-groups.tcl' )
+    order.insert( path_group_idx + 1, 'additional-path-groups.tcl' )
+    pin_idx = order.index( 'pin-assignments.tcl' ) # find pin-assignments.tcl
+    order.insert( pin_idx + 1, 'edge-blockages.tcl' ) # add here
+    init.update_params( { 'order': order } )
+
+    # Adding new input for genlibdb node to run
+
+    # No longer conditional---amber and onyx now use same genlib mechanism
+    order = genlibdb.get_param('order') # get the default script run order
+    extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
+    order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
+    genlibdb.update_params( { 'order': order } )
+
+    # genlibdb -- Remove 'report-interface-timing.tcl' beacuse it takes
+    # very long and is not necessary
+    order = genlibdb.get_param('order')
+    order.remove( 'write-interface-timing.tcl' )
+    genlibdb.update_params( { 'order': order } )
+
+    # Pwr aware steps:
+    if pwr_aware:
+        # init node
+        order = init.get_param('order')
+        read_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
+
+        # 09/2022 reordered to load params (pe-pd-params) before using params (pe-load-upf)
+        order.insert( read_idx + 1, 'pe-pd-params.tcl' ) # add here
+        order.insert( read_idx + 2, 'pe-load-upf.tcl' ) # add here
+        order.insert( read_idx + 3, 'pd-aon-floorplan.tcl' ) # add here
+        order.insert( read_idx + 4, 'add-endcaps-welltaps-setup.tcl' ) # add here
+        order.insert( read_idx + 5, 'pd-add-endcaps-welltaps.tcl' ) # add here
+        order.insert( read_idx + 6, 'add-power-switches.tcl' ) # add here
+        order.remove('add-endcaps-welltaps.tcl')
+        order.append('check-clamp-logic-structure.tcl')
+        init.update_params( { 'order': order } )
+
+        # synth node (needs parm 'adk_allow_sdf_regs')
+        order = synth.get_param('order')
+        order.insert( 0, 'pe-pd-params.tcl' )        # add params file
+        synth.update_params( { 'order': order } )
+
+        # power node
+        order = power.get_param('order')
+        order.insert( 0, 'pd-globalnetconnect.tcl' ) # add new 'pd-globalnetconnect'
+        order.remove('globalnetconnect.tcl')         # remove old 'globalnetconnect'
+        order.insert( 0, 'pe-pd-params.tcl' )        # add params file
+        power.update_params( { 'order': order } )
+
+        # place node
+        order = place.get_param('order')
+        read_idx = order.index( 'main.tcl' ) # find main.tcl
+        order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
+        order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
+        order.append('check-clamp-logic-structure.tcl')
+        place.update_params( { 'order': order } )
+
+        # cts node
+        order = cts.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.append('check-clamp-logic-structure.tcl')
+        cts.update_params( { 'order': order } )
+
+        # postcts_hold node
+        order = postcts_hold.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.append('check-clamp-logic-structure.tcl')
+        postcts_hold.update_params( { 'order': order } )
+
+        # route node
+        order = route.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.append('check-clamp-logic-structure.tcl')
+        route.update_params( { 'order': order } )
+
+        # postroute node
+        order = postroute.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.append('check-clamp-logic-structure.tcl')
+        postroute.update_params( { 'order': order } )
+
+        # Add fix-shorts as the last thing to do in postroute
+        order = postroute.get_param('order') ; # get the default script run order
+        order.append('fix-shorts.tcl' )      ; # Add fix-shorts at the end
+        postroute.update_params( { 'order': order } ) ; # Update
+
+        # signoff node
+        order = signoff.get_param('order')
+        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        read_idx = order.index( 'generate-results.tcl' ) # find generate_results.tcl
+        order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
+        order.append('check-clamp-logic-structure.tcl')
+        signoff.update_params( { 'order': order } )
+
+    return g
 
 if __name__ == '__main__':
-  g = construct()
-  # g.plot()
-
-
+    g = construct()
+    # g.plot()

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -95,94 +95,94 @@ def construct():
     # Create nodes
     #-----------------------------------------------------------------------
 
-    this_dir = os.path.dirname( os.path.abspath( __file__ ) )
+    this_dir = os.path.dirname(os.path.abspath(__file__))
 
     # ADK step
 
-    g.set_adk( adk_name )
+    g.set_adk(adk_name)
     adk = g.get_adk_step()
 
     # Custom steps
 
-    rtl                  = Step( this_dir + '/../common/rtl'                          )
-    constraints          = Step( this_dir + '/constraints'                            )
-    custom_init          = Step( this_dir + '/custom-init'                            )
-    custom_genus_scripts = Step( this_dir + '/custom-genus-scripts'                   )
-    custom_flowgen_setup = Step( this_dir + '/custom-flowgen-setup'                   )
+    rtl                  = Step(this_dir + '/../common/rtl')
+    constraints          = Step(this_dir + '/constraints')
+    custom_init          = Step(this_dir + '/custom-init')
+    custom_genus_scripts = Step(this_dir + '/custom-genus-scripts')
+    custom_flowgen_setup = Step(this_dir + '/custom-flowgen-setup')
     if adk_name == 'tsmc16':
-        custom_power         = Step( this_dir + '/../common/custom-power-leaf-amber'      )
+        custom_power         = Step(this_dir + '/../common/custom-power-leaf-amber')
     else:
-        custom_power         = Step( this_dir + '/../common/custom-power-leaf'            )
+        custom_power         = Step(this_dir + '/../common/custom-power-leaf')
     if want_custom_cts:
-        custom_cts           = Step( this_dir + '/custom-cts'                           )
-    short_fix            = Step( this_dir + '/../common/custom-short-fix'             )
-    genlibdb_constraints = Step( this_dir + '/../common/custom-genlibdb-constraints'  )
-    custom_timing_assert = Step( this_dir + '/../common/custom-timing-assert'         )
-    custom_dc_scripts    = Step( this_dir + '/custom-dc-scripts'                      )
-    testbench            = Step( this_dir + '/../common/testbench'                    )
-    application          = Step( this_dir + '/../common/application'                  )
-    lib2db               = Step( this_dir + '/../common/synopsys-dc-lib2db'           )
+        custom_cts           = Step(this_dir + '/custom-cts')
+    short_fix            = Step(this_dir + '/../common/custom-short-fix')
+    genlibdb_constraints = Step(this_dir + '/../common/custom-genlibdb-constraints')
+    custom_timing_assert = Step(this_dir + '/../common/custom-timing-assert')
+    custom_dc_scripts    = Step(this_dir + '/custom-dc-scripts')
+    testbench            = Step(this_dir + '/../common/testbench')
+    application          = Step(this_dir + '/../common/application')
+    lib2db               = Step(this_dir + '/../common/synopsys-dc-lib2db')
     if want_drc_pm:
-        drc_pm               = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm' )
+        drc_pm               = Step(this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
     if synth_power:
-        post_synth_power     = Step( this_dir + '/../common/tile-post-synth-power'     )
-    post_pnr_power       = Step( this_dir + '/../common/tile-post-pnr-power'         )
+        post_synth_power     = Step(this_dir + '/../common/tile-post-synth-power')
+    post_pnr_power       = Step(this_dir + '/../common/tile-post-pnr-power')
 
     # Power aware setup
     power_domains = None
     pwr_aware_gls = None
     if pwr_aware:
-        power_domains = Step( this_dir + '/../common/power-domains' )
-        pwr_aware_gls = Step( this_dir + '/../common/pwr-aware-gls' )
+        power_domains = Step(this_dir + '/../common/power-domains')
+        pwr_aware_gls = Step(this_dir + '/../common/pwr-aware-gls')
 
     # Default steps
-    info         = Step( 'info',                          default=True )
-    synth        = Step( 'cadence-genus-synthesis',       default=True )
-    iflow        = Step( 'cadence-innovus-flowsetup',     default=True )
-    init         = Step( 'cadence-innovus-init',          default=True )
-    power        = Step( 'cadence-innovus-power',         default=True )
-    place        = Step( 'cadence-innovus-place',         default=True )
-    cts          = Step( 'cadence-innovus-cts',           default=True )
-    postcts_hold = Step( 'cadence-innovus-postcts_hold',  default=True )
-    route        = Step( 'cadence-innovus-route',         default=True )
-    postroute    = Step( 'cadence-innovus-postroute',     default=True )
-    signoff      = Step( 'cadence-innovus-signoff',       default=True )
-    pt_signoff   = Step( 'synopsys-pt-timing-signoff',    default=True )
-    genlibdb     = Step( 'synopsys-ptpx-genlibdb',        default=True )
+    info         = Step('info',                          default=True)
+    synth        = Step('cadence-genus-synthesis',       default=True)
+    iflow        = Step('cadence-innovus-flowsetup',     default=True)
+    init         = Step('cadence-innovus-init',          default=True)
+    power        = Step('cadence-innovus-power',         default=True)
+    place        = Step('cadence-innovus-place',         default=True)
+    cts          = Step('cadence-innovus-cts',           default=True)
+    postcts_hold = Step('cadence-innovus-postcts_hold',  default=True)
+    route        = Step('cadence-innovus-route',         default=True)
+    postroute    = Step('cadence-innovus-postroute',     default=True)
+    signoff      = Step('cadence-innovus-signoff',       default=True)
+    pt_signoff   = Step('synopsys-pt-timing-signoff',    default=True)
+    genlibdb     = Step('synopsys-ptpx-genlibdb',        default=True)
 
     if which("calibre") is not None:
-        drc          = Step( 'mentor-calibre-drc',            default=True )
-        lvs          = Step( 'mentor-calibre-lvs',            default=True )
+        drc          = Step('mentor-calibre-drc',            default=True)
+        lvs          = Step('mentor-calibre-lvs',            default=True)
     else:
-        drc          = Step( 'cadence-pegasus-drc',           default=True )
-        lvs          = Step( 'cadence-pegasus-lvs',           default=True )
-    debugcalibre = Step( 'cadence-innovus-debug-calibre', default=True )
+        drc          = Step('cadence-pegasus-drc',           default=True)
+        lvs          = Step('cadence-pegasus-lvs',           default=True)
+    debugcalibre = Step('cadence-innovus-debug-calibre', default=True)
 
     # Add custom timing scripts
-    custom_timing_steps = [ synth, postcts_hold, signoff ] # connects to these
+    custom_timing_steps = [synth, postcts_hold, signoff] # connects to these
     for c_step in custom_timing_steps:
-        c_step.extend_inputs( custom_timing_assert.all_outputs() )
+        c_step.extend_inputs(custom_timing_assert.all_outputs())
 
     # Add extra input edges to innovus steps that need custom tweaks
-    init.extend_inputs( custom_init.all_outputs() )
-    power.extend_inputs( custom_power.all_outputs() )
-    genlibdb.extend_inputs( genlibdb_constraints.all_outputs() )
-    synth.extend_inputs( custom_genus_scripts.all_outputs() )
-    iflow.extend_inputs( custom_flowgen_setup.all_outputs() )
+    init.extend_inputs(custom_init.all_outputs())
+    power.extend_inputs(custom_power.all_outputs())
+    genlibdb.extend_inputs(genlibdb_constraints.all_outputs())
+    synth.extend_inputs(custom_genus_scripts.all_outputs())
+    iflow.extend_inputs(custom_flowgen_setup.all_outputs())
 
     # Extra input to DC for constraints
-    synth.extend_inputs( ["common.tcl", "reporting.tcl", "generate-results.tcl", "scenarios.tcl", "report_alu.py", "parse_alu.py"] )
+    synth.extend_inputs(["common.tcl", "reporting.tcl", "generate-results.tcl", "scenarios.tcl", "report_alu.py", "parse_alu.py"])
     # Extra outputs from DC
-    synth.extend_outputs( ["sdc"] )
-    iflow.extend_inputs( ["scenarios.tcl", "sdc"] )
-    init.extend_inputs( ["sdc"] )
-    power.extend_inputs( ["sdc"] )
-    place.extend_inputs( ["sdc"] )
-    cts.extend_inputs( ["sdc"] )
+    synth.extend_outputs(["sdc"])
+    iflow.extend_inputs(["scenarios.tcl", "sdc"])
+    init.extend_inputs(["sdc"])
+    power.extend_inputs(["sdc"])
+    place.extend_inputs(["sdc"])
+    cts.extend_inputs(["sdc"])
 
-    order = synth.get_param( 'order' )
-    order.append( 'copy_sdc.tcl' )
-    synth.set_param( 'order', order )
+    order = synth.get_param('order')
+    order.append('copy_sdc.tcl')
+    synth.set_param('order', order)
 
     # Power aware setup
     if pwr_aware:
@@ -199,52 +199,52 @@ def construct():
 
         # Eventually want to extend this to GF as well...!
         if adk_name == 'tsmc16':
-            synth.extend_inputs([ 'check-pdcr-address.sh' ])
+            synth.extend_inputs(['check-pdcr-address.sh'])
 
         init.extend_inputs(['upf_Tile_PE.tcl', 'pe-load-upf.tcl', 'dont-touch-constraints.tcl', 'pe-pd-params.tcl', 'pd-aon-floorplan.tcl', 'add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'add-power-switches.tcl', 'check-clamp-logic-structure.tcl'])
 
         # Eventually want to extend this to GF as well...!
         if adk_name == 'tsmc16':
-            init.extend_inputs([ 'check-pdcr-address.sh' ])
+            init.extend_inputs(['check-pdcr-address.sh'])
 
         # Need pe-pd-params for parm 'vdd_m3_stripe_sparsity'
         # pd-globalnetconnect, pe-pd-params come from 'power-domains' node
-        power.extend_inputs(['pd-globalnetconnect.tcl', 'pe-pd-params.tcl'] )
+        power.extend_inputs(['pd-globalnetconnect.tcl', 'pe-pd-params.tcl'])
 
         place.extend_inputs(['place-dont-use-constraints.tcl', 'check-clamp-logic-structure.tcl', 'add-aon-tie-cells.tcl'])
         cts.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
-        postcts_hold.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
-        route.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
-        postroute.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'] )
-        signoff.extend_inputs(['conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl', 'check-clamp-logic-structure.tcl'] )
+        postcts_hold.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
+        route.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
+        postroute.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
+        signoff.extend_inputs(['conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl', 'check-clamp-logic-structure.tcl'])
         pwr_aware_gls.extend_inputs(['design.vcs.pg.v'])
 
         # Eventually want to extend this to GF as well...!
         if adk_name == 'tsmc16':
             # Fix and repair PowerDomainConfigReg when/if magma decides to renumber it :(
-            synth.pre_extend_commands( ['./inputs/check-pdcr-address.sh'] )
-            init.pre_extend_commands(  ['./inputs/check-pdcr-address.sh'] )
-            pwr_aware_gls.pre_extend_commands( ['./assign-pdcr-address.sh'] )
+            synth.pre_extend_commands(['./inputs/check-pdcr-address.sh'])
+            init.pre_extend_commands(['./inputs/check-pdcr-address.sh'])
+            pwr_aware_gls.pre_extend_commands(['./assign-pdcr-address.sh'])
 
     # Add short_fix script(s) to list of available postroute scripts
-    postroute.extend_inputs( short_fix.all_outputs() )
+    postroute.extend_inputs(short_fix.all_outputs())
 
     # Add graph inputs and outputs so this can be used in hierarchical flows
 
     # Inputs
-    g.add_input( 'design.v', rtl.i('design.v') )
+    g.add_input('design.v', rtl.i('design.v'))
 
     # Outputs
-    g.add_output( 'Tile_PE_tt.lib',      genlibdb.o('design.lib')       )
-    g.add_output( 'Tile_PE_tt.db',       genlibdb.o('design.db')        )
-    g.add_output( 'Tile_PE.lef',         signoff.o('design.lef')        )
-    g.add_output( 'Tile_PE.gds',         signoff.o('design-merged.gds') )
-    g.add_output( 'Tile_PE.sdf',         signoff.o('design.sdf')        )
-    g.add_output( 'Tile_PE.vcs.v',       signoff.o('design.vcs.v')      )
-    g.add_output( 'Tile_PE.vcs.pg.v',    signoff.o('design.vcs.pg.v')   )
-    g.add_output( 'Tile_PE.spef.gz',     signoff.o('design.spef.gz')    )
-    g.add_output( 'Tile_PE.pt.sdc',      signoff.o('design.pt.sdc')     )
-    g.add_output( 'Tile_PE.lvs.v',       lvs.o('design_merged.lvs.v')   )
+    g.add_output('Tile_PE_tt.lib',      genlibdb.o('design.lib'))
+    g.add_output('Tile_PE_tt.db',       genlibdb.o('design.db'))
+    g.add_output('Tile_PE.lef',         signoff.o('design.lef'))
+    g.add_output('Tile_PE.gds',         signoff.o('design-merged.gds'))
+    g.add_output('Tile_PE.sdf',         signoff.o('design.sdf'))
+    g.add_output('Tile_PE.vcs.v',       signoff.o('design.vcs.v'))
+    g.add_output('Tile_PE.vcs.pg.v',    signoff.o('design.vcs.pg.v'))
+    g.add_output('Tile_PE.spef.gz',     signoff.o('design.spef.gz'))
+    g.add_output('Tile_PE.pt.sdc',      signoff.o('design.pt.sdc'))
+    g.add_output('Tile_PE.lvs.v',       lvs.o('design_merged.lvs.v'))
 
     # TSMC needs streamout *without* the (new) default -uniquify flag
     # This python method finds 'stream-out.tcl' and strips out that flag.
@@ -255,44 +255,44 @@ def construct():
     # Graph -- Add nodes
     #-----------------------------------------------------------------------
 
-    g.add_step( info                     )
-    g.add_step( rtl                      )
-    g.add_step( constraints              )
-    g.add_step( custom_dc_scripts        )
-    g.add_step( synth                    )
-    g.add_step( custom_timing_assert     )
-    g.add_step( custom_genus_scripts     )
-    g.add_step( iflow                    )
-    g.add_step( custom_flowgen_setup     )
-    g.add_step( init                     )
-    g.add_step( custom_init              )
-    g.add_step( power                    )
-    g.add_step( custom_power             )
-    g.add_step( place                    )
-    g.add_step( cts                      )
-    g.add_step( postcts_hold             )
-    g.add_step( route                    )
-    g.add_step( postroute                )
-    g.add_step( short_fix                )
-    g.add_step( signoff                  )
-    g.add_step( pt_signoff               )
-    g.add_step( genlibdb_constraints     )
-    g.add_step( genlibdb                 )
-    g.add_step( lib2db                   )
-    g.add_step( drc                      )
-    g.add_step( lvs                      )
-    g.add_step( debugcalibre             )
+    g.add_step(info)
+    g.add_step(rtl)
+    g.add_step(constraints)
+    g.add_step(custom_dc_scripts)
+    g.add_step(synth)
+    g.add_step(custom_timing_assert)
+    g.add_step(custom_genus_scripts)
+    g.add_step(iflow)
+    g.add_step(custom_flowgen_setup)
+    g.add_step(init)
+    g.add_step(custom_init)
+    g.add_step(power)
+    g.add_step(custom_power)
+    g.add_step(place)
+    g.add_step(cts)
+    g.add_step(postcts_hold)
+    g.add_step(route)
+    g.add_step(postroute)
+    g.add_step(short_fix)
+    g.add_step(signoff)
+    g.add_step(pt_signoff)
+    g.add_step(genlibdb_constraints)
+    g.add_step(genlibdb)
+    g.add_step(lib2db)
+    g.add_step(drc)
+    g.add_step(lvs)
+    g.add_step(debugcalibre)
 
-    g.add_step( application              )
-    g.add_step( testbench                )
+    g.add_step(application)
+    g.add_step(testbench)
     if synth_power:
-        g.add_step( post_synth_power       )
-    g.add_step( post_pnr_power           )
+        g.add_step(post_synth_power)
+    g.add_step(post_pnr_power)
 
     # Power aware step
     if pwr_aware:
-        g.add_step( power_domains        )
-        g.add_step( pwr_aware_gls        )
+        g.add_step(power_domains)
+        g.add_step(pwr_aware_gls)
 
     #-----------------------------------------------------------------------
     # Graph -- Add edges
@@ -302,253 +302,254 @@ def construct():
 
     # Connect by name
 
-    g.connect_by_name( adk,      synth        )
-    g.connect_by_name( adk,      iflow        )
-    g.connect_by_name( adk,      init         )
-    g.connect_by_name( adk,      power        )
-    g.connect_by_name( adk,      place        )
-    g.connect_by_name( adk,      cts          )
-    g.connect_by_name( adk,      postcts_hold )
-    g.connect_by_name( adk,      route        )
-    g.connect_by_name( adk,      postroute    )
-    g.connect_by_name( adk,      signoff      )
-    g.connect_by_name( adk,      drc          )
-    g.connect_by_name( adk,      lvs          )
+    g.connect_by_name(adk,      synth)
+    g.connect_by_name(adk,      iflow)
+    g.connect_by_name(adk,      init)
+    g.connect_by_name(adk,      power)
+    g.connect_by_name(adk,      place)
+    g.connect_by_name(adk,      cts)
+    g.connect_by_name(adk,      postcts_hold)
+    g.connect_by_name(adk,      route)
+    g.connect_by_name(adk,      postroute)
+    g.connect_by_name(adk,      signoff)
+    g.connect_by_name(adk,      drc)
+    g.connect_by_name(adk,      lvs)
 
-    g.connect_by_name( rtl,         synth          )
-    g.connect_by_name( constraints, synth          )
-    g.connect_by_name( custom_genus_scripts, synth )
-    g.connect_by_name( constraints, iflow          )
-    g.connect_by_name( custom_dc_scripts, iflow    )
+    g.connect_by_name(rtl,         synth)
+    g.connect_by_name(constraints, synth)
+    g.connect_by_name(custom_genus_scripts, synth)
+    g.connect_by_name(constraints, iflow)
+    g.connect_by_name(custom_dc_scripts, iflow)
 
     for c_step in custom_timing_steps:
-        g.connect_by_name( custom_timing_assert, c_step )
+        g.connect_by_name(custom_timing_assert, c_step)
 
-    g.connect_by_name( synth,       iflow                )
-    g.connect_by_name( synth,       init                 )
-    g.connect_by_name( synth,       power                )
-    g.connect_by_name( synth,       place                )
-    g.connect_by_name( synth,       cts                  )
-    g.connect_by_name( synth,       custom_flowgen_setup )
+    g.connect_by_name(synth,       iflow)
+    g.connect_by_name(synth,       init)
+    g.connect_by_name(synth,       power)
+    g.connect_by_name(synth,       place)
+    g.connect_by_name(synth,       cts)
+    g.connect_by_name(synth,       custom_flowgen_setup)
 
-    g.connect_by_name( custom_flowgen_setup, iflow )
-    g.connect_by_name( iflow,    init         )
-    g.connect_by_name( iflow,    power        )
-    g.connect_by_name( iflow,    place        )
-    g.connect_by_name( iflow,    cts          )
-    g.connect_by_name( iflow,    postcts_hold )
-    g.connect_by_name( iflow,    route        )
-    g.connect_by_name( iflow,    postroute    )
-    g.connect_by_name( iflow,    signoff      )
+    g.connect_by_name(custom_flowgen_setup, iflow)
+    g.connect_by_name(iflow,    init)
+    g.connect_by_name(iflow,    power)
+    g.connect_by_name(iflow,    place)
+    g.connect_by_name(iflow,    cts)
+    g.connect_by_name(iflow,    postcts_hold)
+    g.connect_by_name(iflow,    route)
+    g.connect_by_name(iflow,    postroute)
+    g.connect_by_name(iflow,    signoff)
 
-    g.connect_by_name( custom_init,  init     )
-    g.connect_by_name( custom_power, power    )
+    g.connect_by_name(custom_init,  init)
+    g.connect_by_name(custom_power, power)
 
     # Fetch short-fix script in prep for eventual use by postroute
-    g.connect_by_name( short_fix, postroute )
+    g.connect_by_name(short_fix, postroute)
 
-    g.connect_by_name( init,         power        )
-    g.connect_by_name( power,        place        )
-    g.connect_by_name( place,        cts          )
-    g.connect_by_name( cts,          postcts_hold )
-    g.connect_by_name( postcts_hold, route        )
-    g.connect_by_name( route,        postroute    )
-    g.connect_by_name( postroute,    signoff      )
+    g.connect_by_name(init,         power)
+    g.connect_by_name(power,        place)
+    g.connect_by_name(place,        cts)
+    g.connect_by_name(cts,          postcts_hold)
+    g.connect_by_name(postcts_hold, route)
+    g.connect_by_name(route,        postroute)
+    g.connect_by_name(postroute,    signoff)
 
-    g.connect_by_name( signoff,      drc          )
-    g.connect_by_name( signoff,      lvs          )
+    g.connect_by_name(signoff,      drc)
+    g.connect_by_name(signoff,      lvs)
     g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
     g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
-    g.connect_by_name( signoff,              genlibdb )
-    g.connect_by_name( adk,                  genlibdb )
-    g.connect_by_name( genlibdb_constraints, genlibdb )
+    g.connect_by_name(signoff,              genlibdb)
+    g.connect_by_name(adk,                  genlibdb)
+    g.connect_by_name(genlibdb_constraints, genlibdb)
 
-    g.connect_by_name( genlibdb,             lib2db   )
+    g.connect_by_name(genlibdb,             lib2db)
 
-    g.connect_by_name( adk,          pt_signoff   )
-    g.connect_by_name( signoff,      pt_signoff   )
+    g.connect_by_name(adk,          pt_signoff)
+    g.connect_by_name(signoff,      pt_signoff)
 
-    g.connect_by_name( application, testbench       )
+    g.connect_by_name(application, testbench)
     if synth_power:
-        g.connect_by_name( application, post_synth_power )
-        g.connect_by_name( synth,       post_synth_power )
-        g.connect_by_name( testbench,   post_synth_power )
-    g.connect_by_name( application, post_pnr_power )
-    g.connect_by_name( signoff,     post_pnr_power )
-    g.connect_by_name( pt_signoff,  post_pnr_power )
-    g.connect_by_name( testbench,   post_pnr_power )
+        g.connect_by_name(application, post_synth_power)
+        g.connect_by_name(synth,       post_synth_power)
+        g.connect_by_name(testbench,   post_synth_power)
+    g.connect_by_name(application, post_pnr_power)
+    g.connect_by_name(signoff,     post_pnr_power)
+    g.connect_by_name(pt_signoff,  post_pnr_power)
+    g.connect_by_name(testbench,   post_pnr_power)
 
-    g.connect_by_name( adk,      debugcalibre )
-    g.connect_by_name( synth,    debugcalibre )
-    g.connect_by_name( iflow,    debugcalibre )
-    g.connect_by_name( signoff,  debugcalibre )
-    g.connect_by_name( drc,      debugcalibre )
-    g.connect_by_name( lvs,      debugcalibre )
+    g.connect_by_name(adk,      debugcalibre)
+    g.connect_by_name(synth,    debugcalibre)
+    g.connect_by_name(iflow,    debugcalibre)
+    g.connect_by_name(signoff,  debugcalibre)
+    g.connect_by_name(drc,      debugcalibre)
+    g.connect_by_name(lvs,      debugcalibre)
 
     # Pwr aware steps:
     if pwr_aware:
-        g.connect_by_name( power_domains,        synth        )
-        g.connect_by_name( power_domains,        init         )
-        g.connect_by_name( power_domains,        power        )
-        g.connect_by_name( power_domains,        place        )
-        g.connect_by_name( power_domains,        cts          )
-        g.connect_by_name( power_domains,        postcts_hold )
-        g.connect_by_name( power_domains,        route        )
-        g.connect_by_name( power_domains,        postroute    )
-        g.connect_by_name( power_domains,        signoff      )
-        g.connect_by_name( adk,                  pwr_aware_gls)
-        g.connect_by_name( signoff,              pwr_aware_gls)
+        g.connect_by_name(power_domains,        synth)
+        g.connect_by_name(power_domains,        init)
+        g.connect_by_name(power_domains,        power)
+        g.connect_by_name(power_domains,        place)
+        g.connect_by_name(power_domains,        cts)
+        g.connect_by_name(power_domains,        postcts_hold)
+        g.connect_by_name(power_domains,        route)
+        g.connect_by_name(power_domains,        postroute)
+        g.connect_by_name(power_domains,        signoff)
+        g.connect_by_name(adk,                  pwr_aware_gls)
+        g.connect_by_name(signoff,              pwr_aware_gls)
         #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
 
     # New 'custom_cts' step added for gf12
     if want_custom_cts:
-        cts.extend_inputs( custom_cts.all_outputs() )
-        g.add_step(        custom_cts               )
-        g.connect_by_name( custom_cts,   cts        )
+        cts.extend_inputs(custom_cts.all_outputs())
+        g.add_step(custom_cts)
+        g.connect_by_name(custom_cts,   cts)
 
     # New 'drc_pm' step, added for gf12
     if want_drc_pm:
-        g.add_step( drc_pm )
-        g.connect_by_name( adk,           drc_pm         )
-        g.connect_by_name( signoff,       drc_pm         )
+        g.add_step(drc_pm)
+        g.connect_by_name(adk,           drc_pm)
+        g.connect_by_name(signoff,       drc_pm)
         g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
-        g.connect_by_name( drc_pm,        debugcalibre   )
+        g.connect_by_name(drc_pm,        debugcalibre)
 
-    g.connect_by_name( iflow,    genlibdb       )
+    g.connect_by_name(iflow,    genlibdb)
 
     #-----------------------------------------------------------------------
     # Parameterize
     #-----------------------------------------------------------------------
 
-    g.update_params( parameters )
+    g.update_params(parameters)
 
     # Add custom timing scripts
 
     for c_step in custom_timing_steps:
-        order = c_step.get_param( 'order' )
-        order.append( 'report-special-timing.tcl' )
-        c_step.set_param( 'order', order )
-        c_step.extend_postconditions( [{ 'pytest': 'inputs/test_timing.py' }] )
+        order = c_step.get_param('order')
+        order.append('report-special-timing.tcl')
+        c_step.set_param('order', order)
+        c_step.extend_postconditions([{'pytest': 'inputs/test_timing.py'}])
 
     # Update PWR_AWARE variable
-    synth.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-    init.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
-    power.update_params( { 'PWR_AWARE': parameters['PWR_AWARE'] }, True )
+    synth.update_params({'PWR_AWARE': parameters['PWR_AWARE']}, True)
+    init.update_params({'PWR_AWARE': parameters['PWR_AWARE']}, True)
+    power.update_params({'PWR_AWARE': parameters['PWR_AWARE']}, True)
 
     if pwr_aware:
-        init.update_params( { 'flatten_effort': parameters['flatten_effort'] }, True )
-        pwr_aware_gls.update_params( { 'design_name': parameters['design_name'] }, True )
+        init.update_params({'flatten_effort': parameters['flatten_effort']}, True)
+        pwr_aware_gls.update_params({'design_name': parameters['design_name']}, True)
 
-        init.extend_postconditions(         ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        place.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        cts.extend_postconditions(          ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        postcts_hold.extend_postconditions( ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        route.extend_postconditions(        ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        postroute.extend_postconditions(    ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
-        signoff.extend_postconditions(      ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"] )
+        ASS = ["assert 'Clamping logic structure in the SBs and CBs is maintained' in File( 'mflowgen-run.log' )"]
+        init.extend_postconditions(ASS)
+        place.extend_postconditions(ASS)
+        cts.extend_postconditions(ASS)
+        postcts_hold.extend_postconditions(ASS)
+        route.extend_postconditions(ASS)
+        postroute.extend_postconditions(ASS)
+        signoff.extend_postconditions(ASS)
     # Since we are adding an additional input script to the generic Innovus
     # steps, we modify the order parameter for that node which determines
     # which scripts get run and when they get run.
 
-    init.update_params( { 'core_density_target': parameters['core_density_target'] }, True )
+    init.update_params({'core_density_target': parameters['core_density_target']}, True)
     # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
     # and 'additional-path-groups' after 'make_path_groups'
 
     order = init.get_param('order') # get the default script run order
-    path_group_idx = order.index( 'make-path-groups.tcl' )
-    order.insert( path_group_idx + 1, 'additional-path-groups.tcl' )
-    pin_idx = order.index( 'pin-assignments.tcl' ) # find pin-assignments.tcl
-    order.insert( pin_idx + 1, 'edge-blockages.tcl' ) # add here
-    init.update_params( { 'order': order } )
+    path_group_idx = order.index('make-path-groups.tcl')
+    order.insert(path_group_idx + 1, 'additional-path-groups.tcl')
+    pin_idx = order.index('pin-assignments.tcl') # find pin-assignments.tcl
+    order.insert(pin_idx + 1, 'edge-blockages.tcl') # add here
+    init.update_params({'order': order})
 
     # Adding new input for genlibdb node to run
 
     # No longer conditional---amber and onyx now use same genlib mechanism
     order = genlibdb.get_param('order') # get the default script run order
-    extraction_idx = order.index( 'extract_model.tcl' ) # find extract_model.tcl
-    order.insert( extraction_idx, 'genlibdb-constraints.tcl' ) # add here
-    genlibdb.update_params( { 'order': order } )
+    extraction_idx = order.index('extract_model.tcl') # find extract_model.tcl
+    order.insert(extraction_idx, 'genlibdb-constraints.tcl') # add here
+    genlibdb.update_params({'order': order})
 
     # genlibdb -- Remove 'report-interface-timing.tcl' beacuse it takes
     # very long and is not necessary
     order = genlibdb.get_param('order')
-    order.remove( 'write-interface-timing.tcl' )
-    genlibdb.update_params( { 'order': order } )
+    order.remove('write-interface-timing.tcl')
+    genlibdb.update_params({'order': order})
 
     # Pwr aware steps:
     if pwr_aware:
         # init node
         order = init.get_param('order')
-        read_idx = order.index( 'floorplan.tcl' ) # find floorplan.tcl
+        read_idx = order.index('floorplan.tcl') # find floorplan.tcl
 
         # 09/2022 reordered to load params (pe-pd-params) before using params (pe-load-upf)
-        order.insert( read_idx + 1, 'pe-pd-params.tcl' ) # add here
-        order.insert( read_idx + 2, 'pe-load-upf.tcl' ) # add here
-        order.insert( read_idx + 3, 'pd-aon-floorplan.tcl' ) # add here
-        order.insert( read_idx + 4, 'add-endcaps-welltaps-setup.tcl' ) # add here
-        order.insert( read_idx + 5, 'pd-add-endcaps-welltaps.tcl' ) # add here
-        order.insert( read_idx + 6, 'add-power-switches.tcl' ) # add here
+        order.insert(read_idx + 1, 'pe-pd-params.tcl') # add here
+        order.insert(read_idx + 2, 'pe-load-upf.tcl') # add here
+        order.insert(read_idx + 3, 'pd-aon-floorplan.tcl') # add here
+        order.insert(read_idx + 4, 'add-endcaps-welltaps-setup.tcl') # add here
+        order.insert(read_idx + 5, 'pd-add-endcaps-welltaps.tcl') # add here
+        order.insert(read_idx + 6, 'add-power-switches.tcl') # add here
         order.remove('add-endcaps-welltaps.tcl')
         order.append('check-clamp-logic-structure.tcl')
-        init.update_params( { 'order': order } )
+        init.update_params({'order': order})
 
         # synth node (needs parm 'adk_allow_sdf_regs')
         order = synth.get_param('order')
-        order.insert( 0, 'pe-pd-params.tcl' )        # add params file
-        synth.update_params( { 'order': order } )
+        order.insert(0, 'pe-pd-params.tcl')        # add params file
+        synth.update_params({'order': order})
 
         # power node
         order = power.get_param('order')
-        order.insert( 0, 'pd-globalnetconnect.tcl' ) # add new 'pd-globalnetconnect'
+        order.insert(0, 'pd-globalnetconnect.tcl') # add new 'pd-globalnetconnect'
         order.remove('globalnetconnect.tcl')         # remove old 'globalnetconnect'
-        order.insert( 0, 'pe-pd-params.tcl' )        # add params file
-        power.update_params( { 'order': order } )
+        order.insert(0, 'pe-pd-params.tcl')        # add params file
+        power.update_params({'order': order})
 
         # place node
         order = place.get_param('order')
-        read_idx = order.index( 'main.tcl' ) # find main.tcl
+        read_idx = order.index('main.tcl') # find main.tcl
         order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
         order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
         order.append('check-clamp-logic-structure.tcl')
-        place.update_params( { 'order': order } )
+        place.update_params({'order': order})
 
         # cts node
         order = cts.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        cts.update_params( { 'order': order } )
+        cts.update_params({'order': order})
 
         # postcts_hold node
         order = postcts_hold.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        postcts_hold.update_params( { 'order': order } )
+        postcts_hold.update_params({'order': order})
 
         # route node
         order = route.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        route.update_params( { 'order': order } )
+        route.update_params({'order': order})
 
         # postroute node
         order = postroute.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
         order.append('check-clamp-logic-structure.tcl')
-        postroute.update_params( { 'order': order } )
+        postroute.update_params({'order': order})
 
         # Add fix-shorts as the last thing to do in postroute
         order = postroute.get_param('order') ; # get the default script run order
-        order.append('fix-shorts.tcl' )      ; # Add fix-shorts at the end
-        postroute.update_params( { 'order': order } ) ; # Update
+        order.append('fix-shorts.tcl')      ; # Add fix-shorts at the end
+        postroute.update_params({'order': order}) ; # Update
 
         # signoff node
         order = signoff.get_param('order')
-        order.insert( 0, 'conn-aon-cells-vdd.tcl' ) # add here
-        read_idx = order.index( 'generate-results.tcl' ) # find generate_results.tcl
+        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
+        read_idx = order.index('generate-results.tcl') # find generate_results.tcl
         order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
         order.append('check-clamp-logic-structure.tcl')
-        signoff.update_params( { 'order': order } )
+        signoff.update_params({'order': order})
 
     return g
 

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
-#=========================================================================
+# =========================================================================
 # construct.py
-#=========================================================================
+# =========================================================================
 # Author :
 # Date   :
 
@@ -10,13 +10,14 @@ from mflowgen.components import Graph, Step
 from shutil import which
 from common.get_sys_adk import get_sys_adk
 
+
 def construct():
 
     g = Graph()
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Parameters
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     adk_name = get_sys_adk()  # E.g. 'gf12-adk' or 'tsmc16'
     adk_view = 'multivt'
@@ -36,14 +37,14 @@ def construct():
     if synth_power:
         pwr_aware = False
 
-    want_drc_pm      = True
-    want_custom_cts  = True
+    want_drc_pm = True
+    want_custom_cts = True
 
     # TSMC override(s)
     if adk_name == 'tsmc16':
-        adk_view         = 'multicorner-multivt'
-        want_drc_pm      = False
-        want_custom_cts  = False
+        adk_view = 'multicorner-multivt'
+        want_drc_pm = False
+        want_custom_cts = False
 
     if adk_name == 'tsmc16':
         read_hdl_defines = 'TSMC16'
@@ -53,47 +54,52 @@ def construct():
         read_hdl_defines = ''
 
     parameters = {
-      'construct_path'    : __file__,
-      'design_name'       : 'Tile_PE',
-      'clock_period'      : 1.1,
-      'adk'               : adk_name,
-      'adk_view'          : adk_view,
-      # Synthesis
-      'flatten_effort'    : flatten,
-      'topographical'     : True,
-      'read_hdl_defines'  : read_hdl_defines,
-      # RTL Generation
-      'interconnect_only' : False,
-      'rtl_docker_image'  : 'default', # Current default is 'stanfordaha/garnet:latest'
-      # Power Domains
-      'PWR_AWARE'         : pwr_aware,
-      'core_density_target': 0.6,
-      # Power analysis
-      "use_sdf"           : False, # uses sdf but not the way it is in xrun node
-      'app_to_run'        : 'tests/conv_3_3',
-      'saif_instance'     : 'testbench/dut',
-      'testbench_name'    : 'testbench',
-      'strip_path'        : 'testbench/dut',
-      'drc_env_setup'     : 'drcenv-block.sh'
-      }
+        'construct_path': __file__,
+        'design_name': 'Tile_PE',
+        'clock_period': 1.1,
+        'adk': adk_name,
+        'adk_view': adk_view,
+
+        # Synthesis
+        'flatten_effort': flatten,
+        'topographical': True,
+        'read_hdl_defines': read_hdl_defines,
+
+        # RTL Generation
+        'interconnect_only': False,
+        'rtl_docker_image': 'default',  # Current default is 'stanfordaha/garnet:latest'
+
+        # Power Domains
+        'PWR_AWARE': pwr_aware,
+        'core_density_target': 0.6,
+
+        # Power analysis
+        "use_sdf": False,  # uses sdf but not the way it is in xrun node
+        'app_to_run': 'tests/conv_3_3',
+        'saif_instance': 'testbench/dut',
+        'testbench_name': 'testbench',
+        'strip_path': 'testbench/dut',
+        'drc_env_setup': 'drcenv-block.sh'
+    }
     # TSMC overrides
-    if adk_name == 'tsmc16': parameters.update({
-      'interconnect_only'  : True,
-      'core_density_target': 0.63,
-    })
+    if adk_name == 'tsmc16':
+        parameters.update({
+            'interconnect_only': True,
+            'core_density_target': 0.63,
+        })
 
     # User-level option to change clock frequency
     # E.g. 'export clock_period_PE="4.0"' to target 250MHz
     # Optionally could restrict to bk only: if (os.getenv('USER') == "buildkite-agent")
-    cp=os.getenv('clock_period_PE')
+    cp = os.getenv('clock_period_PE')
     if (cp != None):
         print("@file_info: WARNING found env var 'clock_period_PE'")
         print("@file_info: WARNING setting PE clock period to '%s'" % cp)
-        parameters['clock_period'] = cp;
+        parameters['clock_period'] = cp
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Create nodes
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     this_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -103,37 +109,39 @@ def construct():
     adk = g.get_adk_step()
 
     # Custom steps
+    def custom_step(path):
+        return Step(this_dir + path)
 
-    rtl                  = Step(this_dir + '/../common/rtl')
-    constraints          = Step(this_dir + '/constraints')
-    custom_init          = Step(this_dir + '/custom-init')
-    custom_genus_scripts = Step(this_dir + '/custom-genus-scripts')
-    custom_flowgen_setup = Step(this_dir + '/custom-flowgen-setup')
+    rtl = custom_step('/../common/rtl')
+    constraints = custom_step('/constraints')
+    custom_init = custom_step('/custom-init')
+    custom_genus_scripts = custom_step('/custom-genus-scripts')
+    custom_flowgen_setup = custom_step('/custom-flowgen-setup')
     if adk_name == 'tsmc16':
-        custom_power         = Step(this_dir + '/../common/custom-power-leaf-amber')
+        custom_power = custom_step('/../common/custom-power-leaf-amber')
     else:
-        custom_power         = Step(this_dir + '/../common/custom-power-leaf')
+        custom_power = custom_step('/../common/custom-power-leaf')
     if want_custom_cts:
-        custom_cts           = Step(this_dir + '/custom-cts')
-    short_fix            = Step(this_dir + '/../common/custom-short-fix')
-    genlibdb_constraints = Step(this_dir + '/../common/custom-genlibdb-constraints')
-    custom_timing_assert = Step(this_dir + '/../common/custom-timing-assert')
-    custom_dc_scripts    = Step(this_dir + '/custom-dc-scripts')
-    testbench            = Step(this_dir + '/../common/testbench')
-    application          = Step(this_dir + '/../common/application')
-    lib2db               = Step(this_dir + '/../common/synopsys-dc-lib2db')
+        custom_cts = custom_step('/custom-cts')
+    short_fix = custom_step('/../common/custom-short-fix')
+    genlibdb_constraints = custom_step('/../common/custom-genlibdb-constraints')
+    custom_timing_assert = custom_step('/../common/custom-timing-assert')
+    custom_dc_scripts = custom_step('/custom-dc-scripts')
+    testbench = custom_step('/../common/testbench')
+    application = custom_step('/../common/application')
+    lib2db = custom_step('/../common/synopsys-dc-lib2db')
     if want_drc_pm:
-        drc_pm               = Step(this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
+        drc_pm = custom_step('/../common/gf-mentor-calibre-drcplus-pm')
     if synth_power:
-        post_synth_power     = Step(this_dir + '/../common/tile-post-synth-power')
-    post_pnr_power       = Step(this_dir + '/../common/tile-post-pnr-power')
+        post_synth_power = custom_step('/../common/tile-post-synth-power')
+    post_pnr_power = custom_step('/../common/tile-post-pnr-power')
 
     # Power aware setup
     power_domains = None
     pwr_aware_gls = None
     if pwr_aware:
-        power_domains = Step(this_dir + '/../common/power-domains')
-        pwr_aware_gls = Step(this_dir + '/../common/pwr-aware-gls')
+        power_domains = custom_step('/../common/power-domains')
+        pwr_aware_gls = custom_step('/../common/pwr-aware-gls')
 
     # Default steps - turn off formatting b/c want these columns to line up
     # autopep8: off
@@ -161,7 +169,7 @@ def construct():
     debugcalibre = Step('cadence-innovus-debug-calibre', default=True)
 
     # Add custom timing scripts
-    custom_timing_steps = [synth, postcts_hold, signoff] # connects to these
+    custom_timing_steps = [synth, postcts_hold, signoff]  # connects to these
     for c_step in custom_timing_steps:
         c_step.extend_inputs(custom_timing_assert.all_outputs())
 
@@ -173,7 +181,10 @@ def construct():
     iflow.extend_inputs(custom_flowgen_setup.all_outputs())
 
     # Extra input to DC for constraints
-    synth.extend_inputs(["common.tcl", "reporting.tcl", "generate-results.tcl", "scenarios.tcl", "report_alu.py", "parse_alu.py"])
+    synth.extend_inputs([
+        "common.tcl", "reporting.tcl", "generate-results.tcl",
+        "scenarios.tcl", "report_alu.py", "parse_alu.py"])
+
     # Extra outputs from DC
     synth.extend_outputs(["sdc"])
     iflow.extend_inputs(["scenarios.tcl", "sdc"])
@@ -191,19 +202,26 @@ def construct():
 
         # Need pe-pd-params so adk.tcl can access parm 'adk_allow_sdf_regs'
         # (pe-pd-params come from already-connected 'power-domains' node)
-        synth.extend_inputs([
-          'pe-pd-params.tcl',
-          'designer-interface.tcl', 
-          'upf_Tile_PE.tcl', 
-          'pe-constraints.tcl', 
-          'pe-constraints-2.tcl', 
-          'dc-dont-use-constraints.tcl'])
+        synth.extend_inputs(['pe-pd-params.tcl',
+                             'designer-interface.tcl',
+                             'upf_Tile_PE.tcl',
+                             'pe-constraints.tcl',
+                             'pe-constraints-2.tcl',
+                             'dc-dont-use-constraints.tcl'])
 
         # Eventually want to extend this to GF as well...!
         if adk_name == 'tsmc16':
             synth.extend_inputs(['check-pdcr-address.sh'])
 
-        init.extend_inputs(['upf_Tile_PE.tcl', 'pe-load-upf.tcl', 'dont-touch-constraints.tcl', 'pe-pd-params.tcl', 'pd-aon-floorplan.tcl', 'add-endcaps-welltaps-setup.tcl', 'pd-add-endcaps-welltaps.tcl', 'add-power-switches.tcl', 'check-clamp-logic-structure.tcl'])
+        init.extend_inputs(['upf_Tile_PE.tcl',
+                            'pe-load-upf.tcl',
+                            'dont-touch-constraints.tcl',
+                            'pe-pd-params.tcl',
+                            'pd-aon-floorplan.tcl',
+                            'add-endcaps-welltaps-setup.tcl',
+                            'pd-add-endcaps-welltaps.tcl',
+                            'add-power-switches.tcl',
+                            'check-clamp-logic-structure.tcl'])
 
         # Eventually want to extend this to GF as well...!
         if adk_name == 'tsmc16':
@@ -213,12 +231,16 @@ def construct():
         # pd-globalnetconnect, pe-pd-params come from 'power-domains' node
         power.extend_inputs(['pd-globalnetconnect.tcl', 'pe-pd-params.tcl'])
 
-        place.extend_inputs(['place-dont-use-constraints.tcl', 'check-clamp-logic-structure.tcl', 'add-aon-tie-cells.tcl'])
+        place.extend_inputs(['place-dont-use-constraints.tcl',
+                             'check-clamp-logic-structure.tcl',
+                             'add-aon-tie-cells.tcl'])
         cts.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
         postcts_hold.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
         route.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
         postroute.extend_inputs(['conn-aon-cells-vdd.tcl', 'check-clamp-logic-structure.tcl'])
-        signoff.extend_inputs(['conn-aon-cells-vdd.tcl', 'pd-generate-lvs-netlist.tcl', 'check-clamp-logic-structure.tcl'])
+        signoff.extend_inputs(['conn-aon-cells-vdd.tcl',
+                               'pd-generate-lvs-netlist.tcl',
+                               'check-clamp-logic-structure.tcl'])
         pwr_aware_gls.extend_inputs(['design.vcs.pg.v'])
 
         # Eventually want to extend this to GF as well...!
@@ -256,9 +278,9 @@ def construct():
     if adk_name == "tsmc16":
         streamout_no_uniquify(iflow)
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Graph -- Add nodes
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     g.add_step(info)
     g.add_step(rtl)
@@ -299,9 +321,9 @@ def construct():
         g.add_step(power_domains)
         g.add_step(pwr_aware_gls)
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Graph -- Add edges
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     # Dynamically add edges
 
@@ -405,7 +427,7 @@ def construct():
         g.connect_by_name(power_domains, signoff)
         g.connect_by_name(adk, pwr_aware_gls)
         g.connect_by_name(signoff, pwr_aware_gls)
-        #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
+        # g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
 
     # New 'custom_cts' step added for gf12
     if want_custom_cts:
@@ -423,9 +445,9 @@ def construct():
 
     g.connect_by_name(iflow, genlibdb)
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Parameterize
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     g.update_params(parameters)
 
@@ -462,19 +484,19 @@ def construct():
     # init -- Add 'edge-blockages.tcl' after 'pin-assignments.tcl'
     # and 'additional-path-groups' after 'make_path_groups'
 
-    order = init.get_param('order') # get the default script run order
+    order = init.get_param('order')  # get the default script run order
     path_group_idx = order.index('make-path-groups.tcl')
     order.insert(path_group_idx + 1, 'additional-path-groups.tcl')
-    pin_idx = order.index('pin-assignments.tcl') # find pin-assignments.tcl
-    order.insert(pin_idx + 1, 'edge-blockages.tcl') # add here
+    pin_idx = order.index('pin-assignments.tcl')  # find pin-assignments.tcl
+    order.insert(pin_idx + 1, 'edge-blockages.tcl')  # add here
     init.update_params({'order': order})
 
     # Adding new input for genlibdb node to run
 
     # No longer conditional---amber and onyx now use same genlib mechanism
-    order = genlibdb.get_param('order') # get the default script run order
-    extraction_idx = order.index('extract_model.tcl') # find extract_model.tcl
-    order.insert(extraction_idx, 'genlibdb-constraints.tcl') # add here
+    order = genlibdb.get_param('order')  # get the default script run order
+    extraction_idx = order.index('extract_model.tcl')  # find extract_model.tcl
+    order.insert(extraction_idx, 'genlibdb-constraints.tcl')  # add here
     genlibdb.update_params({'order': order})
 
     # genlibdb -- Remove 'report-interface-timing.tcl' beacuse it takes
@@ -487,15 +509,15 @@ def construct():
     if pwr_aware:
         # init node
         order = init.get_param('order')
-        read_idx = order.index('floorplan.tcl') # find floorplan.tcl
+        read_idx = order.index('floorplan.tcl')  # find floorplan.tcl
 
         # 09/2022 reordered to load params (pe-pd-params) before using params (pe-load-upf)
-        order.insert(read_idx + 1, 'pe-pd-params.tcl') # add here
-        order.insert(read_idx + 2, 'pe-load-upf.tcl') # add here
-        order.insert(read_idx + 3, 'pd-aon-floorplan.tcl') # add here
-        order.insert(read_idx + 4, 'add-endcaps-welltaps-setup.tcl') # add here
-        order.insert(read_idx + 5, 'pd-add-endcaps-welltaps.tcl') # add here
-        order.insert(read_idx + 6, 'add-power-switches.tcl') # add here
+        order.insert(read_idx + 1, 'pe-pd-params.tcl')                # add here
+        order.insert(read_idx + 2, 'pe-load-upf.tcl')                 # add here
+        order.insert(read_idx + 3, 'pd-aon-floorplan.tcl')            # add here
+        order.insert(read_idx + 4, 'add-endcaps-welltaps-setup.tcl')  # add here
+        order.insert(read_idx + 5, 'pd-add-endcaps-welltaps.tcl')     # add here
+        order.insert(read_idx + 6, 'add-power-switches.tcl')          # add here
         order.remove('add-endcaps-welltaps.tcl')
         order.append('check-clamp-logic-structure.tcl')
         init.update_params({'order': order})
@@ -507,14 +529,14 @@ def construct():
 
         # power node
         order = power.get_param('order')
-        order.insert(0, 'pd-globalnetconnect.tcl') # add new 'pd-globalnetconnect'
-        order.remove('globalnetconnect.tcl')         # remove old 'globalnetconnect'
-        order.insert(0, 'pe-pd-params.tcl')        # add params file
+        order.insert(0, 'pd-globalnetconnect.tcl')  # add new 'pd-globalnetconnect'
+        order.remove('globalnetconnect.tcl')        # remove old 'globalnetconnect'
+        order.insert(0, 'pe-pd-params.tcl')         # add params file
         power.update_params({'order': order})
 
         # place node
         order = place.get_param('order')
-        read_idx = order.index('main.tcl') # find main.tcl
+        read_idx = order.index('main.tcl')  # find main.tcl
         order.insert(read_idx + 1, 'add-aon-tie-cells.tcl')
         order.insert(read_idx - 1, 'place-dont-use-constraints.tcl')
         order.append('check-clamp-logic-structure.tcl')
@@ -522,42 +544,43 @@ def construct():
 
         # cts node
         order = cts.get_param('order')
-        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl')  # add here
         order.append('check-clamp-logic-structure.tcl')
         cts.update_params({'order': order})
 
         # postcts_hold node
         order = postcts_hold.get_param('order')
-        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl')  # add here
         order.append('check-clamp-logic-structure.tcl')
         postcts_hold.update_params({'order': order})
 
         # route node
         order = route.get_param('order')
-        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl')  # add here
         order.append('check-clamp-logic-structure.tcl')
         route.update_params({'order': order})
 
         # postroute node
         order = postroute.get_param('order')
-        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
+        order.insert(0, 'conn-aon-cells-vdd.tcl')  # add here
         order.append('check-clamp-logic-structure.tcl')
         postroute.update_params({'order': order})
 
         # Add fix-shorts as the last thing to do in postroute
-        order = postroute.get_param('order') ; # get the default script run order
-        order.append('fix-shorts.tcl')      ; # Add fix-shorts at the end
-        postroute.update_params({'order': order}) ; # Update
+        order = postroute.get_param('order')       # get the default script run order
+        order.append('fix-shorts.tcl')             # Add fix-shorts at the end
+        postroute.update_params({'order': order})  # Update
 
         # signoff node
         order = signoff.get_param('order')
-        order.insert(0, 'conn-aon-cells-vdd.tcl') # add here
-        read_idx = order.index('generate-results.tcl') # find generate_results.tcl
+        order.insert(0, 'conn-aon-cells-vdd.tcl')  # add here
+        read_idx = order.index('generate-results.tcl')  # find generate_results.tcl
         order.insert(read_idx + 1, 'pd-generate-lvs-netlist.tcl')
         order.append('check-clamp-logic-structure.tcl')
         signoff.update_params({'order': order})
 
     return g
+
 
 if __name__ == '__main__':
     g = construct()

--- a/mflowgen/Tile_PE/construct.py
+++ b/mflowgen/Tile_PE/construct.py
@@ -135,27 +135,29 @@ def construct():
         power_domains = Step(this_dir + '/../common/power-domains')
         pwr_aware_gls = Step(this_dir + '/../common/pwr-aware-gls')
 
-    # Default steps
-    info         = Step('info',                          default=True)
-    synth        = Step('cadence-genus-synthesis',       default=True)
-    iflow        = Step('cadence-innovus-flowsetup',     default=True)
-    init         = Step('cadence-innovus-init',          default=True)
-    power        = Step('cadence-innovus-power',         default=True)
-    place        = Step('cadence-innovus-place',         default=True)
-    cts          = Step('cadence-innovus-cts',           default=True)
-    postcts_hold = Step('cadence-innovus-postcts_hold',  default=True)
-    route        = Step('cadence-innovus-route',         default=True)
-    postroute    = Step('cadence-innovus-postroute',     default=True)
-    signoff      = Step('cadence-innovus-signoff',       default=True)
-    pt_signoff   = Step('synopsys-pt-timing-signoff',    default=True)
-    genlibdb     = Step('synopsys-ptpx-genlibdb',        default=True)
+    # Default steps - turn off formatting b/c want these columns to line up
+    # autopep8: off
+    info         = Step('info',                          default=True)  # noqa
+    synth        = Step('cadence-genus-synthesis',       default=True)  # noqa
+    iflow        = Step('cadence-innovus-flowsetup',     default=True)  # noqa
+    init         = Step('cadence-innovus-init',          default=True)  # noqa
+    power        = Step('cadence-innovus-power',         default=True)  # noqa
+    place        = Step('cadence-innovus-place',         default=True)  # noqa
+    cts          = Step('cadence-innovus-cts',           default=True)  # noqa
+    postcts_hold = Step('cadence-innovus-postcts_hold',  default=True)  # noqa
+    route        = Step('cadence-innovus-route',         default=True)  # noqa
+    postroute    = Step('cadence-innovus-postroute',     default=True)  # noqa
+    signoff      = Step('cadence-innovus-signoff',       default=True)  # noqa
+    pt_signoff   = Step('synopsys-pt-timing-signoff',    default=True)  # noqa
+    genlibdb     = Step('synopsys-ptpx-genlibdb',        default=True)  # noqa
+    # autopep8: on
 
     if which("calibre") is not None:
-        drc          = Step('mentor-calibre-drc',            default=True)
-        lvs          = Step('mentor-calibre-lvs',            default=True)
+        drc = Step('mentor-calibre-drc', default=True)
+        lvs = Step('mentor-calibre-lvs', default=True)
     else:
-        drc          = Step('cadence-pegasus-drc',           default=True)
-        lvs          = Step('cadence-pegasus-lvs',           default=True)
+        drc = Step('cadence-pegasus-drc', default=True)
+        lvs = Step('cadence-pegasus-lvs', default=True)
     debugcalibre = Step('cadence-innovus-debug-calibre', default=True)
 
     # Add custom timing scripts
@@ -234,22 +236,25 @@ def construct():
     # Inputs
     g.add_input('design.v', rtl.i('design.v'))
 
-    # Outputs
-    g.add_output('Tile_PE_tt.lib',      genlibdb.o('design.lib'))
-    g.add_output('Tile_PE_tt.db',       genlibdb.o('design.db'))
-    g.add_output('Tile_PE.lef',         signoff.o('design.lef'))
-    g.add_output('Tile_PE.gds',         signoff.o('design-merged.gds'))
-    g.add_output('Tile_PE.sdf',         signoff.o('design.sdf'))
-    g.add_output('Tile_PE.vcs.v',       signoff.o('design.vcs.v'))
-    g.add_output('Tile_PE.vcs.pg.v',    signoff.o('design.vcs.pg.v'))
-    g.add_output('Tile_PE.spef.gz',     signoff.o('design.spef.gz'))
-    g.add_output('Tile_PE.pt.sdc',      signoff.o('design.pt.sdc'))
-    g.add_output('Tile_PE.lvs.v',       lvs.o('design_merged.lvs.v'))
+    # Outputs - turn off formatting b/c want these columns to line up
+    # autopep8: off
+    g.add_output('Tile_PE_tt.lib',      genlibdb.o('design.lib')       )  # noqa
+    g.add_output('Tile_PE_tt.db',       genlibdb.o('design.db')        )  # noqa
+    g.add_output('Tile_PE.lef',         signoff.o('design.lef')        )  # noqa
+    g.add_output('Tile_PE.gds',         signoff.o('design-merged.gds') )  # noqa
+    g.add_output('Tile_PE.sdf',         signoff.o('design.sdf')        )  # noqa
+    g.add_output('Tile_PE.vcs.v',       signoff.o('design.vcs.v')      )  # noqa
+    g.add_output('Tile_PE.vcs.pg.v',    signoff.o('design.vcs.pg.v')   )  # noqa
+    g.add_output('Tile_PE.spef.gz',     signoff.o('design.spef.gz')    )  # noqa
+    g.add_output('Tile_PE.pt.sdc',      signoff.o('design.pt.sdc')     )  # noqa
+    g.add_output('Tile_PE.lvs.v',       lvs.o('design_merged.lvs.v')   )  # noqa
+    # autopep8: on
 
     # TSMC needs streamout *without* the (new) default -uniquify flag
     # This python method finds 'stream-out.tcl' and strips out that flag.
     from common.streamout_no_uniquify import streamout_no_uniquify
-    if adk_name == "tsmc16": streamout_no_uniquify(iflow)
+    if adk_name == "tsmc16":
+        streamout_no_uniquify(iflow)
 
     #-----------------------------------------------------------------------
     # Graph -- Add nodes
@@ -302,20 +307,20 @@ def construct():
 
     # Connect by name
 
-    g.connect_by_name(adk,      synth)
-    g.connect_by_name(adk,      iflow)
-    g.connect_by_name(adk,      init)
-    g.connect_by_name(adk,      power)
-    g.connect_by_name(adk,      place)
-    g.connect_by_name(adk,      cts)
-    g.connect_by_name(adk,      postcts_hold)
-    g.connect_by_name(adk,      route)
-    g.connect_by_name(adk,      postroute)
-    g.connect_by_name(adk,      signoff)
-    g.connect_by_name(adk,      drc)
-    g.connect_by_name(adk,      lvs)
+    g.connect_by_name(adk, synth)
+    g.connect_by_name(adk, iflow)
+    g.connect_by_name(adk, init)
+    g.connect_by_name(adk, power)
+    g.connect_by_name(adk, place)
+    g.connect_by_name(adk, cts)
+    g.connect_by_name(adk, postcts_hold)
+    g.connect_by_name(adk, route)
+    g.connect_by_name(adk, postroute)
+    g.connect_by_name(adk, signoff)
+    g.connect_by_name(adk, drc)
+    g.connect_by_name(adk, lvs)
 
-    g.connect_by_name(rtl,         synth)
+    g.connect_by_name(rtl, synth)
     g.connect_by_name(constraints, synth)
     g.connect_by_name(custom_genus_scripts, synth)
     g.connect_by_name(constraints, iflow)
@@ -324,98 +329,99 @@ def construct():
     for c_step in custom_timing_steps:
         g.connect_by_name(custom_timing_assert, c_step)
 
-    g.connect_by_name(synth,       iflow)
-    g.connect_by_name(synth,       init)
-    g.connect_by_name(synth,       power)
-    g.connect_by_name(synth,       place)
-    g.connect_by_name(synth,       cts)
-    g.connect_by_name(synth,       custom_flowgen_setup)
+    g.connect_by_name(synth, iflow)
+    g.connect_by_name(synth, init)
+    g.connect_by_name(synth, power)
+    g.connect_by_name(synth, place)
+    g.connect_by_name(synth, cts)
+    g.connect_by_name(synth, custom_flowgen_setup)
 
     g.connect_by_name(custom_flowgen_setup, iflow)
-    g.connect_by_name(iflow,    init)
-    g.connect_by_name(iflow,    power)
-    g.connect_by_name(iflow,    place)
-    g.connect_by_name(iflow,    cts)
-    g.connect_by_name(iflow,    postcts_hold)
-    g.connect_by_name(iflow,    route)
-    g.connect_by_name(iflow,    postroute)
-    g.connect_by_name(iflow,    signoff)
+    g.connect_by_name(iflow, init)
+    g.connect_by_name(iflow, power)
+    g.connect_by_name(iflow, place)
+    g.connect_by_name(iflow, cts)
+    g.connect_by_name(iflow, postcts_hold)
+    g.connect_by_name(iflow, route)
+    g.connect_by_name(iflow, postroute)
+    g.connect_by_name(iflow, signoff)
 
-    g.connect_by_name(custom_init,  init)
+    g.connect_by_name(custom_init, init)
     g.connect_by_name(custom_power, power)
 
     # Fetch short-fix script in prep for eventual use by postroute
     g.connect_by_name(short_fix, postroute)
 
-    g.connect_by_name(init,         power)
-    g.connect_by_name(power,        place)
-    g.connect_by_name(place,        cts)
-    g.connect_by_name(cts,          postcts_hold)
+    g.connect_by_name(init, power)
+    g.connect_by_name(power, place)
+    g.connect_by_name(place, cts)
+    g.connect_by_name(cts, postcts_hold)
     g.connect_by_name(postcts_hold, route)
-    g.connect_by_name(route,        postroute)
-    g.connect_by_name(postroute,    signoff)
+    g.connect_by_name(route, postroute)
+    g.connect_by_name(postroute, signoff)
 
-    g.connect_by_name(signoff,      drc)
-    g.connect_by_name(signoff,      lvs)
+    g.connect_by_name(signoff, drc)
+    g.connect_by_name(signoff, lvs)
     g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
     g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
-    g.connect_by_name(signoff,              genlibdb)
-    g.connect_by_name(adk,                  genlibdb)
+    g.connect_by_name(signoff, genlibdb)
+    g.connect_by_name(adk, genlibdb)
     g.connect_by_name(genlibdb_constraints, genlibdb)
 
-    g.connect_by_name(genlibdb,             lib2db)
+    g.connect_by_name(genlibdb, lib2db)
 
-    g.connect_by_name(adk,          pt_signoff)
-    g.connect_by_name(signoff,      pt_signoff)
+    g.connect_by_name(adk, pt_signoff)
+    g.connect_by_name(signoff, pt_signoff)
 
     g.connect_by_name(application, testbench)
     if synth_power:
         g.connect_by_name(application, post_synth_power)
-        g.connect_by_name(synth,       post_synth_power)
-        g.connect_by_name(testbench,   post_synth_power)
-    g.connect_by_name(application, post_pnr_power)
-    g.connect_by_name(signoff,     post_pnr_power)
-    g.connect_by_name(pt_signoff,  post_pnr_power)
-    g.connect_by_name(testbench,   post_pnr_power)
+        g.connect_by_name(synth, post_synth_power)
+        g.connect_by_name(testbench, post_synth_power)
 
-    g.connect_by_name(adk,      debugcalibre)
-    g.connect_by_name(synth,    debugcalibre)
-    g.connect_by_name(iflow,    debugcalibre)
-    g.connect_by_name(signoff,  debugcalibre)
-    g.connect_by_name(drc,      debugcalibre)
-    g.connect_by_name(lvs,      debugcalibre)
+    g.connect_by_name(application, post_pnr_power)
+    g.connect_by_name(signoff, post_pnr_power)
+    g.connect_by_name(pt_signoff, post_pnr_power)
+    g.connect_by_name(testbench, post_pnr_power)
+
+    g.connect_by_name(adk, debugcalibre)
+    g.connect_by_name(synth, debugcalibre)
+    g.connect_by_name(iflow, debugcalibre)
+    g.connect_by_name(signoff, debugcalibre)
+    g.connect_by_name(drc, debugcalibre)
+    g.connect_by_name(lvs, debugcalibre)
 
     # Pwr aware steps:
     if pwr_aware:
-        g.connect_by_name(power_domains,        synth)
-        g.connect_by_name(power_domains,        init)
-        g.connect_by_name(power_domains,        power)
-        g.connect_by_name(power_domains,        place)
-        g.connect_by_name(power_domains,        cts)
-        g.connect_by_name(power_domains,        postcts_hold)
-        g.connect_by_name(power_domains,        route)
-        g.connect_by_name(power_domains,        postroute)
-        g.connect_by_name(power_domains,        signoff)
-        g.connect_by_name(adk,                  pwr_aware_gls)
-        g.connect_by_name(signoff,              pwr_aware_gls)
+        g.connect_by_name(power_domains, synth)
+        g.connect_by_name(power_domains, init)
+        g.connect_by_name(power_domains, power)
+        g.connect_by_name(power_domains, place)
+        g.connect_by_name(power_domains, cts)
+        g.connect_by_name(power_domains, postcts_hold)
+        g.connect_by_name(power_domains, route)
+        g.connect_by_name(power_domains, postroute)
+        g.connect_by_name(power_domains, signoff)
+        g.connect_by_name(adk, pwr_aware_gls)
+        g.connect_by_name(signoff, pwr_aware_gls)
         #g.connect(power_domains.o('pd-globalnetconnect.tcl'), power.i('globalnetconnect.tcl'))
 
     # New 'custom_cts' step added for gf12
     if want_custom_cts:
         cts.extend_inputs(custom_cts.all_outputs())
         g.add_step(custom_cts)
-        g.connect_by_name(custom_cts,   cts)
+        g.connect_by_name(custom_cts, cts)
 
     # New 'drc_pm' step, added for gf12
     if want_drc_pm:
         g.add_step(drc_pm)
-        g.connect_by_name(adk,           drc_pm)
-        g.connect_by_name(signoff,       drc_pm)
+        g.connect_by_name(adk, drc_pm)
+        g.connect_by_name(signoff, drc_pm)
         g.connect(signoff.o('design-merged.gds'), drc_pm.i('design_merged.gds'))
-        g.connect_by_name(drc_pm,        debugcalibre)
+        g.connect_by_name(drc_pm, debugcalibre)
 
-    g.connect_by_name(iflow,    genlibdb)
+    g.connect_by_name(iflow, genlibdb)
 
     #-----------------------------------------------------------------------
     # Parameterize

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -165,102 +165,102 @@ def construct():
     # Create nodes
     #-----------------------------------------------------------------------
 
-    this_dir = os.path.dirname( os.path.abspath( __file__))
+    this_dir = os.path.dirname(os.path.abspath(__file__))
 
     # ADK step
 
-    g.set_adk( adk_name)
+    g.set_adk(adk_name)
     adk = g.get_adk_step()
 
     # Custom steps
 
-    rtl            = Step( this_dir + '/../common/rtl')
-    soc_rtl        = Step( this_dir + '/../common/soc-rtl-v2')
+    rtl            = Step(this_dir + '/../common/rtl')
+    soc_rtl        = Step(this_dir + '/../common/soc-rtl-v2')
 
     if adk_name == "tsmc16":
-        gen_sram       = Step( this_dir + '/../common/gen_sram_macro_amber')
-        constraints    = Step( this_dir + '/constraints_amber')
+        gen_sram       = Step(this_dir + '/../common/gen_sram_macro_amber')
+        constraints    = Step(this_dir + '/constraints_amber')
     else:
-        gen_sram       = Step( this_dir + '/../common/gen_sram_macro')
-        constraints    = Step( this_dir + '/constraints')
+        gen_sram       = Step(this_dir + '/../common/gen_sram_macro')
+        constraints    = Step(this_dir + '/constraints')
 
-    read_design    = Step( this_dir + '/../common/fc-custom-read-design')
+    read_design    = Step(this_dir + '/../common/fc-custom-read-design')
     if adk_name == 'tsmc16':
-        custom_init          = Step( this_dir + '/custom-init-amber')
-        custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber')
-        custom_power         = Step( this_dir + '/../common/custom-power-chip-amber')
-        init_fc              = Step( this_dir + '/../common/init-fullchip-amber')
+        custom_init          = Step(this_dir + '/custom-init-amber')
+        custom_lvs           = Step(this_dir + '/custom-lvs-rules-amber')
+        custom_power         = Step(this_dir + '/../common/custom-power-chip-amber')
+        init_fc              = Step(this_dir + '/../common/init-fullchip-amber')
     else:
-        custom_init          = Step( this_dir + '/custom-init')
-        custom_lvs           = Step( this_dir + '/custom-lvs-rules')
-        custom_power         = Step( this_dir + '/../common/custom-power-chip')
-        custom_cts           = Step( this_dir + '/custom-cts')
-        init_fc              = Step( this_dir + '/../common/init-fullchip')
-    io_file        = Step( this_dir + '/io_file')
-    pre_route      = Step( this_dir + '/pre-route')
-    sealring       = Step( this_dir + '/sealring')
-    netlist_fixing = Step( this_dir + '/../common/fc-netlist-fixing')
+        custom_init          = Step(this_dir + '/custom-init')
+        custom_lvs           = Step(this_dir + '/custom-lvs-rules')
+        custom_power         = Step(this_dir + '/../common/custom-power-chip')
+        custom_cts           = Step(this_dir + '/custom-cts')
+        init_fc              = Step(this_dir + '/../common/init-fullchip')
+    io_file        = Step(this_dir + '/io_file')
+    pre_route      = Step(this_dir + '/pre-route')
+    sealring       = Step(this_dir + '/sealring')
+    netlist_fixing = Step(this_dir + '/../common/fc-netlist-fixing')
     if which_soc == 'onyx':
-        drc_pm         = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
-        drc_dp         = Step( this_dir + '/gf-drc-dp')
-        drc_mas        = Step( this_dir + '/../common/gf-mentor-calibre-drc-mas')
+        drc_pm         = Step(this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
+        drc_dp         = Step(this_dir + '/gf-drc-dp')
+        drc_mas        = Step(this_dir + '/../common/gf-mentor-calibre-drc-mas')
 
     # Block-level designs
 
-    tile_array        = Subgraph( this_dir + '/../tile_array',        'tile_array')
-    glb_top           = Subgraph( this_dir + '/../glb_top',           'glb_top')
-    global_controller = Subgraph( this_dir + '/../global_controller', 'global_controller')
+    tile_array        = Subgraph(this_dir + '/../tile_array',        'tile_array')
+    glb_top           = Subgraph(this_dir + '/../glb_top',           'glb_top')
+    global_controller = Subgraph(this_dir + '/../global_controller', 'global_controller')
 
     if which_soc == 'amber':
-        dragonphy         = Step( this_dir + '/dragonphy')
+        dragonphy         = Step(this_dir + '/dragonphy')
     elif which_soc == 'onyx':
-        xgcd              = Step( this_dir + '/xgcd')
+        xgcd              = Step(this_dir + '/xgcd')
 
     # CGRA simulation
 
-    cgra_rtl_sim_compile  = Step( this_dir + '/cgra_rtl_sim_compile')
-    cgra_rtl_sim_run      = Step( this_dir + '/cgra_rtl_sim_run')
-    cgra_sim_build        = Step( this_dir + '/cgra_sim_build')
-    # cgra_gl_sim_compile   = Step( this_dir + '/cgra_gl_sim_compile')
-    # cgra_gl_sim_run       = Step( this_dir + '/cgra_gl_sim_run')
-    # cgra_gl_ptpx          = Step( this_dir + '/cgra_gl_ptpx')
-    # cgra_rtl_sim_verdict  = Step( this_dir + '/cgra_rtl_sim_verdict')
-    # cgra_gl_sim_verdict   = Step( this_dir + '/cgra_gl_sim_verdict')
+    cgra_rtl_sim_compile  = Step(this_dir + '/cgra_rtl_sim_compile')
+    cgra_rtl_sim_run      = Step(this_dir + '/cgra_rtl_sim_run')
+    cgra_sim_build        = Step(this_dir + '/cgra_sim_build')
+    # cgra_gl_sim_compile   = Step(this_dir + '/cgra_gl_sim_compile')
+    # cgra_gl_sim_run       = Step(this_dir + '/cgra_gl_sim_run')
+    # cgra_gl_ptpx          = Step(this_dir + '/cgra_gl_ptpx')
+    # cgra_rtl_sim_verdict  = Step(this_dir + '/cgra_rtl_sim_verdict')
+    # cgra_gl_sim_verdict   = Step(this_dir + '/cgra_gl_sim_verdict')
 
     # Default steps
 
-    info           = Step( 'info',                          default=True)
-    #constraints   = Step( 'constraints',                   default=True)
-    synth          = Step( 'cadence-genus-synthesis',       default=True)
-    iflow          = Step( 'cadence-innovus-flowsetup',     default=True)
-    init           = Step( 'cadence-innovus-init',          default=True)
-    power          = Step( 'cadence-innovus-power',         default=True)
-    place          = Step( 'cadence-innovus-place',         default=True)
-    cts            = Step( 'cadence-innovus-cts',           default=True)
-    postcts_hold   = Step( 'cadence-innovus-postcts_hold',  default=True)
-    route          = Step( 'cadence-innovus-route',         default=True)
-    postroute      = Step( 'cadence-innovus-postroute',     default=True)
-    postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True)
-    signoff        = Step( 'cadence-innovus-signoff',       default=True)
-    pt_signoff     = Step( 'synopsys-pt-timing-signoff',    default=True)
+    info           = Step('info',                          default=True)
+    #constraints   = Step('constraints',                   default=True)
+    synth          = Step('cadence-genus-synthesis',       default=True)
+    iflow          = Step('cadence-innovus-flowsetup',     default=True)
+    init           = Step('cadence-innovus-init',          default=True)
+    power          = Step('cadence-innovus-power',         default=True)
+    place          = Step('cadence-innovus-place',         default=True)
+    cts            = Step('cadence-innovus-cts',           default=True)
+    postcts_hold   = Step('cadence-innovus-postcts_hold',  default=True)
+    route          = Step('cadence-innovus-route',         default=True)
+    postroute      = Step('cadence-innovus-postroute',     default=True)
+    postroute_hold = Step('cadence-innovus-postroute_hold', default=True)
+    signoff        = Step('cadence-innovus-signoff',       default=True)
+    pt_signoff     = Step('synopsys-pt-timing-signoff',    default=True)
 
     if which("calibre") is not None:
-        drc            = Step( 'mentor-calibre-drc',            default=True)
-        lvs            = Step( 'mentor-calibre-lvs',            default=True)
+        drc            = Step('mentor-calibre-drc',            default=True)
+        lvs            = Step('mentor-calibre-lvs',            default=True)
         # GF has a different way of running fill
         if adk_name == 'gf12-adk':
-            fill           = Step (this_dir + '/../common/mentor-calibre-fill-gf')
-            merge_gdr      = Step( 'mentor-calibre-gdsmerge-child',  default=True)
+            fill           = Step(this_dir + '/../common/mentor-calibre-fill-gf')
+            merge_gdr      = Step('mentor-calibre-gdsmerge-child',  default=True)
         else:
-            fill           = Step( 'mentor-calibre-fill',            default=True)
-            merge_rdl      = Step( 'mentor-calibre-gdsmerge-child',  default=True)
+            fill           = Step('mentor-calibre-fill',            default=True)
+            merge_rdl      = Step('mentor-calibre-gdsmerge-child',  default=True)
             merge_rdl.set_name('gdsmerge-dragonphy-rdl')
 
-        merge_fill     = Step( 'mentor-calibre-gdsmerge-child', default=True)
+        merge_fill     = Step('mentor-calibre-gdsmerge-child', default=True)
     else:
         assert False, 'Sorry! Removed cadence-pegasus option'
 
-    debugcalibre   = Step( 'cadence-innovus-debug-calibre', default=True)
+    debugcalibre   = Step('cadence-innovus-debug-calibre', default=True)
 
     merge_fill.set_name('gdsmerge-fill')
 
@@ -269,130 +269,130 @@ def construct():
     if which_soc == 'onyx':
         # Second sram_node because soc has 2 types of srams
         gen_sram_2 = gen_sram.clone()
-        gen_sram_2.set_name( 'gen_sram_macro_2')
+        gen_sram_2.set_name('gen_sram_macro_2')
 
     # 'power' step now gets its own design-rule check
     power_drc = drc.clone()
-    power_drc.set_name( 'power-drc')
+    power_drc.set_name('power-drc')
 
     # Antenna DRC Check
     antenna_drc = drc.clone()
-    antenna_drc.set_name( 'antenna-drc')
+    antenna_drc.set_name('antenna-drc')
 
     if which_soc == 'onyx':
         # Pre-Fill DRC Check
         prefill_drc = drc.clone()
-        prefill_drc.set_name( 'pre-fill-drc')
+        prefill_drc.set_name('pre-fill-drc')
 
         # Separate ADK for LVS so it has PM cells when needed
         lvs_adk = adk.clone()
-        lvs_adk.set_name( 'lvs_adk')
+        lvs_adk.set_name('lvs_adk')
 
     # Add cgra tile macro inputs to downstream nodes
 
-    synth.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'])
-    synth.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'])
-    synth.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'])
-    synth.extend_inputs( ['sram_tt.lib', 'sram.lef'])
+    synth.extend_inputs(['tile_array_tt.lib', 'tile_array.lef'])
+    synth.extend_inputs(['glb_top_tt.lib', 'glb_top.lef'])
+    synth.extend_inputs(['global_controller_tt.lib', 'global_controller.lef'])
+    synth.extend_inputs(['sram_tt.lib', 'sram.lef'])
 
     if which_soc == 'onyx':
-        synth.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'])
-        synth.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'])
+        synth.extend_inputs(['sram_2_tt.lib', 'sram_2.lef'])
+        synth.extend_inputs(['xgcd_tt.lib', 'xgcd.lef'])
 
     elif which_soc == 'amber':
         # Exclude dragonphy_top from synth inputs to prevent
         # floating dragonphy inputs from being tied to 0
-        synth.extend_inputs( ['dragonphy_top.lef'])
+        synth.extend_inputs(['dragonphy_top.lef'])
 
-    pt_signoff.extend_inputs( ['tile_array_tt.db'])
-    pt_signoff.extend_inputs( ['glb_top_tt.db'])
-    pt_signoff.extend_inputs( ['global_controller_tt.db'])
-    pt_signoff.extend_inputs( ['sram_tt.db'])
+    pt_signoff.extend_inputs(['tile_array_tt.db'])
+    pt_signoff.extend_inputs(['glb_top_tt.db'])
+    pt_signoff.extend_inputs(['global_controller_tt.db'])
+    pt_signoff.extend_inputs(['sram_tt.db'])
 
     if which_soc == 'onyx':
-        pt_signoff.extend_inputs( ['sram_2_tt.db'])
-        pt_signoff.extend_inputs( ['xgcd_tt.db'])
+        pt_signoff.extend_inputs(['sram_2_tt.db'])
+        pt_signoff.extend_inputs(['xgcd_tt.db'])
 
     elif which_soc == 'amber':
-        pt_signoff.extend_inputs( ['dragonphy_top_tt.db'])
+        pt_signoff.extend_inputs(['dragonphy_top_tt.db'])
 
-    route.extend_inputs( ['pre-route.tcl'])
-    signoff.extend_inputs( sealring.all_outputs())
-    signoff.extend_inputs( netlist_fixing.all_outputs())
+    route.extend_inputs(['pre-route.tcl'])
+    signoff.extend_inputs(sealring.all_outputs())
+    signoff.extend_inputs(netlist_fixing.all_outputs())
     # These steps need timing info for cgra tiles
 
-    hier_steps = \
-      [ iflow, init, power, place, cts, postcts_hold,
+    hier_steps = [
+        iflow, init, power, place, cts, postcts_hold,
         route, postroute, signoff]
 
     for step in hier_steps:
-        step.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'])
-        step.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'])
-        step.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'])
-        step.extend_inputs( ['sram_tt.lib', 'sram.lef'])
+        step.extend_inputs(['tile_array_tt.lib', 'tile_array.lef'])
+        step.extend_inputs(['glb_top_tt.lib', 'glb_top.lef'])
+        step.extend_inputs(['global_controller_tt.lib', 'global_controller.lef'])
+        step.extend_inputs(['sram_tt.lib', 'sram.lef'])
 
         if which_soc == 'onyx':
-            step.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'])
-            step.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'])
+            step.extend_inputs(['sram_2_tt.lib', 'sram_2.lef'])
+            step.extend_inputs(['xgcd_tt.lib', 'xgcd.lef'])
 
         elif which_soc == 'amber':
-            step.extend_inputs( ['dragonphy_top_tt.lib', 'dragonphy_top.lef'])
-            step.extend_inputs( ['dragonphy_RDL.lef'])
+            step.extend_inputs(['dragonphy_top_tt.lib', 'dragonphy_top.lef'])
+            step.extend_inputs(['dragonphy_RDL.lef'])
 
     # Need all block gds's to merge into the final layout
     gdsmerge_nodes = [signoff, power]
     for node in gdsmerge_nodes:
-        node.extend_inputs( ['tile_array.gds'])
-        node.extend_inputs( ['glb_top.gds'])
-        node.extend_inputs( ['global_controller.gds'])
-        node.extend_inputs( ['sram.gds'])
+        node.extend_inputs(['tile_array.gds'])
+        node.extend_inputs(['glb_top.gds'])
+        node.extend_inputs(['global_controller.gds'])
+        node.extend_inputs(['sram.gds'])
 
         if which_soc == 'onyx':
-            node.extend_inputs( ['sram_2.gds'])
-            node.extend_inputs( ['xgcd.gds'])
+            node.extend_inputs(['sram_2.gds'])
+            node.extend_inputs(['xgcd.gds'])
 
         elif which_soc == 'amber':
-            node.extend_inputs( ['dragonphy_top.gds'])
-            node.extend_inputs( ['dragonphy_RDL.gds'])
+            node.extend_inputs(['dragonphy_top.gds'])
+            node.extend_inputs(['dragonphy_RDL.gds'])
 
     # Need extracted spice files for both tile types to do LVS
 
-    lvs.extend_inputs( ['tile_array.lvs.v'])
-    lvs.extend_inputs( ['tile_array.sram.spi'])
-    lvs.extend_inputs( ['glb_top.lvs.v'])
-    lvs.extend_inputs( ['glb_top.sram.spi'])
-    lvs.extend_inputs( ['global_controller.lvs.v'])
-    lvs.extend_inputs( ['sram.spi'])
+    lvs.extend_inputs(['tile_array.lvs.v'])
+    lvs.extend_inputs(['tile_array.sram.spi'])
+    lvs.extend_inputs(['glb_top.lvs.v'])
+    lvs.extend_inputs(['glb_top.sram.spi'])
+    lvs.extend_inputs(['global_controller.lvs.v'])
+    lvs.extend_inputs(['sram.spi'])
 
     if which_soc == 'onyx':
-        lvs.extend_inputs( ['sram_2.spi'])
-        lvs.extend_inputs( ['xgcd.lvs.v'])
-        lvs.extend_inputs( ['xgcd-255.lvs.v'])
-        lvs.extend_inputs( ['xgcd-1279.lvs.v'])
-        lvs.extend_inputs( ['ring_oscillator.lvs.v'])
+        lvs.extend_inputs(['sram_2.spi'])
+        lvs.extend_inputs(['xgcd.lvs.v'])
+        lvs.extend_inputs(['xgcd-255.lvs.v'])
+        lvs.extend_inputs(['xgcd-1279.lvs.v'])
+        lvs.extend_inputs(['ring_oscillator.lvs.v'])
 
     elif which_soc == 'amber':
-        lvs.extend_inputs( ['dragonphy_top.spi'])
+        lvs.extend_inputs(['dragonphy_top.spi'])
 
-    lvs.extend_inputs( ['adk_lvs2'])
+    lvs.extend_inputs(['adk_lvs2'])
 
     # Add extra input edges to innovus steps that need custom tweaks
 
-    init.extend_inputs( custom_init.all_outputs())
-    init.extend_inputs( init_fc.all_outputs())
-    power.extend_inputs( custom_power.all_outputs())
+    init.extend_inputs(custom_init.all_outputs())
+    init.extend_inputs(init_fc.all_outputs())
+    power.extend_inputs(custom_power.all_outputs())
     if which_soc == 'onyx':
-        cts.extend_inputs( custom_cts.all_outputs())
+        cts.extend_inputs(custom_cts.all_outputs())
 
-    synth.extend_inputs( soc_rtl.all_outputs())
-    synth.extend_inputs( read_design.all_outputs())
-    synth.extend_inputs( ["cons_scripts"])
+    synth.extend_inputs(soc_rtl.all_outputs())
+    synth.extend_inputs(read_design.all_outputs())
+    synth.extend_inputs(["cons_scripts"])
 
-    power.extend_outputs( ["design-merged.gds"])
+    power.extend_outputs(["design-merged.gds"])
 
     if parameters['interconnect_only'] is False:
-        rtl.extend_outputs( ['header'])
-        rtl.extend_postconditions( ["assert File( 'outputs/header' ) "])
+        rtl.extend_outputs(['header'])
+        rtl.extend_postconditions(["assert File( 'outputs/header' ) "])
 
     # TSMC needs streamout *without* the (new) default -uniquify flag
     # This python method finds 'stream-out.tcl' and strips out that flag.
@@ -413,69 +413,69 @@ def construct():
     # Graph -- Add nodes
     #-----------------------------------------------------------------------
 
-    g.add_step( info)
-    g.add_step( rtl)
-    g.add_step( soc_rtl)
-    g.add_step( gen_sram)
-    g.add_step( tile_array)
-    g.add_step( glb_top)
-    g.add_step( global_controller)
-    g.add_step( constraints)
-    g.add_step( read_design)
-    g.add_step( synth)
-    g.add_step( iflow)
-    g.add_step( init)
-    g.add_step( init_fc)
-    g.add_step( io_file)
-    g.add_step( custom_init)
-    g.add_step( power)
-    g.add_step( custom_power)
-    g.add_step( place)
-    g.add_step( cts)
-    g.add_step( postcts_hold)
-    g.add_step( pre_route)
-    g.add_step( route)
-    g.add_step( postroute)
-    g.add_step( postroute_hold)
-    g.add_step( sealring)
-    g.add_step( netlist_fixing)
-    g.add_step( signoff)
-    g.add_step( pt_signoff)
-    g.add_step( fill)
-    g.add_step( merge_fill)
-    g.add_step( drc)
-    g.add_step( antenna_drc)
-    g.add_step( lvs)
-    g.add_step( custom_lvs)
-    g.add_step( debugcalibre)
+    g.add_step(info)
+    g.add_step(rtl)
+    g.add_step(soc_rtl)
+    g.add_step(gen_sram)
+    g.add_step(tile_array)
+    g.add_step(glb_top)
+    g.add_step(global_controller)
+    g.add_step(constraints)
+    g.add_step(read_design)
+    g.add_step(synth)
+    g.add_step(iflow)
+    g.add_step(init)
+    g.add_step(init_fc)
+    g.add_step(io_file)
+    g.add_step(custom_init)
+    g.add_step(power)
+    g.add_step(custom_power)
+    g.add_step(place)
+    g.add_step(cts)
+    g.add_step(postcts_hold)
+    g.add_step(pre_route)
+    g.add_step(route)
+    g.add_step(postroute)
+    g.add_step(postroute_hold)
+    g.add_step(sealring)
+    g.add_step(netlist_fixing)
+    g.add_step(signoff)
+    g.add_step(pt_signoff)
+    g.add_step(fill)
+    g.add_step(merge_fill)
+    g.add_step(drc)
+    g.add_step(antenna_drc)
+    g.add_step(lvs)
+    g.add_step(custom_lvs)
+    g.add_step(debugcalibre)
 
     # Post-Power DRC check
-    g.add_step( power_drc)
+    g.add_step(power_drc)
 
     # App test nodes
-    g.add_step( cgra_rtl_sim_compile)
-    g.add_step( cgra_sim_build)
-    g.add_step( cgra_rtl_sim_run)
-    # g.add_step( cgra_gl_sim_compile)
+    g.add_step(cgra_rtl_sim_compile)
+    g.add_step(cgra_sim_build)
+    g.add_step(cgra_rtl_sim_run)
+    # g.add_step(cgra_gl_sim_compile)
 
     # Onyx-specific nodes
     if which_soc == 'onyx':
-        g.add_step( gen_sram_2)
-        g.add_step( xgcd)
-        g.add_step( custom_cts)
-        g.add_step( prefill_drc)
-        g.add_step( merge_gdr)
-        g.add_step( drc_pm)
-        g.add_step( drc_dp)
-        g.add_step( drc_mas)
+        g.add_step(gen_sram_2)
+        g.add_step(xgcd)
+        g.add_step(custom_cts)
+        g.add_step(prefill_drc)
+        g.add_step(merge_gdr)
+        g.add_step(drc_pm)
+        g.add_step(drc_dp)
+        g.add_step(drc_mas)
 
         # Different adk view for lvs
-        g.add_step( lvs_adk)
+        g.add_step(lvs_adk)
 
     # Amber-specific nodes
     if which_soc == 'amber':
-        g.add_step( merge_rdl)
-        g.add_step( dragonphy)
+        g.add_step(merge_rdl)
+        g.add_step(dragonphy)
 
     #-----------------------------------------------------------------------
     # Graph -- Add edges
@@ -483,49 +483,49 @@ def construct():
 
     # Connect by name
 
-    g.connect_by_name( adk,      gen_sram)
-    g.connect_by_name( adk,      synth)
-    g.connect_by_name( adk,      iflow)
-    g.connect_by_name( adk,      init)
-    g.connect_by_name( adk,      power)
-    g.connect_by_name( adk,      place)
-    g.connect_by_name( adk,      cts)
-    g.connect_by_name( adk,      postcts_hold)
-    g.connect_by_name( adk,      route)
-    g.connect_by_name( adk,      postroute)
-    g.connect_by_name( adk,      postroute_hold)
-    g.connect_by_name( adk,      signoff)
-    g.connect_by_name( adk,      fill)
-    g.connect_by_name( adk,      merge_fill)
-    g.connect_by_name( adk,      drc)
-    g.connect_by_name( adk,      antenna_drc)
+    g.connect_by_name(adk,      gen_sram)
+    g.connect_by_name(adk,      synth)
+    g.connect_by_name(adk,      iflow)
+    g.connect_by_name(adk,      init)
+    g.connect_by_name(adk,      power)
+    g.connect_by_name(adk,      place)
+    g.connect_by_name(adk,      cts)
+    g.connect_by_name(adk,      postcts_hold)
+    g.connect_by_name(adk,      route)
+    g.connect_by_name(adk,      postroute)
+    g.connect_by_name(adk,      postroute_hold)
+    g.connect_by_name(adk,      signoff)
+    g.connect_by_name(adk,      fill)
+    g.connect_by_name(adk,      merge_fill)
+    g.connect_by_name(adk,      drc)
+    g.connect_by_name(adk,      antenna_drc)
 
     # Onyx-specific connections
     if which_soc == 'onyx':
-        g.connect_by_name( adk,      gen_sram_2)
-        g.connect_by_name( adk,      prefill_drc)
-        g.connect_by_name( adk,      merge_gdr)
-        g.connect_by_name( adk,      drc_pm)
-        g.connect_by_name( adk,      drc_dp)
-        g.connect_by_name( adk,      drc_mas)
+        g.connect_by_name(adk,      gen_sram_2)
+        g.connect_by_name(adk,      prefill_drc)
+        g.connect_by_name(adk,      merge_gdr)
+        g.connect_by_name(adk,      drc_pm)
+        g.connect_by_name(adk,      drc_dp)
+        g.connect_by_name(adk,      drc_mas)
         # Use lvs_adk so lvs has access to cells used in lower-level blocks
-        g.connect_by_name( lvs_adk,  lvs)
+        g.connect_by_name(lvs_adk,  lvs)
 
     # Amber-specific connections
     if which_soc == 'amber':
-        g.connect_by_name( adk,      merge_rdl)
-        g.connect_by_name( adk,      lvs)
+        g.connect_by_name(adk,      merge_rdl)
+        g.connect_by_name(adk,      lvs)
 
     # Post-Power DRC check
-    g.connect_by_name( adk,      power_drc)
+    g.connect_by_name(adk,      power_drc)
 
     # Connect RTL verification nodes
-    g.connect_by_name( rtl, cgra_rtl_sim_compile)
-    g.connect_by_name( cgra_sim_build, cgra_rtl_sim_run)
-    g.connect_by_name( cgra_rtl_sim_compile, cgra_rtl_sim_run)
+    g.connect_by_name(rtl, cgra_rtl_sim_compile)
+    g.connect_by_name(cgra_sim_build, cgra_rtl_sim_run)
+    g.connect_by_name(cgra_rtl_sim_compile, cgra_rtl_sim_run)
 
     # Connect GL verification nodes
-    # g.connect_by_name( signoff, cgra_gl_sim_compile)
+    # g.connect_by_name(signoff, cgra_gl_sim_compile)
 
     # All of the blocks within this hierarchical design
     # Skip these if we're doing soc_only
@@ -537,56 +537,56 @@ def construct():
             blocks += [dragonphy]
 
         for block in blocks:
-            g.connect_by_name( block, synth)
-            g.connect_by_name( block, iflow)
-            g.connect_by_name( block, init)
-            g.connect_by_name( block, power)
-            g.connect_by_name( block, place)
-            g.connect_by_name( block, cts)
-            g.connect_by_name( block, postcts_hold)
-            g.connect_by_name( block, route)
-            g.connect_by_name( block, postroute)
-            g.connect_by_name( block, postroute_hold)
-            g.connect_by_name( block, signoff)
-            g.connect_by_name( block, pt_signoff)
-            g.connect_by_name( block, drc)
-            g.connect_by_name( block, lvs)
+            g.connect_by_name(block, synth)
+            g.connect_by_name(block, iflow)
+            g.connect_by_name(block, init)
+            g.connect_by_name(block, power)
+            g.connect_by_name(block, place)
+            g.connect_by_name(block, cts)
+            g.connect_by_name(block, postcts_hold)
+            g.connect_by_name(block, route)
+            g.connect_by_name(block, postroute)
+            g.connect_by_name(block, postroute_hold)
+            g.connect_by_name(block, signoff)
+            g.connect_by_name(block, pt_signoff)
+            g.connect_by_name(block, drc)
+            g.connect_by_name(block, lvs)
         # Tile_array can use rtl from rtl node
-        g.connect_by_name( rtl, tile_array)
+        g.connect_by_name(rtl, tile_array)
         # glb_top can use rtl from rtl node
-        g.connect_by_name( rtl, glb_top)
+        g.connect_by_name(rtl, glb_top)
         # global_controller can use rtl from rtl node
-        g.connect_by_name( rtl, global_controller)
+        g.connect_by_name(rtl, global_controller)
 
-    g.connect_by_name( rtl,         synth)
-    g.connect_by_name( soc_rtl,     synth)
-    g.connect_by_name( constraints, synth)
-    g.connect_by_name( read_design, synth)
+    g.connect_by_name(rtl,         synth)
+    g.connect_by_name(soc_rtl,     synth)
+    g.connect_by_name(constraints, synth)
+    g.connect_by_name(read_design, synth)
 
-    g.connect_by_name( soc_rtl,  io_file)
+    g.connect_by_name(soc_rtl,  io_file)
 
-    g.connect_by_name( synth,       iflow)
-    g.connect_by_name( synth,       init)
-    g.connect_by_name( synth,       power)
-    g.connect_by_name( synth,       place)
-    g.connect_by_name( synth,       cts)
+    g.connect_by_name(synth,       iflow)
+    g.connect_by_name(synth,       init)
+    g.connect_by_name(synth,       power)
+    g.connect_by_name(synth,       place)
+    g.connect_by_name(synth,       cts)
 
-    g.connect_by_name( iflow,    init)
-    g.connect_by_name( iflow,    power)
-    g.connect_by_name( iflow,    place)
-    g.connect_by_name( iflow,    cts)
-    g.connect_by_name( iflow,    postcts_hold)
-    g.connect_by_name( iflow,    route)
-    g.connect_by_name( iflow,    postroute)
-    g.connect_by_name( iflow,    postroute_hold)
-    g.connect_by_name( iflow,    signoff)
+    g.connect_by_name(iflow,    init)
+    g.connect_by_name(iflow,    power)
+    g.connect_by_name(iflow,    place)
+    g.connect_by_name(iflow,    cts)
+    g.connect_by_name(iflow,    postcts_hold)
+    g.connect_by_name(iflow,    route)
+    g.connect_by_name(iflow,    postroute)
+    g.connect_by_name(iflow,    postroute_hold)
+    g.connect_by_name(iflow,    signoff)
 
-    g.connect_by_name( custom_init,  init)
-    g.connect_by_name( custom_lvs,   lvs)
-    g.connect_by_name( custom_power, power)
+    g.connect_by_name(custom_init,  init)
+    g.connect_by_name(custom_lvs,   lvs)
+    g.connect_by_name(custom_power, power)
 
     if which_soc == 'onyx':
-        g.connect_by_name( custom_cts,   cts)
+        g.connect_by_name(custom_cts,   cts)
 
     # Connect gen_sram_macro node(s) to all downstream nodes that
     # need them
@@ -594,7 +594,7 @@ def construct():
                   route, postroute, postroute_hold, signoff, pt_signoff,
                   drc, lvs]
     for node in sram_nodes:
-        g.connect_by_name( gen_sram, node)
+        g.connect_by_name(gen_sram, node)
         if which_soc == 'onyx':
             for sram_output in gen_sram_2.all_outputs():
                 node_input = sram_output.replace('sram', 'sram_2')
@@ -602,77 +602,77 @@ def construct():
                     g.connect(gen_sram_2.o(sram_output), node.i(node_input))
 
     # Full chip floorplan stuff
-    g.connect_by_name( io_file, init_fc)
-    g.connect_by_name( init_fc, init)
+    g.connect_by_name(io_file, init_fc)
+    g.connect_by_name(init_fc, init)
 
-    g.connect_by_name( init,           power)
-    g.connect_by_name( power,          place)
-    g.connect_by_name( place,          cts)
-    g.connect_by_name( cts,            postcts_hold)
-    g.connect_by_name( postcts_hold,   route)
-    g.connect_by_name( route,          postroute)
-    g.connect_by_name( postroute,      postroute_hold)
-    g.connect_by_name( postroute_hold, signoff)
-    g.connect_by_name( signoff,        lvs)
+    g.connect_by_name(init,           power)
+    g.connect_by_name(power,          place)
+    g.connect_by_name(place,          cts)
+    g.connect_by_name(cts,            postcts_hold)
+    g.connect_by_name(postcts_hold,   route)
+    g.connect_by_name(route,          postroute)
+    g.connect_by_name(postroute,      postroute_hold)
+    g.connect_by_name(postroute_hold, signoff)
+    g.connect_by_name(signoff,        lvs)
 
     if which_soc == 'onyx':
         # Merge guardring gds into design
         g.connect(signoff.o('design-merged.gds'), merge_gdr.i('design.gds'))
 
         # Send gds with sealring to drc, fill, and lvs
-        g.connect_by_name( merge_gdr, lvs)
+        g.connect_by_name(merge_gdr, lvs)
         # Run pre-fill DRC after signoff
-        g.connect_by_name( merge_gdr, prefill_drc)
+        g.connect_by_name(merge_gdr, prefill_drc)
         # Run PM DRC after signoff
-        g.connect_by_name( merge_gdr, drc_pm)
+        g.connect_by_name(merge_gdr, drc_pm)
 
         # For GF, Fill is already merged during fill step
 
         # Run Fill on merged GDS
-        g.connect( merge_gdr.o('design_merged.gds'), fill.i('design.gds'))
+        g.connect(merge_gdr.o('design_merged.gds'), fill.i('design.gds'))
 
         # Connect fill directly to DRC steps
-        g.connect( fill.o('fill.gds'), drc_dp.i('design_merged.gds'))
-        g.connect( fill.o('fill.gds'), antenna_drc.i('design_merged.gds'))
+        g.connect(fill.o('fill.gds'), drc_dp.i('design_merged.gds'))
+        g.connect(fill.o('fill.gds'), antenna_drc.i('design_merged.gds'))
         # Connect drc_dp output gds to final signoff drc
-        g.connect_by_name( drc_dp, drc)
-        g.connect_by_name( drc_dp, drc_mas)
+        g.connect_by_name(drc_dp, drc)
+        g.connect_by_name(drc_dp, drc_mas)
 
     if which_soc == 'amber':
         g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
         g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
         # Skipping
-        g.connect( signoff.o('design-merged.gds'),   merge_rdl.i('design.gds'))
-        g.connect( dragonphy.o('dragonphy_RDL.gds'), merge_rdl.i('child.gds'))
-        g.connect_by_name( merge_rdl, lvs)
+        g.connect(signoff.o('design-merged.gds'),   merge_rdl.i('design.gds'))
+        g.connect(dragonphy.o('dragonphy_RDL.gds'), merge_rdl.i('child.gds'))
+        g.connect_by_name(merge_rdl, lvs)
 
         # Run Fill on merged GDS
-        g.connect( merge_rdl.o('design_merged.gds'), fill.i('design.gds'))
+        g.connect(merge_rdl.o('design_merged.gds'), fill.i('design.gds'))
 
         # Merge fill
-        g.connect( merge_rdl.o('design_merged.gds'), merge_fill.i('design.gds'))
-        g.connect( fill.o('fill.gds'), merge_fill.i('child.gds'))
+        g.connect(merge_rdl.o('design_merged.gds'), merge_fill.i('design.gds'))
+        g.connect(fill.o('fill.gds'), merge_fill.i('child.gds'))
 
         # Run DRC on merged and filled gds
-        g.connect_by_name( merge_fill, drc)
-        g.connect_by_name( merge_fill, antenna_drc)
+        g.connect_by_name(merge_fill, drc)
+        g.connect_by_name(merge_fill, antenna_drc)
 
-    g.connect_by_name( adk,          pt_signoff)
-    g.connect_by_name( signoff,      pt_signoff)
+    g.connect_by_name(adk,          pt_signoff)
+    g.connect_by_name(signoff,      pt_signoff)
 
-    g.connect_by_name( adk,      debugcalibre)
-    g.connect_by_name( synth,    debugcalibre)
-    g.connect_by_name( iflow,    debugcalibre)
-    g.connect_by_name( signoff,  debugcalibre)
+    g.connect_by_name(adk,      debugcalibre)
+    g.connect_by_name(synth,    debugcalibre)
+    g.connect_by_name(iflow,    debugcalibre)
+    g.connect_by_name(signoff,  debugcalibre)
 
     if which_soc == 'amber':
-        g.connect_by_name( drc,      debugcalibre)
-        g.connect_by_name( lvs,      debugcalibre)
+        g.connect_by_name(drc,      debugcalibre)
+        g.connect_by_name(lvs,      debugcalibre)
 
-    g.connect_by_name( pre_route, route)
-    g.connect_by_name( sealring, signoff)
-    g.connect_by_name( netlist_fixing, signoff)
+    g.connect_by_name(pre_route, route)
+    g.connect_by_name(sealring, signoff)
+    g.connect_by_name(netlist_fixing, signoff)
 
     # Post-Power DRC
     g.connect(power.o('design-merged.gds'), power_drc.i('design_merged.gds'))
@@ -681,17 +681,17 @@ def construct():
     #-----------------------------------------------------------------------
 
     # Allow user to override parms with env in a limited sort of way
-    parameters = sr_override_parms( parameters)
+    parameters = sr_override_parms(parameters)
     print(f'parameters["hold_target_slack"]={parameters["hold_target_slack"]}')
-    g.update_params( parameters)
+    g.update_params(parameters)
 
     if which_soc == 'onyx':
         # Provide different parameter set to second sram node, so it can actually 
         # generate a different sram
-        gen_sram_2.update_params( sram_2_params)
+        gen_sram_2.update_params(sram_2_params)
 
         # LVS adk has separate view parameter
-        lvs_adk.update_params({ 'adk_view' : parameters['lvs_adk_view']})
+        lvs_adk.update_params({'adk_view' : parameters['lvs_adk_view']})
 
     # Since we are adding an additional input script to the generic Innovus
     # steps, we modify the order parameter for that node which determines
@@ -744,15 +744,15 @@ def construct():
     # Power node order manipulation
     order = power.get_param('order')
     # Move endcap/welltap insertion to end of power step to improve runtime
-    order.append( 'add-endcaps-welltaps.tcl')
+    order.append('add-endcaps-welltaps.tcl')
     # Stream out post-power GDS so that we can run DRC here
-    order.append( 'innovus-foundation-flow/custom-scripts/stream-out.tcl')
-    order.append( 'attach-results-to-outputs.tcl')
+    order.append('innovus-foundation-flow/custom-scripts/stream-out.tcl')
+    order.append('attach-results-to-outputs.tcl')
     power.update_params({'order': order})
 
     # Add pre-route plugin to insert skip_routing commands
     order = route.get_param('order')
-    order.insert( 0, 'pre-route.tcl')
+    order.insert(0, 'pre-route.tcl')
     route.update_params({'order': order})
 
     # Signoff order additions
@@ -761,8 +761,8 @@ def construct():
     if parameters['include_sealring'] == True:
         order.insert(0, 'add-sealring.tcl')
     # Add netlist-fixing script before we save new netlist
-    index = order.index( 'generate-results.tcl')
-    order.insert( index, 'netlist-fixing.tcl')
+    index = order.index('generate-results.tcl')
+    order.insert(index, 'netlist-fixing.tcl')
     signoff.update_params({'order': order})
 
     if which_soc == 'amber':
@@ -787,11 +787,11 @@ def construct():
             'child_top_cell': f"{parameters['design_name']}_F16a"})
 
         # need to give coordinates for guardring
-        merge_gdr.update_params( guardring_params)
+        merge_gdr.update_params(guardring_params)
 
         # Antenna DRC node needs to use antenna rule deck
-        antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'],
-                                     'drc_env_setup': parameters['antenna_drc_env_setup']})
+        antenna_drc.update_params({'drc_rule_deck': parameters['antenna_drc_rule_deck'],
+                                   'drc_env_setup': parameters['antenna_drc_env_setup']})
 
     # Power DRC node should use block level rule deck to improve runtimes and not report false errors
     power_drc.update_params({'drc_rule_deck': parameters['power_drc_rule_deck']})

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -13,786 +13,784 @@ from shutil import which
 from common.get_sys_adk import get_sys_adk
 
 def sr_override_parms(parmdict):
+    '''
+    # A mechanism whereby e.g. buildkite can alter parms at the last minute
+    # by way of environmental variables e.g. for faster postroute_hold step
+    # could do something like
+    #    export MFLOWGEN_PARM_OVERRIDE_hold_target_slack=0.6
+    #    mflowgen run --design $$GARNET_HOME/mflowgen/full_chip
+    #    make cadence-innovus-postroute_hold
   '''
-  # A mechanism whereby e.g. buildkite can alter parms at the last minute
-  # by way of environmental variables e.g. for faster postroute_hold step
-  # could do something like
-  #    export MFLOWGEN_PARM_OVERRIDE_hold_target_slack=0.6
-  #    mflowgen run --design $$GARNET_HOME/mflowgen/full_chip
-  #    make cadence-innovus-postroute_hold
-'''
-  import os
-  for e in os.environ:
-    # e.g. e="MFLOWGEN_PARM_OVERRIDE_hold_target_slack"
-    if e[0:22]=="MFLOWGEN_PARM_OVERRIDE":
-      parm=e[23:99];     # e.g. parm="hold_target_slack"
-      print(f'+++ FOUND MFLOWGEN PARAMETER OVERRIDE "{parm}={os.environ[e]}"')
-      print(f'BEFOR: parmdict["hold_target_slack"]={parmdict["hold_target_slack"]}')
-      parmdict[parm]=os.environ[e]
-  print(f'AFTER: parmdict["hold_target_slack"]={parmdict["hold_target_slack"]}')
-
-
-  return(parmdict)
+    import os
+    for e in os.environ:
+        # e.g. e="MFLOWGEN_PARM_OVERRIDE_hold_target_slack"
+        if e[0:22]=="MFLOWGEN_PARM_OVERRIDE":
+            parm=e[23:99];     # e.g. parm="hold_target_slack"
+            print(f'+++ FOUND MFLOWGEN PARAMETER OVERRIDE "{parm}={os.environ[e]}"')
+            print(f'BEFOR: parmdict["hold_target_slack"]={parmdict["hold_target_slack"]}')
+            parmdict[parm]=os.environ[e]
+    print(f'AFTER: parmdict["hold_target_slack"]={parmdict["hold_target_slack"]}')
+    return(parmdict)
 
 
 def construct():
 
-  g = Graph()
+    g = Graph()
 
-  #-----------------------------------------------------------------------
-  # Parameters
-  #-----------------------------------------------------------------------
+    #-----------------------------------------------------------------------
+    # Parameters
+    #-----------------------------------------------------------------------
 
-  adk_name = get_sys_adk()  # E.g. 'gf12-adk' or 'tsmc16'
-  adk_view = 'multivt'
-  which_soc = 'onyx'
+    adk_name = get_sys_adk()  # E.g. 'gf12-adk' or 'tsmc16'
+    adk_view = 'multivt'
+    which_soc = 'onyx'
 
-  # TSMC override(s)
-  if adk_name == 'tsmc16':
-      adk_view = 'view-standard'
-      which_soc = 'amber'
+    # TSMC override(s)
+    if adk_name == 'tsmc16':
+        adk_view = 'view-standard'
+        which_soc = 'amber'
 
-  if which("calibre") is not None:
-      drc_rule_deck = 'calibre-drc-chip.rule'
-      antenna_drc_rule_deck = 'calibre-drc-antenna.rule'
-      power_drc_rule_deck = 'calibre-drc-block.rule'
-  else:
-      drc_rule_deck = 'pegasus-drc-chip.rule'
-      antenna_drc_rule_deck = 'pegasus-drc-antenna.rule'
-      power_drc_rule_deck = 'pegasus-drc-block.rule'
+    if which("calibre") is not None:
+        drc_rule_deck = 'calibre-drc-chip.rule'
+        antenna_drc_rule_deck = 'calibre-drc-antenna.rule'
+        power_drc_rule_deck = 'calibre-drc-block.rule'
+    else:
+        drc_rule_deck = 'pegasus-drc-chip.rule'
+        antenna_drc_rule_deck = 'pegasus-drc-antenna.rule'
+        power_drc_rule_deck = 'pegasus-drc-block.rule'
 
-  parameters = {
-    'construct_path'    : __file__,
-    'design_name'       : 'GarnetSOC_pad_frame',
-    'clock_period'      : 1.1,
-    'adk'               : adk_name,
-    'adk_view'          : adk_view,
-    # Synthesis
-    'flatten_effort'    : 0,
-    'topographical'     : True,
-    # RTL Generation
-    'array_width'       : 32,
-    'array_height'      : 16,
-    'num_glb_tiles'     : 16,
-    'interconnect_only' : False,
-    'use_local_garnet'  : False,
-    # glb tile memory size (unit: KB)
-    # 'glb_tile_mem_size' : 64,  #  64x16 => 1M global buffer
-    'glb_tile_mem_size' : 256,   # 256*16 => 4M global buffer
-    # Power Domains
-    'PWR_AWARE'         : True,
-    # Include Garnet?
-    'soc_only'          : False,
-    # Include SoC core? (use 0 for false, 1 for true)
-    'include_core'      : 1,
-    # Include sealring?
-    'include_sealring'  : False,
-    # SRAM macros
-    'num_words'         : 4096,
-    'word_size'         : 64,
-    'mux_size'          : 8,
-    'num_subarrays'     : 2,
-    'partial_write'     : True,
-    # Low Effort flow
-    'express_flow'             : False,
-    'skip_verify_connectivity' : True,
-    # Hold fixing
-    'signoff_engine' : True,
-    'hold_target_slack'  : 0.100,
-    # LVS
-    # - need lvs2 because dragonphy uses LVT cells
-    'lvs_extra_spice_include' : 'inputs/adk_lvs2/*.cdl',
-    'lvs_hcells_file'   : 'inputs/adk/hcells.inc',
-    'lvs_connect_names' : '"VDD VSS VDDPST"',
-    'lvs_verify_netlist' : 0,
-    # TSMC16 support for LVS - need lvs2 because dragonphy uses LVT cells
-    'adk_view_lvs2'     : 'multivt',
-    # TLX Ports Partitions
-    'TLX_FWD_DATA_LO_WIDTH' : 16,
-    'TLX_REV_DATA_LO_WIDTH' : 45,
-    # DRC rule deck
-    'drc_rule_deck'         : drc_rule_deck,
-    'antenna_drc_rule_deck' : antenna_drc_rule_deck,
-    'power_drc_rule_deck'   : power_drc_rule_deck,
-    'nthreads'              : 16,
-    'drc_env_setup'         : 'drcenv-chip.sh',
-    'antenna_drc_env_setup' : 'drcenv-chip-ant.sh',
-    # Testbench
-    'cgra_apps' : ["tests/conv_1_2", "tests/conv_2_1"]
-  }
-  
-  # Note 'lvs_adk_view' not used by amber/tsmc
-  if parameters['PWR_AWARE'] == True:
-      parameters['lvs_adk_view'] = adk_view + '-pm'
-  else:
-      parameters['lvs_adk_view'] = adk_view
+    parameters = {
+      'construct_path'    : __file__,
+      'design_name'       : 'GarnetSOC_pad_frame',
+      'clock_period'      : 1.1,
+      'adk'               : adk_name,
+      'adk_view'          : adk_view,
+      # Synthesis
+      'flatten_effort'    : 0,
+      'topographical'     : True,
+      # RTL Generation
+      'array_width'       : 32,
+      'array_height'      : 16,
+      'num_glb_tiles'     : 16,
+      'interconnect_only' : False,
+      'use_local_garnet'  : False,
+      # glb tile memory size (unit: KB)
+      # 'glb_tile_mem_size' : 64,  #  64x16 => 1M global buffer
+      'glb_tile_mem_size' : 256,   # 256*16 => 4M global buffer
+      # Power Domains
+      'PWR_AWARE'         : True,
+      # Include Garnet?
+      'soc_only'          : False,
+      # Include SoC core? (use 0 for false, 1 for true)
+      'include_core'      : 1,
+      # Include sealring?
+      'include_sealring'  : False,
+      # SRAM macros
+      'num_words'         : 4096,
+      'word_size'         : 64,
+      'mux_size'          : 8,
+      'num_subarrays'     : 2,
+      'partial_write'     : True,
+      # Low Effort flow
+      'express_flow'             : False,
+      'skip_verify_connectivity' : True,
+      # Hold fixing
+      'signoff_engine' : True,
+      'hold_target_slack'  : 0.100,
+      # LVS
+      # - need lvs2 because dragonphy uses LVT cells
+      'lvs_extra_spice_include' : 'inputs/adk_lvs2/*.cdl',
+      'lvs_hcells_file'   : 'inputs/adk/hcells.inc',
+      'lvs_connect_names' : '"VDD VSS VDDPST"',
+      'lvs_verify_netlist' : 0,
+      # TSMC16 support for LVS - need lvs2 because dragonphy uses LVT cells
+      'adk_view_lvs2'     : 'multivt',
+      # TLX Ports Partitions
+      'TLX_FWD_DATA_LO_WIDTH' : 16,
+      'TLX_REV_DATA_LO_WIDTH' : 45,
+      # DRC rule deck
+      'drc_rule_deck'         : drc_rule_deck,
+      'antenna_drc_rule_deck' : antenna_drc_rule_deck,
+      'power_drc_rule_deck'   : power_drc_rule_deck,
+      'nthreads'              : 16,
+      'drc_env_setup'         : 'drcenv-chip.sh',
+      'antenna_drc_env_setup' : 'drcenv-chip-ant.sh',
+      # Testbench
+      'cgra_apps' : ["tests/conv_1_2", "tests/conv_2_1"]
+    }
 
-  # TSMC overrides
-  if adk_name == 'tsmc16': parameters.update({
-    'clock_period'      : 1.3,
-    'include_sealring'  : True,
-    'num_words'         : 2048,
-    'corner'            : "tt0p8v25c",
-    # Dragonphy
-    'dragonphy_rdl_x'   : '613.565u',
-    'dragonphy_rdl_y'   : '3901.872u',
-    'hold_target_slack'  : 0.060,
+    # Note 'lvs_adk_view' not used by amber/tsmc
+    if parameters['PWR_AWARE'] == True:
+        parameters['lvs_adk_view'] = adk_view + '-pm'
+    else:
+        parameters['lvs_adk_view'] = adk_view
 
-  })
-  # OG TSMC did not set drc_env_setup etc.
-  if adk_name == 'tsmc16':
-    parameters.pop('use_local_garnet')
-    parameters.pop('drc_env_setup')
-    parameters.pop('antenna_drc_env_setup')
+    # TSMC overrides
+    if adk_name == 'tsmc16': parameters.update({
+      'clock_period'      : 1.3,
+      'include_sealring'  : True,
+      'num_words'         : 2048,
+      'corner'            : "tt0p8v25c",
+      # Dragonphy
+      'dragonphy_rdl_x'   : '613.565u',
+      'dragonphy_rdl_y'   : '3901.872u',
+      'hold_target_slack'  : 0.060,
 
-  # 'sram_2' and 'guarding' are onyx/GF-only parameters (for now)
+    })
+    # OG TSMC did not set drc_env_setup etc.
+    if adk_name == 'tsmc16':
+        parameters.pop('use_local_garnet')
+        parameters.pop('drc_env_setup')
+        parameters.pop('antenna_drc_env_setup')
 
-  sram_2_params = {
-    # SRAM macros
-    'num_words'         : 32768,
-    'word_size'         : 32,
-    'mux_size'          : 16,
-    'num_subarrays'     : 8,
-    'partial_write'     : True,
-  }
+    # 'sram_2' and 'guarding' are onyx/GF-only parameters (for now)
 
-  guardring_params = {
-    # Merging guardring into GDS
-    'child_gds' : 'inputs/adk/guardring.gds',
-    'coord_x'   : '-49.98u',
-    'coord_y'   : '-49.92u'
-  }
-  
-  #-----------------------------------------------------------------------
-  # Create nodes
-  #-----------------------------------------------------------------------
+    sram_2_params = {
+      # SRAM macros
+      'num_words'         : 32768,
+      'word_size'         : 32,
+      'mux_size'          : 16,
+      'num_subarrays'     : 8,
+      'partial_write'     : True,
+    }
 
-  this_dir = os.path.dirname( os.path.abspath( __file__ ) )
+    guardring_params = {
+      # Merging guardring into GDS
+      'child_gds' : 'inputs/adk/guardring.gds',
+      'coord_x'   : '-49.98u',
+      'coord_y'   : '-49.92u'
+    }
 
-  # ADK step
+    #-----------------------------------------------------------------------
+    # Create nodes
+    #-----------------------------------------------------------------------
 
-  g.set_adk( adk_name )
-  adk = g.get_adk_step()
+    this_dir = os.path.dirname( os.path.abspath( __file__ ) )
 
-  # Custom steps
+    # ADK step
 
-  rtl            = Step( this_dir + '/../common/rtl'                          )
-  soc_rtl        = Step( this_dir + '/../common/soc-rtl-v2'                   )
+    g.set_adk( adk_name )
+    adk = g.get_adk_step()
 
-  if adk_name == "tsmc16":
-    gen_sram       = Step( this_dir + '/../common/gen_sram_macro_amber'         )
-    constraints    = Step( this_dir + '/constraints_amber'                      )
-  else:
-    gen_sram       = Step( this_dir + '/../common/gen_sram_macro'               )
-    constraints    = Step( this_dir + '/constraints'                            )
+    # Custom steps
 
-  read_design    = Step( this_dir + '/../common/fc-custom-read-design'        )
-  if adk_name == 'tsmc16':
-    custom_init          = Step( this_dir + '/custom-init-amber'                 )
-    custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber'            )
-    custom_power         = Step( this_dir + '/../common/custom-power-chip-amber' )
-    init_fc              = Step( this_dir + '/../common/init-fullchip-amber'     )
-  else:
-    custom_init          = Step( this_dir + '/custom-init'                 )
-    custom_lvs           = Step( this_dir + '/custom-lvs-rules'            )
-    custom_power         = Step( this_dir + '/../common/custom-power-chip' )
-    custom_cts           = Step( this_dir + '/custom-cts'                  )
-    init_fc              = Step( this_dir + '/../common/init-fullchip'     )
-  io_file        = Step( this_dir + '/io_file'                                )
-  pre_route      = Step( this_dir + '/pre-route'                              )
-  sealring       = Step( this_dir + '/sealring'                               )
-  netlist_fixing = Step( this_dir + '/../common/fc-netlist-fixing'            )
-  if which_soc == 'onyx':
-    drc_pm         = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm' )
-    drc_dp         = Step( this_dir + '/gf-drc-dp'                              )
-    drc_mas        = Step( this_dir + '/../common/gf-mentor-calibre-drc-mas'    )
+    rtl            = Step( this_dir + '/../common/rtl'                          )
+    soc_rtl        = Step( this_dir + '/../common/soc-rtl-v2'                   )
 
-  # Block-level designs
+    if adk_name == "tsmc16":
+        gen_sram       = Step( this_dir + '/../common/gen_sram_macro_amber'         )
+        constraints    = Step( this_dir + '/constraints_amber'                      )
+    else:
+        gen_sram       = Step( this_dir + '/../common/gen_sram_macro'               )
+        constraints    = Step( this_dir + '/constraints'                            )
 
-  tile_array        = Subgraph( this_dir + '/../tile_array',        'tile_array'        )
-  glb_top           = Subgraph( this_dir + '/../glb_top',           'glb_top'           )
-  global_controller = Subgraph( this_dir + '/../global_controller', 'global_controller' )
+    read_design    = Step( this_dir + '/../common/fc-custom-read-design'        )
+    if adk_name == 'tsmc16':
+        custom_init          = Step( this_dir + '/custom-init-amber'                 )
+        custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber'            )
+        custom_power         = Step( this_dir + '/../common/custom-power-chip-amber' )
+        init_fc              = Step( this_dir + '/../common/init-fullchip-amber'     )
+    else:
+        custom_init          = Step( this_dir + '/custom-init'                 )
+        custom_lvs           = Step( this_dir + '/custom-lvs-rules'            )
+        custom_power         = Step( this_dir + '/../common/custom-power-chip' )
+        custom_cts           = Step( this_dir + '/custom-cts'                  )
+        init_fc              = Step( this_dir + '/../common/init-fullchip'     )
+    io_file        = Step( this_dir + '/io_file'                                )
+    pre_route      = Step( this_dir + '/pre-route'                              )
+    sealring       = Step( this_dir + '/sealring'                               )
+    netlist_fixing = Step( this_dir + '/../common/fc-netlist-fixing'            )
+    if which_soc == 'onyx':
+        drc_pm         = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm' )
+        drc_dp         = Step( this_dir + '/gf-drc-dp'                              )
+        drc_mas        = Step( this_dir + '/../common/gf-mentor-calibre-drc-mas'    )
 
-  if which_soc == 'amber':
-    dragonphy         = Step( this_dir + '/dragonphy')
-  elif which_soc == 'onyx':
-    xgcd              = Step( this_dir + '/xgcd'     )
+    # Block-level designs
 
-  # CGRA simulation
+    tile_array        = Subgraph( this_dir + '/../tile_array',        'tile_array'        )
+    glb_top           = Subgraph( this_dir + '/../glb_top',           'glb_top'           )
+    global_controller = Subgraph( this_dir + '/../global_controller', 'global_controller' )
 
-  cgra_rtl_sim_compile  = Step( this_dir + '/cgra_rtl_sim_compile' )
-  cgra_rtl_sim_run      = Step( this_dir + '/cgra_rtl_sim_run'     )
-  cgra_sim_build        = Step( this_dir + '/cgra_sim_build'       )
-  # cgra_gl_sim_compile   = Step( this_dir + '/cgra_gl_sim_compile'  )
-  # cgra_gl_sim_run       = Step( this_dir + '/cgra_gl_sim_run'      )
-  # cgra_gl_ptpx          = Step( this_dir + '/cgra_gl_ptpx'         )
-  # cgra_rtl_sim_verdict  = Step( this_dir + '/cgra_rtl_sim_verdict' )
-  # cgra_gl_sim_verdict   = Step( this_dir + '/cgra_gl_sim_verdict'  )
+    if which_soc == 'amber':
+        dragonphy         = Step( this_dir + '/dragonphy')
+    elif which_soc == 'onyx':
+        xgcd              = Step( this_dir + '/xgcd'     )
 
-  # Default steps
+    # CGRA simulation
 
-  info           = Step( 'info',                          default=True )
-  #constraints    = Step( 'constraints',                   default=True )
-  synth          = Step( 'cadence-genus-synthesis',       default=True )
-  iflow          = Step( 'cadence-innovus-flowsetup',     default=True )
-  init           = Step( 'cadence-innovus-init',          default=True )
-  power          = Step( 'cadence-innovus-power',         default=True )
-  place          = Step( 'cadence-innovus-place',         default=True )
-  cts            = Step( 'cadence-innovus-cts',           default=True )
-  postcts_hold   = Step( 'cadence-innovus-postcts_hold',  default=True )
-  route          = Step( 'cadence-innovus-route',         default=True )
-  postroute      = Step( 'cadence-innovus-postroute',     default=True )
-  postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
-  signoff        = Step( 'cadence-innovus-signoff',       default=True )
-  pt_signoff     = Step( 'synopsys-pt-timing-signoff',    default=True )
+    cgra_rtl_sim_compile  = Step( this_dir + '/cgra_rtl_sim_compile' )
+    cgra_rtl_sim_run      = Step( this_dir + '/cgra_rtl_sim_run'     )
+    cgra_sim_build        = Step( this_dir + '/cgra_sim_build'       )
+    # cgra_gl_sim_compile   = Step( this_dir + '/cgra_gl_sim_compile'  )
+    # cgra_gl_sim_run       = Step( this_dir + '/cgra_gl_sim_run'      )
+    # cgra_gl_ptpx          = Step( this_dir + '/cgra_gl_ptpx'         )
+    # cgra_rtl_sim_verdict  = Step( this_dir + '/cgra_rtl_sim_verdict' )
+    # cgra_gl_sim_verdict   = Step( this_dir + '/cgra_gl_sim_verdict'  )
 
-  if which("calibre") is not None:
-      drc            = Step( 'mentor-calibre-drc',            default=True )
-      lvs            = Step( 'mentor-calibre-lvs',            default=True )
-      # GF has a different way of running fill
-      if adk_name == 'gf12-adk':
-          fill           = Step (this_dir + '/../common/mentor-calibre-fill-gf' )
-          merge_gdr      = Step( 'mentor-calibre-gdsmerge-child',  default=True )
-      else:
-          fill           = Step( 'mentor-calibre-fill',            default=True )
-          merge_rdl      = Step( 'mentor-calibre-gdsmerge-child',  default=True )
-          merge_rdl.set_name('gdsmerge-dragonphy-rdl')
+    # Default steps
 
-      merge_fill     = Step( 'mentor-calibre-gdsmerge-child', default=True )
-  else:
-      assert False, 'Sorry! Removed cadence-pegasus option'
+    info           = Step( 'info',                          default=True )
+    #constraints    = Step( 'constraints',                   default=True )
+    synth          = Step( 'cadence-genus-synthesis',       default=True )
+    iflow          = Step( 'cadence-innovus-flowsetup',     default=True )
+    init           = Step( 'cadence-innovus-init',          default=True )
+    power          = Step( 'cadence-innovus-power',         default=True )
+    place          = Step( 'cadence-innovus-place',         default=True )
+    cts            = Step( 'cadence-innovus-cts',           default=True )
+    postcts_hold   = Step( 'cadence-innovus-postcts_hold',  default=True )
+    route          = Step( 'cadence-innovus-route',         default=True )
+    postroute      = Step( 'cadence-innovus-postroute',     default=True )
+    postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
+    signoff        = Step( 'cadence-innovus-signoff',       default=True )
+    pt_signoff     = Step( 'synopsys-pt-timing-signoff',    default=True )
 
-  debugcalibre   = Step( 'cadence-innovus-debug-calibre', default=True )
+    if which("calibre") is not None:
+        drc            = Step( 'mentor-calibre-drc',            default=True )
+        lvs            = Step( 'mentor-calibre-lvs',            default=True )
+        # GF has a different way of running fill
+        if adk_name == 'gf12-adk':
+            fill           = Step (this_dir + '/../common/mentor-calibre-fill-gf' )
+            merge_gdr      = Step( 'mentor-calibre-gdsmerge-child',  default=True )
+        else:
+            fill           = Step( 'mentor-calibre-fill',            default=True )
+            merge_rdl      = Step( 'mentor-calibre-gdsmerge-child',  default=True )
+            merge_rdl.set_name('gdsmerge-dragonphy-rdl')
 
-  merge_fill.set_name('gdsmerge-fill')
+        merge_fill     = Step( 'mentor-calibre-gdsmerge-child', default=True )
+    else:
+        assert False, 'Sorry! Removed cadence-pegasus option'
 
-  # Send in the clones
+    debugcalibre   = Step( 'cadence-innovus-debug-calibre', default=True )
 
-  if which_soc == 'onyx':
-    # Second sram_node because soc has 2 types of srams
-    gen_sram_2 = gen_sram.clone()
-    gen_sram_2.set_name( 'gen_sram_macro_2' )
+    merge_fill.set_name('gdsmerge-fill')
 
-  # 'power' step now gets its own design-rule check
-  power_drc = drc.clone()
-  power_drc.set_name( 'power-drc' )
-
-  # Antenna DRC Check
-  antenna_drc = drc.clone()
-  antenna_drc.set_name( 'antenna-drc' )
-
-  if which_soc == 'onyx':
-    # Pre-Fill DRC Check
-    prefill_drc = drc.clone()
-    prefill_drc.set_name( 'pre-fill-drc' )
-
-    # Separate ADK for LVS so it has PM cells when needed
-    lvs_adk = adk.clone()
-    lvs_adk.set_name( 'lvs_adk' )
-
-  # Add cgra tile macro inputs to downstream nodes
-
-  synth.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'] )
-  synth.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'] )
-  synth.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'] )
-  synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
-
-  if which_soc == 'onyx':
-    synth.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'] )
-    synth.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'] )
-
-  elif which_soc == 'amber':
-    # Exclude dragonphy_top from synth inputs to prevent
-    # floating dragonphy inputs from being tied to 0
-    synth.extend_inputs( ['dragonphy_top.lef'] )
-
-  pt_signoff.extend_inputs( ['tile_array_tt.db'] )
-  pt_signoff.extend_inputs( ['glb_top_tt.db'] )
-  pt_signoff.extend_inputs( ['global_controller_tt.db'] )
-  pt_signoff.extend_inputs( ['sram_tt.db'] )
-
-  if which_soc == 'onyx':
-    pt_signoff.extend_inputs( ['sram_2_tt.db'] )
-    pt_signoff.extend_inputs( ['xgcd_tt.db'] )
-
-  elif which_soc == 'amber':
-    pt_signoff.extend_inputs( ['dragonphy_top_tt.db'] )
-
-  route.extend_inputs( ['pre-route.tcl'] )
-  signoff.extend_inputs( sealring.all_outputs() )
-  signoff.extend_inputs( netlist_fixing.all_outputs() )
-  # These steps need timing info for cgra tiles
-
-  hier_steps = \
-    [ iflow, init, power, place, cts, postcts_hold,
-      route, postroute, signoff]
-
-  for step in hier_steps:
-    step.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'] )
-    step.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'] )
-    step.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'] )
-    step.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
+    # Send in the clones
 
     if which_soc == 'onyx':
-      step.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'] )
-      step.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'] )
+        # Second sram_node because soc has 2 types of srams
+        gen_sram_2 = gen_sram.clone()
+        gen_sram_2.set_name( 'gen_sram_macro_2' )
+
+    # 'power' step now gets its own design-rule check
+    power_drc = drc.clone()
+    power_drc.set_name( 'power-drc' )
+
+    # Antenna DRC Check
+    antenna_drc = drc.clone()
+    antenna_drc.set_name( 'antenna-drc' )
+
+    if which_soc == 'onyx':
+        # Pre-Fill DRC Check
+        prefill_drc = drc.clone()
+        prefill_drc.set_name( 'pre-fill-drc' )
+
+        # Separate ADK for LVS so it has PM cells when needed
+        lvs_adk = adk.clone()
+        lvs_adk.set_name( 'lvs_adk' )
+
+    # Add cgra tile macro inputs to downstream nodes
+
+    synth.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'] )
+    synth.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'] )
+    synth.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'] )
+    synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
+
+    if which_soc == 'onyx':
+        synth.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'] )
+        synth.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'] )
 
     elif which_soc == 'amber':
-      step.extend_inputs( ['dragonphy_top_tt.lib', 'dragonphy_top.lef'] )
-      step.extend_inputs( ['dragonphy_RDL.lef'] )
+        # Exclude dragonphy_top from synth inputs to prevent
+        # floating dragonphy inputs from being tied to 0
+        synth.extend_inputs( ['dragonphy_top.lef'] )
 
-  # Need all block gds's to merge into the final layout
-  gdsmerge_nodes = [signoff, power]
-  for node in gdsmerge_nodes:
-      node.extend_inputs( ['tile_array.gds'] )
-      node.extend_inputs( ['glb_top.gds'] )
-      node.extend_inputs( ['global_controller.gds'] )
-      node.extend_inputs( ['sram.gds'] )
+    pt_signoff.extend_inputs( ['tile_array_tt.db'] )
+    pt_signoff.extend_inputs( ['glb_top_tt.db'] )
+    pt_signoff.extend_inputs( ['global_controller_tt.db'] )
+    pt_signoff.extend_inputs( ['sram_tt.db'] )
 
-      if which_soc == 'onyx':
-        node.extend_inputs( ['sram_2.gds'] )
-        node.extend_inputs( ['xgcd.gds'] )
-
-      elif which_soc == 'amber':
-        node.extend_inputs( ['dragonphy_top.gds'] )
-        node.extend_inputs( ['dragonphy_RDL.gds'] )
-
-  # Need extracted spice files for both tile types to do LVS
-
-  lvs.extend_inputs( ['tile_array.lvs.v'] )
-  lvs.extend_inputs( ['tile_array.sram.spi'] )
-  lvs.extend_inputs( ['glb_top.lvs.v'] )
-  lvs.extend_inputs( ['glb_top.sram.spi'] )
-  lvs.extend_inputs( ['global_controller.lvs.v'] )
-  lvs.extend_inputs( ['sram.spi'] )
-
-  if which_soc == 'onyx':
-    lvs.extend_inputs( ['sram_2.spi'] )
-    lvs.extend_inputs( ['xgcd.lvs.v'] )
-    lvs.extend_inputs( ['xgcd-255.lvs.v'] )
-    lvs.extend_inputs( ['xgcd-1279.lvs.v'] )
-    lvs.extend_inputs( ['ring_oscillator.lvs.v'] )
-
-  elif which_soc == 'amber':
-    lvs.extend_inputs( ['dragonphy_top.spi'] )
-
-  lvs.extend_inputs( ['adk_lvs2'] )
-
-  # Add extra input edges to innovus steps that need custom tweaks
-
-  init.extend_inputs( custom_init.all_outputs() )
-  init.extend_inputs( init_fc.all_outputs() )
-  power.extend_inputs( custom_power.all_outputs() )
-  if which_soc == 'onyx':
-    cts.extend_inputs( custom_cts.all_outputs() )
-
-  synth.extend_inputs( soc_rtl.all_outputs() )
-  synth.extend_inputs( read_design.all_outputs() )
-  synth.extend_inputs( ["cons_scripts"] )
-
-  power.extend_outputs( ["design-merged.gds"] )
-
-  if parameters['interconnect_only'] is False:
-    rtl.extend_outputs( ['header'] )
-    rtl.extend_postconditions( ["assert File( 'outputs/header' ) "] )
-
-  # TSMC needs streamout *without* the (new) default -uniquify flag
-  # This python method finds 'stream-out.tcl' and strips out that flag.
-  if adk_name == "tsmc16":
-    from common.streamout_no_uniquify import streamout_no_uniquify
-    streamout_no_uniquify(iflow)
-
-  if adk_name == "tsmc16":
-     # Replace default onyx scripts with amber versions instead
-     cmd1 = "cp rtl-scripts-amber/nic400_design_files.tcl  rtl-scripts"
-     cmd2 = "cp rtl-scripts-amber/nic400_include_paths.tcl rtl-scripts"
-     cmd3 = "cp rtl-scripts-amber/soc_design_files.tcl     rtl-scripts"
-     soc_rtl.pre_extend_commands( [ cmd1 ] )
-     soc_rtl.pre_extend_commands( [ cmd2 ] )
-     soc_rtl.pre_extend_commands( [ cmd3 ] )
-
-  #-----------------------------------------------------------------------
-  # Graph -- Add nodes
-  #-----------------------------------------------------------------------
-
-  g.add_step( info              )
-  g.add_step( rtl               )
-  g.add_step( soc_rtl           )
-  g.add_step( gen_sram          )
-  g.add_step( tile_array        )
-  g.add_step( glb_top           )
-  g.add_step( global_controller )
-  g.add_step( constraints       )
-  g.add_step( read_design       )
-  g.add_step( synth             )
-  g.add_step( iflow             )
-  g.add_step( init              )
-  g.add_step( init_fc           )
-  g.add_step( io_file           )
-  g.add_step( custom_init       )
-  g.add_step( power             )
-  g.add_step( custom_power      )
-  g.add_step( place             )
-  g.add_step( cts               )
-  g.add_step( postcts_hold      )
-  g.add_step( pre_route         )
-  g.add_step( route             )
-  g.add_step( postroute         )
-  g.add_step( postroute_hold    )
-  g.add_step( sealring          )
-  g.add_step( netlist_fixing    )
-  g.add_step( signoff           )
-  g.add_step( pt_signoff        )
-  g.add_step( fill              )
-  g.add_step( merge_fill        )
-  g.add_step( drc               )
-  g.add_step( antenna_drc       )
-  g.add_step( lvs               )
-  g.add_step( custom_lvs        )
-  g.add_step( debugcalibre      )
-
-  # Post-Power DRC check
-  g.add_step( power_drc         )
-
-  # App test nodes
-  g.add_step( cgra_rtl_sim_compile )
-  g.add_step( cgra_sim_build       )
-  g.add_step( cgra_rtl_sim_run     )
-  # g.add_step( cgra_gl_sim_compile )
-
-  # Onyx-specific nodes
-  if which_soc == 'onyx':
-    g.add_step( gen_sram_2        )
-    g.add_step( xgcd              )
-    g.add_step( custom_cts        )
-    g.add_step( prefill_drc       )
-    g.add_step( merge_gdr         )
-    g.add_step( drc_pm            )
-    g.add_step( drc_dp            )
-    g.add_step( drc_mas           )
-    
-    # Different adk view for lvs
-    g.add_step( lvs_adk           )
-
-  # Amber-specific nodes
-  if which_soc == 'amber':
-    g.add_step( merge_rdl         )
-    g.add_step( dragonphy         )
-
-  #-----------------------------------------------------------------------
-  # Graph -- Add edges
-  #-----------------------------------------------------------------------
-
-  # Connect by name
-
-  g.connect_by_name( adk,      gen_sram       )
-  g.connect_by_name( adk,      synth          )
-  g.connect_by_name( adk,      iflow          )
-  g.connect_by_name( adk,      init           )
-  g.connect_by_name( adk,      power          )
-  g.connect_by_name( adk,      place          )
-  g.connect_by_name( adk,      cts            )
-  g.connect_by_name( adk,      postcts_hold   )
-  g.connect_by_name( adk,      route          )
-  g.connect_by_name( adk,      postroute      )
-  g.connect_by_name( adk,      postroute_hold )
-  g.connect_by_name( adk,      signoff        )
-  g.connect_by_name( adk,      fill           )
-  g.connect_by_name( adk,      merge_fill     )
-  g.connect_by_name( adk,      drc            )
-  g.connect_by_name( adk,      antenna_drc    )
-
-  # Onyx-specific connections
-  if which_soc == 'onyx':
-    g.connect_by_name( adk,      gen_sram_2     )
-    g.connect_by_name( adk,      prefill_drc    )
-    g.connect_by_name( adk,      merge_gdr      )
-    g.connect_by_name( adk,      drc_pm         )
-    g.connect_by_name( adk,      drc_dp         )
-    g.connect_by_name( adk,      drc_mas        )
-    # Use lvs_adk so lvs has access to cells used in lower-level blocks
-    g.connect_by_name( lvs_adk,  lvs            )
-
-  # Amber-specific connections
-  if which_soc == 'amber':
-    g.connect_by_name( adk,      merge_rdl      )
-    g.connect_by_name( adk,      lvs            )
-
-  # Post-Power DRC check
-  g.connect_by_name( adk,      power_drc )
-
-  # Connect RTL verification nodes
-  g.connect_by_name( rtl, cgra_rtl_sim_compile )
-  g.connect_by_name( cgra_sim_build, cgra_rtl_sim_run )
-  g.connect_by_name( cgra_rtl_sim_compile, cgra_rtl_sim_run )
-
-  # Connect GL verification nodes
-  # g.connect_by_name( signoff, cgra_gl_sim_compile )
-
-  # All of the blocks within this hierarchical design
-  # Skip these if we're doing soc_only
-  if parameters['soc_only'] == False:
-      blocks = [tile_array, glb_top, global_controller]
-      if which_soc == 'onyx':
-        blocks += [xgcd]
-      elif which_soc == 'amber':
-        blocks += [dragonphy]
-
-      for block in blocks:
-          g.connect_by_name( block, synth          )
-          g.connect_by_name( block, iflow          )
-          g.connect_by_name( block, init           )
-          g.connect_by_name( block, power          )
-          g.connect_by_name( block, place          )
-          g.connect_by_name( block, cts            )
-          g.connect_by_name( block, postcts_hold   )
-          g.connect_by_name( block, route          )
-          g.connect_by_name( block, postroute      )
-          g.connect_by_name( block, postroute_hold )
-          g.connect_by_name( block, signoff        )
-          g.connect_by_name( block, pt_signoff     )
-          g.connect_by_name( block, drc            )
-          g.connect_by_name( block, lvs            )
-      # Tile_array can use rtl from rtl node
-      g.connect_by_name( rtl, tile_array )
-      # glb_top can use rtl from rtl node
-      g.connect_by_name( rtl, glb_top )
-      # global_controller can use rtl from rtl node
-      g.connect_by_name( rtl, global_controller )
-
-  g.connect_by_name( rtl,         synth     )
-  g.connect_by_name( soc_rtl,     synth        )
-  g.connect_by_name( constraints, synth        )
-  g.connect_by_name( read_design, synth        )
-
-  g.connect_by_name( soc_rtl,  io_file      )
-
-  g.connect_by_name( synth,       iflow        )
-  g.connect_by_name( synth,       init         )
-  g.connect_by_name( synth,       power        )
-  g.connect_by_name( synth,       place        )
-  g.connect_by_name( synth,       cts          )
-
-  g.connect_by_name( iflow,    init           )
-  g.connect_by_name( iflow,    power          )
-  g.connect_by_name( iflow,    place          )
-  g.connect_by_name( iflow,    cts            )
-  g.connect_by_name( iflow,    postcts_hold   )
-  g.connect_by_name( iflow,    route          )
-  g.connect_by_name( iflow,    postroute      )
-  g.connect_by_name( iflow,    postroute_hold )
-  g.connect_by_name( iflow,    signoff        )
-
-  g.connect_by_name( custom_init,  init     )
-  g.connect_by_name( custom_lvs,   lvs      )
-  g.connect_by_name( custom_power, power    )
-
-  if which_soc == 'onyx':
-    g.connect_by_name( custom_cts,   cts      )
-
-  # Connect gen_sram_macro node(s) to all downstream nodes that
-  # need them
-  sram_nodes = [synth, iflow, init, power, place, cts, postcts_hold,
-                route, postroute, postroute_hold, signoff, pt_signoff,
-                drc, lvs]
-  for node in sram_nodes:
-    g.connect_by_name( gen_sram, node )
     if which_soc == 'onyx':
-      for sram_output in gen_sram_2.all_outputs():
-          node_input = sram_output.replace('sram', 'sram_2')
-          if node_input in node.all_inputs():
-              g.connect(gen_sram_2.o(sram_output), node.i(node_input))
+        pt_signoff.extend_inputs( ['sram_2_tt.db'] )
+        pt_signoff.extend_inputs( ['xgcd_tt.db'] )
 
-  # Full chip floorplan stuff
-  g.connect_by_name( io_file, init_fc )
-  g.connect_by_name( init_fc, init    )
+    elif which_soc == 'amber':
+        pt_signoff.extend_inputs( ['dragonphy_top_tt.db'] )
 
-  g.connect_by_name( init,           power          )
-  g.connect_by_name( power,          place          )
-  g.connect_by_name( place,          cts            )
-  g.connect_by_name( cts,            postcts_hold   )
-  g.connect_by_name( postcts_hold,   route          )
-  g.connect_by_name( route,          postroute      )
-  g.connect_by_name( postroute,      postroute_hold )
-  g.connect_by_name( postroute_hold, signoff        )
-  g.connect_by_name( signoff,        lvs            )
+    route.extend_inputs( ['pre-route.tcl'] )
+    signoff.extend_inputs( sealring.all_outputs() )
+    signoff.extend_inputs( netlist_fixing.all_outputs() )
+    # These steps need timing info for cgra tiles
 
-  if which_soc == 'onyx':
-      # Merge guardring gds into design
-      g.connect(signoff.o('design-merged.gds'), merge_gdr.i('design.gds'))
+    hier_steps = \
+      [ iflow, init, power, place, cts, postcts_hold,
+        route, postroute, signoff]
 
-      # Send gds with sealring to drc, fill, and lvs
-      g.connect_by_name( merge_gdr, lvs )
-      # Run pre-fill DRC after signoff
-      g.connect_by_name( merge_gdr, prefill_drc )
-      # Run PM DRC after signoff
-      g.connect_by_name( merge_gdr, drc_pm )
+    for step in hier_steps:
+        step.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'] )
+        step.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'] )
+        step.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'] )
+        step.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
 
-      # For GF, Fill is already merged during fill step
+        if which_soc == 'onyx':
+            step.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'] )
+            step.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'] )
 
-      # Run Fill on merged GDS
-      g.connect( merge_gdr.o('design_merged.gds'), fill.i('design.gds') )
+        elif which_soc == 'amber':
+            step.extend_inputs( ['dragonphy_top_tt.lib', 'dragonphy_top.lef'] )
+            step.extend_inputs( ['dragonphy_RDL.lef'] )
 
-      # Connect fill directly to DRC steps
-      g.connect( fill.o('fill.gds'), drc_dp.i('design_merged.gds') )
-      g.connect( fill.o('fill.gds'), antenna_drc.i('design_merged.gds') )
-      # Connect drc_dp output gds to final signoff drc
-      g.connect_by_name( drc_dp, drc )
-      g.connect_by_name( drc_dp, drc_mas )
+    # Need all block gds's to merge into the final layout
+    gdsmerge_nodes = [signoff, power]
+    for node in gdsmerge_nodes:
+        node.extend_inputs( ['tile_array.gds'] )
+        node.extend_inputs( ['glb_top.gds'] )
+        node.extend_inputs( ['global_controller.gds'] )
+        node.extend_inputs( ['sram.gds'] )
 
-  if which_soc == 'amber':
-      g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
-      g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
+        if which_soc == 'onyx':
+            node.extend_inputs( ['sram_2.gds'] )
+            node.extend_inputs( ['xgcd.gds'] )
 
-      # Skipping
-      g.connect( signoff.o('design-merged.gds'),   merge_rdl.i('design.gds') )
-      g.connect( dragonphy.o('dragonphy_RDL.gds'), merge_rdl.i('child.gds') )
-      g.connect_by_name( merge_rdl, lvs )
+        elif which_soc == 'amber':
+            node.extend_inputs( ['dragonphy_top.gds'] )
+            node.extend_inputs( ['dragonphy_RDL.gds'] )
 
-      # Run Fill on merged GDS
-      g.connect( merge_rdl.o('design_merged.gds'), fill.i('design.gds') )
+    # Need extracted spice files for both tile types to do LVS
 
-      # Merge fill
-      g.connect( merge_rdl.o('design_merged.gds'), merge_fill.i('design.gds') )
-      g.connect( fill.o('fill.gds'), merge_fill.i('child.gds') )
+    lvs.extend_inputs( ['tile_array.lvs.v'] )
+    lvs.extend_inputs( ['tile_array.sram.spi'] )
+    lvs.extend_inputs( ['glb_top.lvs.v'] )
+    lvs.extend_inputs( ['glb_top.sram.spi'] )
+    lvs.extend_inputs( ['global_controller.lvs.v'] )
+    lvs.extend_inputs( ['sram.spi'] )
 
-      # Run DRC on merged and filled gds
-      g.connect_by_name( merge_fill, drc )
-      g.connect_by_name( merge_fill, antenna_drc )
+    if which_soc == 'onyx':
+        lvs.extend_inputs( ['sram_2.spi'] )
+        lvs.extend_inputs( ['xgcd.lvs.v'] )
+        lvs.extend_inputs( ['xgcd-255.lvs.v'] )
+        lvs.extend_inputs( ['xgcd-1279.lvs.v'] )
+        lvs.extend_inputs( ['ring_oscillator.lvs.v'] )
 
-  g.connect_by_name( adk,          pt_signoff   )
-  g.connect_by_name( signoff,      pt_signoff   )
+    elif which_soc == 'amber':
+        lvs.extend_inputs( ['dragonphy_top.spi'] )
 
-  g.connect_by_name( adk,      debugcalibre )
-  g.connect_by_name( synth,    debugcalibre )
-  g.connect_by_name( iflow,    debugcalibre )
-  g.connect_by_name( signoff,  debugcalibre )
+    lvs.extend_inputs( ['adk_lvs2'] )
 
-  if which_soc == 'amber':
-    g.connect_by_name( drc,      debugcalibre )
-    g.connect_by_name( lvs,      debugcalibre )
+    # Add extra input edges to innovus steps that need custom tweaks
 
-  g.connect_by_name( pre_route, route )
-  g.connect_by_name( sealring, signoff )
-  g.connect_by_name( netlist_fixing, signoff )
+    init.extend_inputs( custom_init.all_outputs() )
+    init.extend_inputs( init_fc.all_outputs() )
+    power.extend_inputs( custom_power.all_outputs() )
+    if which_soc == 'onyx':
+        cts.extend_inputs( custom_cts.all_outputs() )
 
-  # Post-Power DRC
-  g.connect(power.o('design-merged.gds'), power_drc.i('design_merged.gds'))
-  #-----------------------------------------------------------------------
-  # Parameterize
-  #-----------------------------------------------------------------------
+    synth.extend_inputs( soc_rtl.all_outputs() )
+    synth.extend_inputs( read_design.all_outputs() )
+    synth.extend_inputs( ["cons_scripts"] )
 
-  # Allow user to override parms with env in a limited sort of way
-  parameters = sr_override_parms( parameters )
-  print(f'parameters["hold_target_slack"]={parameters["hold_target_slack"]}')
-  g.update_params( parameters )
+    power.extend_outputs( ["design-merged.gds"] )
 
-  if which_soc == 'onyx':
-    # Provide different parameter set to second sram node, so it can actually 
-    # generate a different sram
-    gen_sram_2.update_params( sram_2_params )
-  
-    # LVS adk has separate view parameter
-    lvs_adk.update_params({ 'adk_view' : parameters['lvs_adk_view']})
+    if parameters['interconnect_only'] is False:
+        rtl.extend_outputs( ['header'] )
+        rtl.extend_postconditions( ["assert File( 'outputs/header' ) "] )
 
-  # Since we are adding an additional input script to the generic Innovus
-  # steps, we modify the order parameter for that node which determines
-  # which scripts get run and when they get run.
+    # TSMC needs streamout *without* the (new) default -uniquify flag
+    # This python method finds 'stream-out.tcl' and strips out that flag.
+    if adk_name == "tsmc16":
+        from common.streamout_no_uniquify import streamout_no_uniquify
+        streamout_no_uniquify(iflow)
 
-  # DC needs these param to set the NO_CGRA macro
-  synth.update_params({'soc_only': parameters['soc_only']}, True)
-  # DC needs these params to set macros in soc rtl
-  synth.update_params({'TLX_FWD_DATA_LO_WIDTH' : parameters['TLX_FWD_DATA_LO_WIDTH']}, True)
-  synth.update_params({'TLX_REV_DATA_LO_WIDTH' : parameters['TLX_REV_DATA_LO_WIDTH']}, True)
-  init.update_params({'soc_only': parameters['soc_only']}, True)
+    if adk_name == "tsmc16":
+        # Replace default onyx scripts with amber versions instead
+        cmd1 = "cp rtl-scripts-amber/nic400_design_files.tcl  rtl-scripts"
+        cmd2 = "cp rtl-scripts-amber/nic400_include_paths.tcl rtl-scripts"
+        cmd3 = "cp rtl-scripts-amber/soc_design_files.tcl     rtl-scripts"
+        soc_rtl.pre_extend_commands( [ cmd1 ] )
+        soc_rtl.pre_extend_commands( [ cmd2 ] )
+        soc_rtl.pre_extend_commands( [ cmd3 ] )
 
-  if which_soc == 'amber': init.update_params(
-    {'order': [
-      'main.tcl','quality-of-life.tcl',
-      'stylus-compatibility-procs.tcl','floorplan.tcl','io-fillers.tcl',
-      'alignment-cells.tcl',
-      'analog-bumps/route-phy-bumps.tcl',
-      'analog-bumps/bump-connect.tcl',
-      'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
-      'place-macros.tcl', 'dont-touch.tcl'
-    ]}
-  )
+    #-----------------------------------------------------------------------
+    # Graph -- Add nodes
+    #-----------------------------------------------------------------------
 
-  if which_soc == 'onyx': init.update_params(
-    {'order': [
-      'main.tcl','quality-of-life.tcl',
-      'stylus-compatibility-procs.tcl','floorplan.tcl','io-fillers.tcl',
-      'alignment-cells.tcl',
-      #'analog-bumps/route-phy-bumps.tcl',
-      #'analog-bumps/bump-connect.tcl',
-      'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
-      'place-macros.tcl', 'dont-touch.tcl'
-    ]}
-  )
+    g.add_step( info              )
+    g.add_step( rtl               )
+    g.add_step( soc_rtl           )
+    g.add_step( gen_sram          )
+    g.add_step( tile_array        )
+    g.add_step( glb_top           )
+    g.add_step( global_controller )
+    g.add_step( constraints       )
+    g.add_step( read_design       )
+    g.add_step( synth             )
+    g.add_step( iflow             )
+    g.add_step( init              )
+    g.add_step( init_fc           )
+    g.add_step( io_file           )
+    g.add_step( custom_init       )
+    g.add_step( power             )
+    g.add_step( custom_power      )
+    g.add_step( place             )
+    g.add_step( cts               )
+    g.add_step( postcts_hold      )
+    g.add_step( pre_route         )
+    g.add_step( route             )
+    g.add_step( postroute         )
+    g.add_step( postroute_hold    )
+    g.add_step( sealring          )
+    g.add_step( netlist_fixing    )
+    g.add_step( signoff           )
+    g.add_step( pt_signoff        )
+    g.add_step( fill              )
+    g.add_step( merge_fill        )
+    g.add_step( drc               )
+    g.add_step( antenna_drc       )
+    g.add_step( lvs               )
+    g.add_step( custom_lvs        )
+    g.add_step( debugcalibre      )
 
-  # glb_top parameters update
-  glb_top.update_params({'array_width': parameters['array_width']}, True)
-  glb_top.update_params({'glb_tile_mem_size': parameters['glb_tile_mem_size']}, True)
-  glb_top.update_params({'num_glb_tiles': parameters['num_glb_tiles']}, True)
+    # Post-Power DRC check
+    g.add_step( power_drc         )
 
-  # App test parameters update
-  cgra_rtl_sim_compile.update_params({'array_width': parameters['array_width']}, True)
-  cgra_rtl_sim_compile.update_params({'array_height': parameters['array_height']}, True)
-  cgra_rtl_sim_compile.update_params({'clock_period': parameters['clock_period']}, True)
-  cgra_rtl_sim_compile.update_params({'glb_tile_mem_size': parameters['glb_tile_mem_size']}, True)
+    # App test nodes
+    g.add_step( cgra_rtl_sim_compile )
+    g.add_step( cgra_sim_build       )
+    g.add_step( cgra_rtl_sim_run     )
+    # g.add_step( cgra_gl_sim_compile )
 
-  cgra_rtl_sim_run.update_params({'cgra_apps': parameters['cgra_apps']}, True)
+    # Onyx-specific nodes
+    if which_soc == 'onyx':
+        g.add_step( gen_sram_2        )
+        g.add_step( xgcd              )
+        g.add_step( custom_cts        )
+        g.add_step( prefill_drc       )
+        g.add_step( merge_gdr         )
+        g.add_step( drc_pm            )
+        g.add_step( drc_dp            )
+        g.add_step( drc_mas           )
 
-  # Power node order manipulation
-  order = power.get_param('order')
-  # Move endcap/welltap insertion to end of power step to improve runtime
-  order.append( 'add-endcaps-welltaps.tcl' )
-  # Stream out post-power GDS so that we can run DRC here
-  order.append( 'innovus-foundation-flow/custom-scripts/stream-out.tcl' )
-  order.append( 'attach-results-to-outputs.tcl' )
-  power.update_params( { 'order': order } )
+        # Different adk view for lvs
+        g.add_step( lvs_adk           )
 
-  # Add pre-route plugin to insert skip_routing commands
-  order = route.get_param('order')
-  order.insert( 0, 'pre-route.tcl' )
-  route.update_params( { 'order': order } )
+    # Amber-specific nodes
+    if which_soc == 'amber':
+        g.add_step( merge_rdl         )
+        g.add_step( dragonphy         )
 
-  # Signoff order additions
-  order = signoff.get_param('order')
-  # Add sealring at beginning of signoff, so it's in before we stream out GDS
-  if parameters['include_sealring'] == True:
-      order.insert(0, 'add-sealring.tcl')
-  # Add netlist-fixing script before we save new netlist
-  index = order.index( 'generate-results.tcl' )
-  order.insert( index, 'netlist-fixing.tcl' )
-  signoff.update_params( { 'order': order } )
+    #-----------------------------------------------------------------------
+    # Graph -- Add edges
+    #-----------------------------------------------------------------------
 
-  if which_soc == 'amber':
-    merge_rdl.update_params( {'coord_x': parameters['dragonphy_rdl_x'], 'coord_y': parameters['dragonphy_rdl_y'], 'flatten_child': True,
-                            'design_top_cell': parameters['design_name'], 'child_top_cell': 'dragonphy_RDL'} )
+    # Connect by name
 
-    merge_fill.update_params( {'design_top_cell': parameters['design_name'], 'child_top_cell': f"{parameters['design_name']}_F16a"} )
+    g.connect_by_name( adk,      gen_sram       )
+    g.connect_by_name( adk,      synth          )
+    g.connect_by_name( adk,      iflow          )
+    g.connect_by_name( adk,      init           )
+    g.connect_by_name( adk,      power          )
+    g.connect_by_name( adk,      place          )
+    g.connect_by_name( adk,      cts            )
+    g.connect_by_name( adk,      postcts_hold   )
+    g.connect_by_name( adk,      route          )
+    g.connect_by_name( adk,      postroute      )
+    g.connect_by_name( adk,      postroute_hold )
+    g.connect_by_name( adk,      signoff        )
+    g.connect_by_name( adk,      fill           )
+    g.connect_by_name( adk,      merge_fill     )
+    g.connect_by_name( adk,      drc            )
+    g.connect_by_name( adk,      antenna_drc    )
 
-    # Antenna DRC node needs to use antenna rule deck
-    antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'] } )
+    # Onyx-specific connections
+    if which_soc == 'onyx':
+        g.connect_by_name( adk,      gen_sram_2     )
+        g.connect_by_name( adk,      prefill_drc    )
+        g.connect_by_name( adk,      merge_gdr      )
+        g.connect_by_name( adk,      drc_pm         )
+        g.connect_by_name( adk,      drc_dp         )
+        g.connect_by_name( adk,      drc_mas        )
+        # Use lvs_adk so lvs has access to cells used in lower-level blocks
+        g.connect_by_name( lvs_adk,  lvs            )
 
-  if which_soc == 'onyx':
+    # Amber-specific connections
+    if which_soc == 'amber':
+        g.connect_by_name( adk,      merge_rdl      )
+        g.connect_by_name( adk,      lvs            )
 
-    merge_fill.update_params( {'design_top_cell': parameters['design_name'], 'child_top_cell': f"{parameters['design_name']}_F16a"} )
-  
-    # need to give coordinates for guardring
-    merge_gdr.update_params( guardring_params )
- 
-    # Antenna DRC node needs to use antenna rule deck
-    antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'],
-                                 'drc_env_setup': parameters['antenna_drc_env_setup'] } )
+    # Post-Power DRC check
+    g.connect_by_name( adk,      power_drc )
 
-  # Power DRC node should use block level rule deck to improve runtimes and not report false errors
-  power_drc.update_params( {'drc_rule_deck': parameters['power_drc_rule_deck'] } )
+    # Connect RTL verification nodes
+    g.connect_by_name( rtl, cgra_rtl_sim_compile )
+    g.connect_by_name( cgra_sim_build, cgra_rtl_sim_run )
+    g.connect_by_name( cgra_rtl_sim_compile, cgra_rtl_sim_run )
 
-  return g
+    # Connect GL verification nodes
+    # g.connect_by_name( signoff, cgra_gl_sim_compile )
+
+    # All of the blocks within this hierarchical design
+    # Skip these if we're doing soc_only
+    if parameters['soc_only'] == False:
+        blocks = [tile_array, glb_top, global_controller]
+        if which_soc == 'onyx':
+            blocks += [xgcd]
+        elif which_soc == 'amber':
+            blocks += [dragonphy]
+
+        for block in blocks:
+            g.connect_by_name( block, synth          )
+            g.connect_by_name( block, iflow          )
+            g.connect_by_name( block, init           )
+            g.connect_by_name( block, power          )
+            g.connect_by_name( block, place          )
+            g.connect_by_name( block, cts            )
+            g.connect_by_name( block, postcts_hold   )
+            g.connect_by_name( block, route          )
+            g.connect_by_name( block, postroute      )
+            g.connect_by_name( block, postroute_hold )
+            g.connect_by_name( block, signoff        )
+            g.connect_by_name( block, pt_signoff     )
+            g.connect_by_name( block, drc            )
+            g.connect_by_name( block, lvs            )
+        # Tile_array can use rtl from rtl node
+        g.connect_by_name( rtl, tile_array )
+        # glb_top can use rtl from rtl node
+        g.connect_by_name( rtl, glb_top )
+        # global_controller can use rtl from rtl node
+        g.connect_by_name( rtl, global_controller )
+
+    g.connect_by_name( rtl,         synth     )
+    g.connect_by_name( soc_rtl,     synth        )
+    g.connect_by_name( constraints, synth        )
+    g.connect_by_name( read_design, synth        )
+
+    g.connect_by_name( soc_rtl,  io_file      )
+
+    g.connect_by_name( synth,       iflow        )
+    g.connect_by_name( synth,       init         )
+    g.connect_by_name( synth,       power        )
+    g.connect_by_name( synth,       place        )
+    g.connect_by_name( synth,       cts          )
+
+    g.connect_by_name( iflow,    init           )
+    g.connect_by_name( iflow,    power          )
+    g.connect_by_name( iflow,    place          )
+    g.connect_by_name( iflow,    cts            )
+    g.connect_by_name( iflow,    postcts_hold   )
+    g.connect_by_name( iflow,    route          )
+    g.connect_by_name( iflow,    postroute      )
+    g.connect_by_name( iflow,    postroute_hold )
+    g.connect_by_name( iflow,    signoff        )
+
+    g.connect_by_name( custom_init,  init     )
+    g.connect_by_name( custom_lvs,   lvs      )
+    g.connect_by_name( custom_power, power    )
+
+    if which_soc == 'onyx':
+        g.connect_by_name( custom_cts,   cts      )
+
+    # Connect gen_sram_macro node(s) to all downstream nodes that
+    # need them
+    sram_nodes = [synth, iflow, init, power, place, cts, postcts_hold,
+                  route, postroute, postroute_hold, signoff, pt_signoff,
+                  drc, lvs]
+    for node in sram_nodes:
+        g.connect_by_name( gen_sram, node )
+        if which_soc == 'onyx':
+            for sram_output in gen_sram_2.all_outputs():
+                node_input = sram_output.replace('sram', 'sram_2')
+                if node_input in node.all_inputs():
+                    g.connect(gen_sram_2.o(sram_output), node.i(node_input))
+
+    # Full chip floorplan stuff
+    g.connect_by_name( io_file, init_fc )
+    g.connect_by_name( init_fc, init    )
+
+    g.connect_by_name( init,           power          )
+    g.connect_by_name( power,          place          )
+    g.connect_by_name( place,          cts            )
+    g.connect_by_name( cts,            postcts_hold   )
+    g.connect_by_name( postcts_hold,   route          )
+    g.connect_by_name( route,          postroute      )
+    g.connect_by_name( postroute,      postroute_hold )
+    g.connect_by_name( postroute_hold, signoff        )
+    g.connect_by_name( signoff,        lvs            )
+
+    if which_soc == 'onyx':
+        # Merge guardring gds into design
+        g.connect(signoff.o('design-merged.gds'), merge_gdr.i('design.gds'))
+
+        # Send gds with sealring to drc, fill, and lvs
+        g.connect_by_name( merge_gdr, lvs )
+        # Run pre-fill DRC after signoff
+        g.connect_by_name( merge_gdr, prefill_drc )
+        # Run PM DRC after signoff
+        g.connect_by_name( merge_gdr, drc_pm )
+
+        # For GF, Fill is already merged during fill step
+
+        # Run Fill on merged GDS
+        g.connect( merge_gdr.o('design_merged.gds'), fill.i('design.gds') )
+
+        # Connect fill directly to DRC steps
+        g.connect( fill.o('fill.gds'), drc_dp.i('design_merged.gds') )
+        g.connect( fill.o('fill.gds'), antenna_drc.i('design_merged.gds') )
+        # Connect drc_dp output gds to final signoff drc
+        g.connect_by_name( drc_dp, drc )
+        g.connect_by_name( drc_dp, drc_mas )
+
+    if which_soc == 'amber':
+        g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
+        g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
+
+        # Skipping
+        g.connect( signoff.o('design-merged.gds'),   merge_rdl.i('design.gds') )
+        g.connect( dragonphy.o('dragonphy_RDL.gds'), merge_rdl.i('child.gds') )
+        g.connect_by_name( merge_rdl, lvs )
+
+        # Run Fill on merged GDS
+        g.connect( merge_rdl.o('design_merged.gds'), fill.i('design.gds') )
+
+        # Merge fill
+        g.connect( merge_rdl.o('design_merged.gds'), merge_fill.i('design.gds') )
+        g.connect( fill.o('fill.gds'), merge_fill.i('child.gds') )
+
+        # Run DRC on merged and filled gds
+        g.connect_by_name( merge_fill, drc )
+        g.connect_by_name( merge_fill, antenna_drc )
+
+    g.connect_by_name( adk,          pt_signoff   )
+    g.connect_by_name( signoff,      pt_signoff   )
+
+    g.connect_by_name( adk,      debugcalibre )
+    g.connect_by_name( synth,    debugcalibre )
+    g.connect_by_name( iflow,    debugcalibre )
+    g.connect_by_name( signoff,  debugcalibre )
+
+    if which_soc == 'amber':
+        g.connect_by_name( drc,      debugcalibre )
+        g.connect_by_name( lvs,      debugcalibre )
+
+    g.connect_by_name( pre_route, route )
+    g.connect_by_name( sealring, signoff )
+    g.connect_by_name( netlist_fixing, signoff )
+
+    # Post-Power DRC
+    g.connect(power.o('design-merged.gds'), power_drc.i('design_merged.gds'))
+    #-----------------------------------------------------------------------
+    # Parameterize
+    #-----------------------------------------------------------------------
+
+    # Allow user to override parms with env in a limited sort of way
+    parameters = sr_override_parms( parameters )
+    print(f'parameters["hold_target_slack"]={parameters["hold_target_slack"]}')
+    g.update_params( parameters )
+
+    if which_soc == 'onyx':
+        # Provide different parameter set to second sram node, so it can actually 
+        # generate a different sram
+        gen_sram_2.update_params( sram_2_params )
+
+        # LVS adk has separate view parameter
+        lvs_adk.update_params({ 'adk_view' : parameters['lvs_adk_view']})
+
+    # Since we are adding an additional input script to the generic Innovus
+    # steps, we modify the order parameter for that node which determines
+    # which scripts get run and when they get run.
+
+    # DC needs these param to set the NO_CGRA macro
+    synth.update_params({'soc_only': parameters['soc_only']}, True)
+    # DC needs these params to set macros in soc rtl
+    synth.update_params({'TLX_FWD_DATA_LO_WIDTH' : parameters['TLX_FWD_DATA_LO_WIDTH']}, True)
+    synth.update_params({'TLX_REV_DATA_LO_WIDTH' : parameters['TLX_REV_DATA_LO_WIDTH']}, True)
+    init.update_params({'soc_only': parameters['soc_only']}, True)
+
+    if which_soc == 'amber': init.update_params(
+      {'order': [
+        'main.tcl','quality-of-life.tcl',
+        'stylus-compatibility-procs.tcl','floorplan.tcl','io-fillers.tcl',
+        'alignment-cells.tcl',
+        'analog-bumps/route-phy-bumps.tcl',
+        'analog-bumps/bump-connect.tcl',
+        'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
+        'place-macros.tcl', 'dont-touch.tcl'
+      ]}
+    )
+
+    if which_soc == 'onyx': init.update_params(
+      {'order': [
+        'main.tcl','quality-of-life.tcl',
+        'stylus-compatibility-procs.tcl','floorplan.tcl','io-fillers.tcl',
+        'alignment-cells.tcl',
+        #'analog-bumps/route-phy-bumps.tcl',
+        #'analog-bumps/bump-connect.tcl',
+        'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
+        'place-macros.tcl', 'dont-touch.tcl'
+      ]}
+    )
+
+    # glb_top parameters update
+    glb_top.update_params({'array_width': parameters['array_width']}, True)
+    glb_top.update_params({'glb_tile_mem_size': parameters['glb_tile_mem_size']}, True)
+    glb_top.update_params({'num_glb_tiles': parameters['num_glb_tiles']}, True)
+
+    # App test parameters update
+    cgra_rtl_sim_compile.update_params({'array_width': parameters['array_width']}, True)
+    cgra_rtl_sim_compile.update_params({'array_height': parameters['array_height']}, True)
+    cgra_rtl_sim_compile.update_params({'clock_period': parameters['clock_period']}, True)
+    cgra_rtl_sim_compile.update_params({'glb_tile_mem_size': parameters['glb_tile_mem_size']}, True)
+
+    cgra_rtl_sim_run.update_params({'cgra_apps': parameters['cgra_apps']}, True)
+
+    # Power node order manipulation
+    order = power.get_param('order')
+    # Move endcap/welltap insertion to end of power step to improve runtime
+    order.append( 'add-endcaps-welltaps.tcl' )
+    # Stream out post-power GDS so that we can run DRC here
+    order.append( 'innovus-foundation-flow/custom-scripts/stream-out.tcl' )
+    order.append( 'attach-results-to-outputs.tcl' )
+    power.update_params( { 'order': order } )
+
+    # Add pre-route plugin to insert skip_routing commands
+    order = route.get_param('order')
+    order.insert( 0, 'pre-route.tcl' )
+    route.update_params( { 'order': order } )
+
+    # Signoff order additions
+    order = signoff.get_param('order')
+    # Add sealring at beginning of signoff, so it's in before we stream out GDS
+    if parameters['include_sealring'] == True:
+        order.insert(0, 'add-sealring.tcl')
+    # Add netlist-fixing script before we save new netlist
+    index = order.index( 'generate-results.tcl' )
+    order.insert( index, 'netlist-fixing.tcl' )
+    signoff.update_params( { 'order': order } )
+
+    if which_soc == 'amber':
+        merge_rdl.update_params( {'coord_x': parameters['dragonphy_rdl_x'], 'coord_y': parameters['dragonphy_rdl_y'], 'flatten_child': True,
+                                'design_top_cell': parameters['design_name'], 'child_top_cell': 'dragonphy_RDL'} )
+
+        merge_fill.update_params( {'design_top_cell': parameters['design_name'], 'child_top_cell': f"{parameters['design_name']}_F16a"} )
+
+        # Antenna DRC node needs to use antenna rule deck
+        antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'] } )
+
+    if which_soc == 'onyx':
+
+        merge_fill.update_params( {'design_top_cell': parameters['design_name'], 'child_top_cell': f"{parameters['design_name']}_F16a"} )
+
+        # need to give coordinates for guardring
+        merge_gdr.update_params( guardring_params )
+
+        # Antenna DRC node needs to use antenna rule deck
+        antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'],
+                                     'drc_env_setup': parameters['antenna_drc_env_setup'] } )
+
+    # Power DRC node should use block level rule deck to improve runtimes and not report false errors
+    power_drc.update_params( {'drc_rule_deck': parameters['power_drc_rule_deck'] } )
+
+    return g
 
 
 if __name__ == '__main__':
-  g = construct()
+    g = construct()
 #  g.plot()

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -165,102 +165,102 @@ def construct():
     # Create nodes
     #-----------------------------------------------------------------------
 
-    this_dir = os.path.dirname( os.path.abspath( __file__ ) )
+    this_dir = os.path.dirname( os.path.abspath( __file__))
 
     # ADK step
 
-    g.set_adk( adk_name )
+    g.set_adk( adk_name)
     adk = g.get_adk_step()
 
     # Custom steps
 
-    rtl            = Step( this_dir + '/../common/rtl'                          )
-    soc_rtl        = Step( this_dir + '/../common/soc-rtl-v2'                   )
+    rtl            = Step( this_dir + '/../common/rtl')
+    soc_rtl        = Step( this_dir + '/../common/soc-rtl-v2')
 
     if adk_name == "tsmc16":
-        gen_sram       = Step( this_dir + '/../common/gen_sram_macro_amber'         )
-        constraints    = Step( this_dir + '/constraints_amber'                      )
+        gen_sram       = Step( this_dir + '/../common/gen_sram_macro_amber')
+        constraints    = Step( this_dir + '/constraints_amber')
     else:
-        gen_sram       = Step( this_dir + '/../common/gen_sram_macro'               )
-        constraints    = Step( this_dir + '/constraints'                            )
+        gen_sram       = Step( this_dir + '/../common/gen_sram_macro')
+        constraints    = Step( this_dir + '/constraints')
 
-    read_design    = Step( this_dir + '/../common/fc-custom-read-design'        )
+    read_design    = Step( this_dir + '/../common/fc-custom-read-design')
     if adk_name == 'tsmc16':
-        custom_init          = Step( this_dir + '/custom-init-amber'                 )
-        custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber'            )
-        custom_power         = Step( this_dir + '/../common/custom-power-chip-amber' )
-        init_fc              = Step( this_dir + '/../common/init-fullchip-amber'     )
+        custom_init          = Step( this_dir + '/custom-init-amber')
+        custom_lvs           = Step( this_dir + '/custom-lvs-rules-amber')
+        custom_power         = Step( this_dir + '/../common/custom-power-chip-amber')
+        init_fc              = Step( this_dir + '/../common/init-fullchip-amber')
     else:
-        custom_init          = Step( this_dir + '/custom-init'                 )
-        custom_lvs           = Step( this_dir + '/custom-lvs-rules'            )
-        custom_power         = Step( this_dir + '/../common/custom-power-chip' )
-        custom_cts           = Step( this_dir + '/custom-cts'                  )
-        init_fc              = Step( this_dir + '/../common/init-fullchip'     )
-    io_file        = Step( this_dir + '/io_file'                                )
-    pre_route      = Step( this_dir + '/pre-route'                              )
-    sealring       = Step( this_dir + '/sealring'                               )
-    netlist_fixing = Step( this_dir + '/../common/fc-netlist-fixing'            )
+        custom_init          = Step( this_dir + '/custom-init')
+        custom_lvs           = Step( this_dir + '/custom-lvs-rules')
+        custom_power         = Step( this_dir + '/../common/custom-power-chip')
+        custom_cts           = Step( this_dir + '/custom-cts')
+        init_fc              = Step( this_dir + '/../common/init-fullchip')
+    io_file        = Step( this_dir + '/io_file')
+    pre_route      = Step( this_dir + '/pre-route')
+    sealring       = Step( this_dir + '/sealring')
+    netlist_fixing = Step( this_dir + '/../common/fc-netlist-fixing')
     if which_soc == 'onyx':
-        drc_pm         = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm' )
-        drc_dp         = Step( this_dir + '/gf-drc-dp'                              )
-        drc_mas        = Step( this_dir + '/../common/gf-mentor-calibre-drc-mas'    )
+        drc_pm         = Step( this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
+        drc_dp         = Step( this_dir + '/gf-drc-dp')
+        drc_mas        = Step( this_dir + '/../common/gf-mentor-calibre-drc-mas')
 
     # Block-level designs
 
-    tile_array        = Subgraph( this_dir + '/../tile_array',        'tile_array'        )
-    glb_top           = Subgraph( this_dir + '/../glb_top',           'glb_top'           )
-    global_controller = Subgraph( this_dir + '/../global_controller', 'global_controller' )
+    tile_array        = Subgraph( this_dir + '/../tile_array',        'tile_array')
+    glb_top           = Subgraph( this_dir + '/../glb_top',           'glb_top')
+    global_controller = Subgraph( this_dir + '/../global_controller', 'global_controller')
 
     if which_soc == 'amber':
         dragonphy         = Step( this_dir + '/dragonphy')
     elif which_soc == 'onyx':
-        xgcd              = Step( this_dir + '/xgcd'     )
+        xgcd              = Step( this_dir + '/xgcd')
 
     # CGRA simulation
 
-    cgra_rtl_sim_compile  = Step( this_dir + '/cgra_rtl_sim_compile' )
-    cgra_rtl_sim_run      = Step( this_dir + '/cgra_rtl_sim_run'     )
-    cgra_sim_build        = Step( this_dir + '/cgra_sim_build'       )
-    # cgra_gl_sim_compile   = Step( this_dir + '/cgra_gl_sim_compile'  )
-    # cgra_gl_sim_run       = Step( this_dir + '/cgra_gl_sim_run'      )
-    # cgra_gl_ptpx          = Step( this_dir + '/cgra_gl_ptpx'         )
-    # cgra_rtl_sim_verdict  = Step( this_dir + '/cgra_rtl_sim_verdict' )
-    # cgra_gl_sim_verdict   = Step( this_dir + '/cgra_gl_sim_verdict'  )
+    cgra_rtl_sim_compile  = Step( this_dir + '/cgra_rtl_sim_compile')
+    cgra_rtl_sim_run      = Step( this_dir + '/cgra_rtl_sim_run')
+    cgra_sim_build        = Step( this_dir + '/cgra_sim_build')
+    # cgra_gl_sim_compile   = Step( this_dir + '/cgra_gl_sim_compile')
+    # cgra_gl_sim_run       = Step( this_dir + '/cgra_gl_sim_run')
+    # cgra_gl_ptpx          = Step( this_dir + '/cgra_gl_ptpx')
+    # cgra_rtl_sim_verdict  = Step( this_dir + '/cgra_rtl_sim_verdict')
+    # cgra_gl_sim_verdict   = Step( this_dir + '/cgra_gl_sim_verdict')
 
     # Default steps
 
-    info           = Step( 'info',                          default=True )
-    #constraints    = Step( 'constraints',                   default=True )
-    synth          = Step( 'cadence-genus-synthesis',       default=True )
-    iflow          = Step( 'cadence-innovus-flowsetup',     default=True )
-    init           = Step( 'cadence-innovus-init',          default=True )
-    power          = Step( 'cadence-innovus-power',         default=True )
-    place          = Step( 'cadence-innovus-place',         default=True )
-    cts            = Step( 'cadence-innovus-cts',           default=True )
-    postcts_hold   = Step( 'cadence-innovus-postcts_hold',  default=True )
-    route          = Step( 'cadence-innovus-route',         default=True )
-    postroute      = Step( 'cadence-innovus-postroute',     default=True )
-    postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
-    signoff        = Step( 'cadence-innovus-signoff',       default=True )
-    pt_signoff     = Step( 'synopsys-pt-timing-signoff',    default=True )
+    info           = Step( 'info',                          default=True)
+    #constraints   = Step( 'constraints',                   default=True)
+    synth          = Step( 'cadence-genus-synthesis',       default=True)
+    iflow          = Step( 'cadence-innovus-flowsetup',     default=True)
+    init           = Step( 'cadence-innovus-init',          default=True)
+    power          = Step( 'cadence-innovus-power',         default=True)
+    place          = Step( 'cadence-innovus-place',         default=True)
+    cts            = Step( 'cadence-innovus-cts',           default=True)
+    postcts_hold   = Step( 'cadence-innovus-postcts_hold',  default=True)
+    route          = Step( 'cadence-innovus-route',         default=True)
+    postroute      = Step( 'cadence-innovus-postroute',     default=True)
+    postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True)
+    signoff        = Step( 'cadence-innovus-signoff',       default=True)
+    pt_signoff     = Step( 'synopsys-pt-timing-signoff',    default=True)
 
     if which("calibre") is not None:
-        drc            = Step( 'mentor-calibre-drc',            default=True )
-        lvs            = Step( 'mentor-calibre-lvs',            default=True )
+        drc            = Step( 'mentor-calibre-drc',            default=True)
+        lvs            = Step( 'mentor-calibre-lvs',            default=True)
         # GF has a different way of running fill
         if adk_name == 'gf12-adk':
-            fill           = Step (this_dir + '/../common/mentor-calibre-fill-gf' )
-            merge_gdr      = Step( 'mentor-calibre-gdsmerge-child',  default=True )
+            fill           = Step (this_dir + '/../common/mentor-calibre-fill-gf')
+            merge_gdr      = Step( 'mentor-calibre-gdsmerge-child',  default=True)
         else:
-            fill           = Step( 'mentor-calibre-fill',            default=True )
-            merge_rdl      = Step( 'mentor-calibre-gdsmerge-child',  default=True )
+            fill           = Step( 'mentor-calibre-fill',            default=True)
+            merge_rdl      = Step( 'mentor-calibre-gdsmerge-child',  default=True)
             merge_rdl.set_name('gdsmerge-dragonphy-rdl')
 
-        merge_fill     = Step( 'mentor-calibre-gdsmerge-child', default=True )
+        merge_fill     = Step( 'mentor-calibre-gdsmerge-child', default=True)
     else:
         assert False, 'Sorry! Removed cadence-pegasus option'
 
-    debugcalibre   = Step( 'cadence-innovus-debug-calibre', default=True )
+    debugcalibre   = Step( 'cadence-innovus-debug-calibre', default=True)
 
     merge_fill.set_name('gdsmerge-fill')
 
@@ -269,56 +269,56 @@ def construct():
     if which_soc == 'onyx':
         # Second sram_node because soc has 2 types of srams
         gen_sram_2 = gen_sram.clone()
-        gen_sram_2.set_name( 'gen_sram_macro_2' )
+        gen_sram_2.set_name( 'gen_sram_macro_2')
 
     # 'power' step now gets its own design-rule check
     power_drc = drc.clone()
-    power_drc.set_name( 'power-drc' )
+    power_drc.set_name( 'power-drc')
 
     # Antenna DRC Check
     antenna_drc = drc.clone()
-    antenna_drc.set_name( 'antenna-drc' )
+    antenna_drc.set_name( 'antenna-drc')
 
     if which_soc == 'onyx':
         # Pre-Fill DRC Check
         prefill_drc = drc.clone()
-        prefill_drc.set_name( 'pre-fill-drc' )
+        prefill_drc.set_name( 'pre-fill-drc')
 
         # Separate ADK for LVS so it has PM cells when needed
         lvs_adk = adk.clone()
-        lvs_adk.set_name( 'lvs_adk' )
+        lvs_adk.set_name( 'lvs_adk')
 
     # Add cgra tile macro inputs to downstream nodes
 
-    synth.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'] )
-    synth.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'] )
-    synth.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'] )
-    synth.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
+    synth.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'])
+    synth.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'])
+    synth.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'])
+    synth.extend_inputs( ['sram_tt.lib', 'sram.lef'])
 
     if which_soc == 'onyx':
-        synth.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'] )
-        synth.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'] )
+        synth.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'])
+        synth.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'])
 
     elif which_soc == 'amber':
         # Exclude dragonphy_top from synth inputs to prevent
         # floating dragonphy inputs from being tied to 0
-        synth.extend_inputs( ['dragonphy_top.lef'] )
+        synth.extend_inputs( ['dragonphy_top.lef'])
 
-    pt_signoff.extend_inputs( ['tile_array_tt.db'] )
-    pt_signoff.extend_inputs( ['glb_top_tt.db'] )
-    pt_signoff.extend_inputs( ['global_controller_tt.db'] )
-    pt_signoff.extend_inputs( ['sram_tt.db'] )
+    pt_signoff.extend_inputs( ['tile_array_tt.db'])
+    pt_signoff.extend_inputs( ['glb_top_tt.db'])
+    pt_signoff.extend_inputs( ['global_controller_tt.db'])
+    pt_signoff.extend_inputs( ['sram_tt.db'])
 
     if which_soc == 'onyx':
-        pt_signoff.extend_inputs( ['sram_2_tt.db'] )
-        pt_signoff.extend_inputs( ['xgcd_tt.db'] )
+        pt_signoff.extend_inputs( ['sram_2_tt.db'])
+        pt_signoff.extend_inputs( ['xgcd_tt.db'])
 
     elif which_soc == 'amber':
-        pt_signoff.extend_inputs( ['dragonphy_top_tt.db'] )
+        pt_signoff.extend_inputs( ['dragonphy_top_tt.db'])
 
-    route.extend_inputs( ['pre-route.tcl'] )
-    signoff.extend_inputs( sealring.all_outputs() )
-    signoff.extend_inputs( netlist_fixing.all_outputs() )
+    route.extend_inputs( ['pre-route.tcl'])
+    signoff.extend_inputs( sealring.all_outputs())
+    signoff.extend_inputs( netlist_fixing.all_outputs())
     # These steps need timing info for cgra tiles
 
     hier_steps = \
@@ -326,73 +326,73 @@ def construct():
         route, postroute, signoff]
 
     for step in hier_steps:
-        step.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'] )
-        step.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'] )
-        step.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'] )
-        step.extend_inputs( ['sram_tt.lib', 'sram.lef'] )
+        step.extend_inputs( ['tile_array_tt.lib', 'tile_array.lef'])
+        step.extend_inputs( ['glb_top_tt.lib', 'glb_top.lef'])
+        step.extend_inputs( ['global_controller_tt.lib', 'global_controller.lef'])
+        step.extend_inputs( ['sram_tt.lib', 'sram.lef'])
 
         if which_soc == 'onyx':
-            step.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'] )
-            step.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'] )
+            step.extend_inputs( ['sram_2_tt.lib', 'sram_2.lef'])
+            step.extend_inputs( ['xgcd_tt.lib', 'xgcd.lef'])
 
         elif which_soc == 'amber':
-            step.extend_inputs( ['dragonphy_top_tt.lib', 'dragonphy_top.lef'] )
-            step.extend_inputs( ['dragonphy_RDL.lef'] )
+            step.extend_inputs( ['dragonphy_top_tt.lib', 'dragonphy_top.lef'])
+            step.extend_inputs( ['dragonphy_RDL.lef'])
 
     # Need all block gds's to merge into the final layout
     gdsmerge_nodes = [signoff, power]
     for node in gdsmerge_nodes:
-        node.extend_inputs( ['tile_array.gds'] )
-        node.extend_inputs( ['glb_top.gds'] )
-        node.extend_inputs( ['global_controller.gds'] )
-        node.extend_inputs( ['sram.gds'] )
+        node.extend_inputs( ['tile_array.gds'])
+        node.extend_inputs( ['glb_top.gds'])
+        node.extend_inputs( ['global_controller.gds'])
+        node.extend_inputs( ['sram.gds'])
 
         if which_soc == 'onyx':
-            node.extend_inputs( ['sram_2.gds'] )
-            node.extend_inputs( ['xgcd.gds'] )
+            node.extend_inputs( ['sram_2.gds'])
+            node.extend_inputs( ['xgcd.gds'])
 
         elif which_soc == 'amber':
-            node.extend_inputs( ['dragonphy_top.gds'] )
-            node.extend_inputs( ['dragonphy_RDL.gds'] )
+            node.extend_inputs( ['dragonphy_top.gds'])
+            node.extend_inputs( ['dragonphy_RDL.gds'])
 
     # Need extracted spice files for both tile types to do LVS
 
-    lvs.extend_inputs( ['tile_array.lvs.v'] )
-    lvs.extend_inputs( ['tile_array.sram.spi'] )
-    lvs.extend_inputs( ['glb_top.lvs.v'] )
-    lvs.extend_inputs( ['glb_top.sram.spi'] )
-    lvs.extend_inputs( ['global_controller.lvs.v'] )
-    lvs.extend_inputs( ['sram.spi'] )
+    lvs.extend_inputs( ['tile_array.lvs.v'])
+    lvs.extend_inputs( ['tile_array.sram.spi'])
+    lvs.extend_inputs( ['glb_top.lvs.v'])
+    lvs.extend_inputs( ['glb_top.sram.spi'])
+    lvs.extend_inputs( ['global_controller.lvs.v'])
+    lvs.extend_inputs( ['sram.spi'])
 
     if which_soc == 'onyx':
-        lvs.extend_inputs( ['sram_2.spi'] )
-        lvs.extend_inputs( ['xgcd.lvs.v'] )
-        lvs.extend_inputs( ['xgcd-255.lvs.v'] )
-        lvs.extend_inputs( ['xgcd-1279.lvs.v'] )
-        lvs.extend_inputs( ['ring_oscillator.lvs.v'] )
+        lvs.extend_inputs( ['sram_2.spi'])
+        lvs.extend_inputs( ['xgcd.lvs.v'])
+        lvs.extend_inputs( ['xgcd-255.lvs.v'])
+        lvs.extend_inputs( ['xgcd-1279.lvs.v'])
+        lvs.extend_inputs( ['ring_oscillator.lvs.v'])
 
     elif which_soc == 'amber':
-        lvs.extend_inputs( ['dragonphy_top.spi'] )
+        lvs.extend_inputs( ['dragonphy_top.spi'])
 
-    lvs.extend_inputs( ['adk_lvs2'] )
+    lvs.extend_inputs( ['adk_lvs2'])
 
     # Add extra input edges to innovus steps that need custom tweaks
 
-    init.extend_inputs( custom_init.all_outputs() )
-    init.extend_inputs( init_fc.all_outputs() )
-    power.extend_inputs( custom_power.all_outputs() )
+    init.extend_inputs( custom_init.all_outputs())
+    init.extend_inputs( init_fc.all_outputs())
+    power.extend_inputs( custom_power.all_outputs())
     if which_soc == 'onyx':
-        cts.extend_inputs( custom_cts.all_outputs() )
+        cts.extend_inputs( custom_cts.all_outputs())
 
-    synth.extend_inputs( soc_rtl.all_outputs() )
-    synth.extend_inputs( read_design.all_outputs() )
-    synth.extend_inputs( ["cons_scripts"] )
+    synth.extend_inputs( soc_rtl.all_outputs())
+    synth.extend_inputs( read_design.all_outputs())
+    synth.extend_inputs( ["cons_scripts"])
 
-    power.extend_outputs( ["design-merged.gds"] )
+    power.extend_outputs( ["design-merged.gds"])
 
     if parameters['interconnect_only'] is False:
-        rtl.extend_outputs( ['header'] )
-        rtl.extend_postconditions( ["assert File( 'outputs/header' ) "] )
+        rtl.extend_outputs( ['header'])
+        rtl.extend_postconditions( ["assert File( 'outputs/header' ) "])
 
     # TSMC needs streamout *without* the (new) default -uniquify flag
     # This python method finds 'stream-out.tcl' and strips out that flag.
@@ -405,77 +405,77 @@ def construct():
         cmd1 = "cp rtl-scripts-amber/nic400_design_files.tcl  rtl-scripts"
         cmd2 = "cp rtl-scripts-amber/nic400_include_paths.tcl rtl-scripts"
         cmd3 = "cp rtl-scripts-amber/soc_design_files.tcl     rtl-scripts"
-        soc_rtl.pre_extend_commands( [ cmd1 ] )
-        soc_rtl.pre_extend_commands( [ cmd2 ] )
-        soc_rtl.pre_extend_commands( [ cmd3 ] )
+        soc_rtl.pre_extend_commands([cmd1])
+        soc_rtl.pre_extend_commands([cmd2])
+        soc_rtl.pre_extend_commands([cmd3])
 
     #-----------------------------------------------------------------------
     # Graph -- Add nodes
     #-----------------------------------------------------------------------
 
-    g.add_step( info              )
-    g.add_step( rtl               )
-    g.add_step( soc_rtl           )
-    g.add_step( gen_sram          )
-    g.add_step( tile_array        )
-    g.add_step( glb_top           )
-    g.add_step( global_controller )
-    g.add_step( constraints       )
-    g.add_step( read_design       )
-    g.add_step( synth             )
-    g.add_step( iflow             )
-    g.add_step( init              )
-    g.add_step( init_fc           )
-    g.add_step( io_file           )
-    g.add_step( custom_init       )
-    g.add_step( power             )
-    g.add_step( custom_power      )
-    g.add_step( place             )
-    g.add_step( cts               )
-    g.add_step( postcts_hold      )
-    g.add_step( pre_route         )
-    g.add_step( route             )
-    g.add_step( postroute         )
-    g.add_step( postroute_hold    )
-    g.add_step( sealring          )
-    g.add_step( netlist_fixing    )
-    g.add_step( signoff           )
-    g.add_step( pt_signoff        )
-    g.add_step( fill              )
-    g.add_step( merge_fill        )
-    g.add_step( drc               )
-    g.add_step( antenna_drc       )
-    g.add_step( lvs               )
-    g.add_step( custom_lvs        )
-    g.add_step( debugcalibre      )
+    g.add_step( info)
+    g.add_step( rtl)
+    g.add_step( soc_rtl)
+    g.add_step( gen_sram)
+    g.add_step( tile_array)
+    g.add_step( glb_top)
+    g.add_step( global_controller)
+    g.add_step( constraints)
+    g.add_step( read_design)
+    g.add_step( synth)
+    g.add_step( iflow)
+    g.add_step( init)
+    g.add_step( init_fc)
+    g.add_step( io_file)
+    g.add_step( custom_init)
+    g.add_step( power)
+    g.add_step( custom_power)
+    g.add_step( place)
+    g.add_step( cts)
+    g.add_step( postcts_hold)
+    g.add_step( pre_route)
+    g.add_step( route)
+    g.add_step( postroute)
+    g.add_step( postroute_hold)
+    g.add_step( sealring)
+    g.add_step( netlist_fixing)
+    g.add_step( signoff)
+    g.add_step( pt_signoff)
+    g.add_step( fill)
+    g.add_step( merge_fill)
+    g.add_step( drc)
+    g.add_step( antenna_drc)
+    g.add_step( lvs)
+    g.add_step( custom_lvs)
+    g.add_step( debugcalibre)
 
     # Post-Power DRC check
-    g.add_step( power_drc         )
+    g.add_step( power_drc)
 
     # App test nodes
-    g.add_step( cgra_rtl_sim_compile )
-    g.add_step( cgra_sim_build       )
-    g.add_step( cgra_rtl_sim_run     )
-    # g.add_step( cgra_gl_sim_compile )
+    g.add_step( cgra_rtl_sim_compile)
+    g.add_step( cgra_sim_build)
+    g.add_step( cgra_rtl_sim_run)
+    # g.add_step( cgra_gl_sim_compile)
 
     # Onyx-specific nodes
     if which_soc == 'onyx':
-        g.add_step( gen_sram_2        )
-        g.add_step( xgcd              )
-        g.add_step( custom_cts        )
-        g.add_step( prefill_drc       )
-        g.add_step( merge_gdr         )
-        g.add_step( drc_pm            )
-        g.add_step( drc_dp            )
-        g.add_step( drc_mas           )
+        g.add_step( gen_sram_2)
+        g.add_step( xgcd)
+        g.add_step( custom_cts)
+        g.add_step( prefill_drc)
+        g.add_step( merge_gdr)
+        g.add_step( drc_pm)
+        g.add_step( drc_dp)
+        g.add_step( drc_mas)
 
         # Different adk view for lvs
-        g.add_step( lvs_adk           )
+        g.add_step( lvs_adk)
 
     # Amber-specific nodes
     if which_soc == 'amber':
-        g.add_step( merge_rdl         )
-        g.add_step( dragonphy         )
+        g.add_step( merge_rdl)
+        g.add_step( dragonphy)
 
     #-----------------------------------------------------------------------
     # Graph -- Add edges
@@ -483,49 +483,49 @@ def construct():
 
     # Connect by name
 
-    g.connect_by_name( adk,      gen_sram       )
-    g.connect_by_name( adk,      synth          )
-    g.connect_by_name( adk,      iflow          )
-    g.connect_by_name( adk,      init           )
-    g.connect_by_name( adk,      power          )
-    g.connect_by_name( adk,      place          )
-    g.connect_by_name( adk,      cts            )
-    g.connect_by_name( adk,      postcts_hold   )
-    g.connect_by_name( adk,      route          )
-    g.connect_by_name( adk,      postroute      )
-    g.connect_by_name( adk,      postroute_hold )
-    g.connect_by_name( adk,      signoff        )
-    g.connect_by_name( adk,      fill           )
-    g.connect_by_name( adk,      merge_fill     )
-    g.connect_by_name( adk,      drc            )
-    g.connect_by_name( adk,      antenna_drc    )
+    g.connect_by_name( adk,      gen_sram)
+    g.connect_by_name( adk,      synth)
+    g.connect_by_name( adk,      iflow)
+    g.connect_by_name( adk,      init)
+    g.connect_by_name( adk,      power)
+    g.connect_by_name( adk,      place)
+    g.connect_by_name( adk,      cts)
+    g.connect_by_name( adk,      postcts_hold)
+    g.connect_by_name( adk,      route)
+    g.connect_by_name( adk,      postroute)
+    g.connect_by_name( adk,      postroute_hold)
+    g.connect_by_name( adk,      signoff)
+    g.connect_by_name( adk,      fill)
+    g.connect_by_name( adk,      merge_fill)
+    g.connect_by_name( adk,      drc)
+    g.connect_by_name( adk,      antenna_drc)
 
     # Onyx-specific connections
     if which_soc == 'onyx':
-        g.connect_by_name( adk,      gen_sram_2     )
-        g.connect_by_name( adk,      prefill_drc    )
-        g.connect_by_name( adk,      merge_gdr      )
-        g.connect_by_name( adk,      drc_pm         )
-        g.connect_by_name( adk,      drc_dp         )
-        g.connect_by_name( adk,      drc_mas        )
+        g.connect_by_name( adk,      gen_sram_2)
+        g.connect_by_name( adk,      prefill_drc)
+        g.connect_by_name( adk,      merge_gdr)
+        g.connect_by_name( adk,      drc_pm)
+        g.connect_by_name( adk,      drc_dp)
+        g.connect_by_name( adk,      drc_mas)
         # Use lvs_adk so lvs has access to cells used in lower-level blocks
-        g.connect_by_name( lvs_adk,  lvs            )
+        g.connect_by_name( lvs_adk,  lvs)
 
     # Amber-specific connections
     if which_soc == 'amber':
-        g.connect_by_name( adk,      merge_rdl      )
-        g.connect_by_name( adk,      lvs            )
+        g.connect_by_name( adk,      merge_rdl)
+        g.connect_by_name( adk,      lvs)
 
     # Post-Power DRC check
-    g.connect_by_name( adk,      power_drc )
+    g.connect_by_name( adk,      power_drc)
 
     # Connect RTL verification nodes
-    g.connect_by_name( rtl, cgra_rtl_sim_compile )
-    g.connect_by_name( cgra_sim_build, cgra_rtl_sim_run )
-    g.connect_by_name( cgra_rtl_sim_compile, cgra_rtl_sim_run )
+    g.connect_by_name( rtl, cgra_rtl_sim_compile)
+    g.connect_by_name( cgra_sim_build, cgra_rtl_sim_run)
+    g.connect_by_name( cgra_rtl_sim_compile, cgra_rtl_sim_run)
 
     # Connect GL verification nodes
-    # g.connect_by_name( signoff, cgra_gl_sim_compile )
+    # g.connect_by_name( signoff, cgra_gl_sim_compile)
 
     # All of the blocks within this hierarchical design
     # Skip these if we're doing soc_only
@@ -537,56 +537,56 @@ def construct():
             blocks += [dragonphy]
 
         for block in blocks:
-            g.connect_by_name( block, synth          )
-            g.connect_by_name( block, iflow          )
-            g.connect_by_name( block, init           )
-            g.connect_by_name( block, power          )
-            g.connect_by_name( block, place          )
-            g.connect_by_name( block, cts            )
-            g.connect_by_name( block, postcts_hold   )
-            g.connect_by_name( block, route          )
-            g.connect_by_name( block, postroute      )
-            g.connect_by_name( block, postroute_hold )
-            g.connect_by_name( block, signoff        )
-            g.connect_by_name( block, pt_signoff     )
-            g.connect_by_name( block, drc            )
-            g.connect_by_name( block, lvs            )
+            g.connect_by_name( block, synth)
+            g.connect_by_name( block, iflow)
+            g.connect_by_name( block, init)
+            g.connect_by_name( block, power)
+            g.connect_by_name( block, place)
+            g.connect_by_name( block, cts)
+            g.connect_by_name( block, postcts_hold)
+            g.connect_by_name( block, route)
+            g.connect_by_name( block, postroute)
+            g.connect_by_name( block, postroute_hold)
+            g.connect_by_name( block, signoff)
+            g.connect_by_name( block, pt_signoff)
+            g.connect_by_name( block, drc)
+            g.connect_by_name( block, lvs)
         # Tile_array can use rtl from rtl node
-        g.connect_by_name( rtl, tile_array )
+        g.connect_by_name( rtl, tile_array)
         # glb_top can use rtl from rtl node
-        g.connect_by_name( rtl, glb_top )
+        g.connect_by_name( rtl, glb_top)
         # global_controller can use rtl from rtl node
-        g.connect_by_name( rtl, global_controller )
+        g.connect_by_name( rtl, global_controller)
 
-    g.connect_by_name( rtl,         synth     )
-    g.connect_by_name( soc_rtl,     synth        )
-    g.connect_by_name( constraints, synth        )
-    g.connect_by_name( read_design, synth        )
+    g.connect_by_name( rtl,         synth)
+    g.connect_by_name( soc_rtl,     synth)
+    g.connect_by_name( constraints, synth)
+    g.connect_by_name( read_design, synth)
 
-    g.connect_by_name( soc_rtl,  io_file      )
+    g.connect_by_name( soc_rtl,  io_file)
 
-    g.connect_by_name( synth,       iflow        )
-    g.connect_by_name( synth,       init         )
-    g.connect_by_name( synth,       power        )
-    g.connect_by_name( synth,       place        )
-    g.connect_by_name( synth,       cts          )
+    g.connect_by_name( synth,       iflow)
+    g.connect_by_name( synth,       init)
+    g.connect_by_name( synth,       power)
+    g.connect_by_name( synth,       place)
+    g.connect_by_name( synth,       cts)
 
-    g.connect_by_name( iflow,    init           )
-    g.connect_by_name( iflow,    power          )
-    g.connect_by_name( iflow,    place          )
-    g.connect_by_name( iflow,    cts            )
-    g.connect_by_name( iflow,    postcts_hold   )
-    g.connect_by_name( iflow,    route          )
-    g.connect_by_name( iflow,    postroute      )
-    g.connect_by_name( iflow,    postroute_hold )
-    g.connect_by_name( iflow,    signoff        )
+    g.connect_by_name( iflow,    init)
+    g.connect_by_name( iflow,    power)
+    g.connect_by_name( iflow,    place)
+    g.connect_by_name( iflow,    cts)
+    g.connect_by_name( iflow,    postcts_hold)
+    g.connect_by_name( iflow,    route)
+    g.connect_by_name( iflow,    postroute)
+    g.connect_by_name( iflow,    postroute_hold)
+    g.connect_by_name( iflow,    signoff)
 
-    g.connect_by_name( custom_init,  init     )
-    g.connect_by_name( custom_lvs,   lvs      )
-    g.connect_by_name( custom_power, power    )
+    g.connect_by_name( custom_init,  init)
+    g.connect_by_name( custom_lvs,   lvs)
+    g.connect_by_name( custom_power, power)
 
     if which_soc == 'onyx':
-        g.connect_by_name( custom_cts,   cts      )
+        g.connect_by_name( custom_cts,   cts)
 
     # Connect gen_sram_macro node(s) to all downstream nodes that
     # need them
@@ -594,7 +594,7 @@ def construct():
                   route, postroute, postroute_hold, signoff, pt_signoff,
                   drc, lvs]
     for node in sram_nodes:
-        g.connect_by_name( gen_sram, node )
+        g.connect_by_name( gen_sram, node)
         if which_soc == 'onyx':
             for sram_output in gen_sram_2.all_outputs():
                 node_input = sram_output.replace('sram', 'sram_2')
@@ -602,77 +602,77 @@ def construct():
                     g.connect(gen_sram_2.o(sram_output), node.i(node_input))
 
     # Full chip floorplan stuff
-    g.connect_by_name( io_file, init_fc )
-    g.connect_by_name( init_fc, init    )
+    g.connect_by_name( io_file, init_fc)
+    g.connect_by_name( init_fc, init)
 
-    g.connect_by_name( init,           power          )
-    g.connect_by_name( power,          place          )
-    g.connect_by_name( place,          cts            )
-    g.connect_by_name( cts,            postcts_hold   )
-    g.connect_by_name( postcts_hold,   route          )
-    g.connect_by_name( route,          postroute      )
-    g.connect_by_name( postroute,      postroute_hold )
-    g.connect_by_name( postroute_hold, signoff        )
-    g.connect_by_name( signoff,        lvs            )
+    g.connect_by_name( init,           power)
+    g.connect_by_name( power,          place)
+    g.connect_by_name( place,          cts)
+    g.connect_by_name( cts,            postcts_hold)
+    g.connect_by_name( postcts_hold,   route)
+    g.connect_by_name( route,          postroute)
+    g.connect_by_name( postroute,      postroute_hold)
+    g.connect_by_name( postroute_hold, signoff)
+    g.connect_by_name( signoff,        lvs)
 
     if which_soc == 'onyx':
         # Merge guardring gds into design
         g.connect(signoff.o('design-merged.gds'), merge_gdr.i('design.gds'))
 
         # Send gds with sealring to drc, fill, and lvs
-        g.connect_by_name( merge_gdr, lvs )
+        g.connect_by_name( merge_gdr, lvs)
         # Run pre-fill DRC after signoff
-        g.connect_by_name( merge_gdr, prefill_drc )
+        g.connect_by_name( merge_gdr, prefill_drc)
         # Run PM DRC after signoff
-        g.connect_by_name( merge_gdr, drc_pm )
+        g.connect_by_name( merge_gdr, drc_pm)
 
         # For GF, Fill is already merged during fill step
 
         # Run Fill on merged GDS
-        g.connect( merge_gdr.o('design_merged.gds'), fill.i('design.gds') )
+        g.connect( merge_gdr.o('design_merged.gds'), fill.i('design.gds'))
 
         # Connect fill directly to DRC steps
-        g.connect( fill.o('fill.gds'), drc_dp.i('design_merged.gds') )
-        g.connect( fill.o('fill.gds'), antenna_drc.i('design_merged.gds') )
+        g.connect( fill.o('fill.gds'), drc_dp.i('design_merged.gds'))
+        g.connect( fill.o('fill.gds'), antenna_drc.i('design_merged.gds'))
         # Connect drc_dp output gds to final signoff drc
-        g.connect_by_name( drc_dp, drc )
-        g.connect_by_name( drc_dp, drc_mas )
+        g.connect_by_name( drc_dp, drc)
+        g.connect_by_name( drc_dp, drc_mas)
 
     if which_soc == 'amber':
         g.connect(signoff.o('design-merged.gds'), drc.i('design_merged.gds'))
         g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
         # Skipping
-        g.connect( signoff.o('design-merged.gds'),   merge_rdl.i('design.gds') )
-        g.connect( dragonphy.o('dragonphy_RDL.gds'), merge_rdl.i('child.gds') )
-        g.connect_by_name( merge_rdl, lvs )
+        g.connect( signoff.o('design-merged.gds'),   merge_rdl.i('design.gds'))
+        g.connect( dragonphy.o('dragonphy_RDL.gds'), merge_rdl.i('child.gds'))
+        g.connect_by_name( merge_rdl, lvs)
 
         # Run Fill on merged GDS
-        g.connect( merge_rdl.o('design_merged.gds'), fill.i('design.gds') )
+        g.connect( merge_rdl.o('design_merged.gds'), fill.i('design.gds'))
 
         # Merge fill
-        g.connect( merge_rdl.o('design_merged.gds'), merge_fill.i('design.gds') )
-        g.connect( fill.o('fill.gds'), merge_fill.i('child.gds') )
+        g.connect( merge_rdl.o('design_merged.gds'), merge_fill.i('design.gds'))
+        g.connect( fill.o('fill.gds'), merge_fill.i('child.gds'))
 
         # Run DRC on merged and filled gds
-        g.connect_by_name( merge_fill, drc )
-        g.connect_by_name( merge_fill, antenna_drc )
+        g.connect_by_name( merge_fill, drc)
+        g.connect_by_name( merge_fill, antenna_drc)
 
-    g.connect_by_name( adk,          pt_signoff   )
-    g.connect_by_name( signoff,      pt_signoff   )
+    g.connect_by_name( adk,          pt_signoff)
+    g.connect_by_name( signoff,      pt_signoff)
 
-    g.connect_by_name( adk,      debugcalibre )
-    g.connect_by_name( synth,    debugcalibre )
-    g.connect_by_name( iflow,    debugcalibre )
-    g.connect_by_name( signoff,  debugcalibre )
+    g.connect_by_name( adk,      debugcalibre)
+    g.connect_by_name( synth,    debugcalibre)
+    g.connect_by_name( iflow,    debugcalibre)
+    g.connect_by_name( signoff,  debugcalibre)
 
     if which_soc == 'amber':
-        g.connect_by_name( drc,      debugcalibre )
-        g.connect_by_name( lvs,      debugcalibre )
+        g.connect_by_name( drc,      debugcalibre)
+        g.connect_by_name( lvs,      debugcalibre)
 
-    g.connect_by_name( pre_route, route )
-    g.connect_by_name( sealring, signoff )
-    g.connect_by_name( netlist_fixing, signoff )
+    g.connect_by_name( pre_route, route)
+    g.connect_by_name( sealring, signoff)
+    g.connect_by_name( netlist_fixing, signoff)
 
     # Post-Power DRC
     g.connect(power.o('design-merged.gds'), power_drc.i('design_merged.gds'))
@@ -681,14 +681,14 @@ def construct():
     #-----------------------------------------------------------------------
 
     # Allow user to override parms with env in a limited sort of way
-    parameters = sr_override_parms( parameters )
+    parameters = sr_override_parms( parameters)
     print(f'parameters["hold_target_slack"]={parameters["hold_target_slack"]}')
-    g.update_params( parameters )
+    g.update_params( parameters)
 
     if which_soc == 'onyx':
         # Provide different parameter set to second sram node, so it can actually 
         # generate a different sram
-        gen_sram_2.update_params( sram_2_params )
+        gen_sram_2.update_params( sram_2_params)
 
         # LVS adk has separate view parameter
         lvs_adk.update_params({ 'adk_view' : parameters['lvs_adk_view']})
@@ -744,16 +744,16 @@ def construct():
     # Power node order manipulation
     order = power.get_param('order')
     # Move endcap/welltap insertion to end of power step to improve runtime
-    order.append( 'add-endcaps-welltaps.tcl' )
+    order.append( 'add-endcaps-welltaps.tcl')
     # Stream out post-power GDS so that we can run DRC here
-    order.append( 'innovus-foundation-flow/custom-scripts/stream-out.tcl' )
-    order.append( 'attach-results-to-outputs.tcl' )
-    power.update_params( { 'order': order } )
+    order.append( 'innovus-foundation-flow/custom-scripts/stream-out.tcl')
+    order.append( 'attach-results-to-outputs.tcl')
+    power.update_params({'order': order})
 
     # Add pre-route plugin to insert skip_routing commands
     order = route.get_param('order')
-    order.insert( 0, 'pre-route.tcl' )
-    route.update_params( { 'order': order } )
+    order.insert( 0, 'pre-route.tcl')
+    route.update_params({'order': order})
 
     # Signoff order additions
     order = signoff.get_param('order')
@@ -761,32 +761,40 @@ def construct():
     if parameters['include_sealring'] == True:
         order.insert(0, 'add-sealring.tcl')
     # Add netlist-fixing script before we save new netlist
-    index = order.index( 'generate-results.tcl' )
-    order.insert( index, 'netlist-fixing.tcl' )
-    signoff.update_params( { 'order': order } )
+    index = order.index( 'generate-results.tcl')
+    order.insert( index, 'netlist-fixing.tcl')
+    signoff.update_params({'order': order})
 
     if which_soc == 'amber':
-        merge_rdl.update_params( {'coord_x': parameters['dragonphy_rdl_x'], 'coord_y': parameters['dragonphy_rdl_y'], 'flatten_child': True,
-                                'design_top_cell': parameters['design_name'], 'child_top_cell': 'dragonphy_RDL'} )
+        merge_rdl.update_params({
+            'coord_x': parameters['dragonphy_rdl_x'],
+            'coord_y': parameters['dragonphy_rdl_y'],
+            'flatten_child': True,
+            'design_top_cell': parameters['design_name'],
+            'child_top_cell': 'dragonphy_RDL'})
 
-        merge_fill.update_params( {'design_top_cell': parameters['design_name'], 'child_top_cell': f"{parameters['design_name']}_F16a"} )
+        merge_fill.update_params({
+            'design_top_cell': parameters['design_name'],
+            'child_top_cell': f"{parameters['design_name']}_F16a"})
 
         # Antenna DRC node needs to use antenna rule deck
-        antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'] } )
+        antenna_drc.update_params({'drc_rule_deck': parameters['antenna_drc_rule_deck']})
 
     if which_soc == 'onyx':
 
-        merge_fill.update_params( {'design_top_cell': parameters['design_name'], 'child_top_cell': f"{parameters['design_name']}_F16a"} )
+        merge_fill.update_params({
+            'design_top_cell': parameters['design_name'],
+            'child_top_cell': f"{parameters['design_name']}_F16a"})
 
         # need to give coordinates for guardring
-        merge_gdr.update_params( guardring_params )
+        merge_gdr.update_params( guardring_params)
 
         # Antenna DRC node needs to use antenna rule deck
         antenna_drc.update_params( { 'drc_rule_deck': parameters['antenna_drc_rule_deck'],
-                                     'drc_env_setup': parameters['antenna_drc_env_setup'] } )
+                                     'drc_env_setup': parameters['antenna_drc_env_setup']})
 
     # Power DRC node should use block level rule deck to improve runtimes and not report false errors
-    power_drc.update_params( {'drc_rule_deck': parameters['power_drc_rule_deck'] } )
+    power_drc.update_params({'drc_rule_deck': parameters['power_drc_rule_deck']})
 
     return g
 

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -207,8 +207,8 @@ def construct():
 
     # Block-level designs
 
-    tile_array        = Subgraph(this_dir + '/../tile_array',        'tile_array')
-    glb_top           = Subgraph(this_dir + '/../glb_top',           'glb_top')
+    tile_array        = Subgraph(this_dir + '/../tile_array', 'tile_array')
+    glb_top           = Subgraph(this_dir + '/../glb_top', 'glb_top')
     global_controller = Subgraph(this_dir + '/../global_controller', 'global_controller')
 
     if which_soc == 'amber':
@@ -229,38 +229,41 @@ def construct():
 
     # Default steps
 
-    info           = Step('info',                          default=True)
-    #constraints   = Step('constraints',                   default=True)
-    synth          = Step('cadence-genus-synthesis',       default=True)
-    iflow          = Step('cadence-innovus-flowsetup',     default=True)
-    init           = Step('cadence-innovus-init',          default=True)
-    power          = Step('cadence-innovus-power',         default=True)
-    place          = Step('cadence-innovus-place',         default=True)
-    cts            = Step('cadence-innovus-cts',           default=True)
-    postcts_hold   = Step('cadence-innovus-postcts_hold',  default=True)
-    route          = Step('cadence-innovus-route',         default=True)
-    postroute      = Step('cadence-innovus-postroute',     default=True)
-    postroute_hold = Step('cadence-innovus-postroute_hold', default=True)
-    signoff        = Step('cadence-innovus-signoff',       default=True)
-    pt_signoff     = Step('synopsys-pt-timing-signoff',    default=True)
+    def default_step(step_name):
+        return Step(step_name, default=True)
+
+    info           = default_step('info')
+    #constraints   = default_step('constraints')
+    synth          = default_step('cadence-genus-synthesis')
+    iflow          = default_step('cadence-innovus-flowsetup')
+    init           = default_step('cadence-innovus-init')
+    power          = default_step('cadence-innovus-power')
+    place          = default_step('cadence-innovus-place')
+    cts            = default_step('cadence-innovus-cts')
+    postcts_hold   = default_step('cadence-innovus-postcts_hold')
+    route          = default_step('cadence-innovus-route')
+    postroute      = default_step('cadence-innovus-postroute')
+    postroute_hold = default_step('cadence-innovus-postroute_hold')
+    signoff        = default_step('cadence-innovus-signoff')
+    pt_signoff     = default_step('synopsys-pt-timing-signoff')
 
     if which("calibre") is not None:
-        drc            = Step('mentor-calibre-drc',            default=True)
-        lvs            = Step('mentor-calibre-lvs',            default=True)
+        drc = default_step('mentor-calibre-drc')
+        lvs = default_step('mentor-calibre-lvs')
         # GF has a different way of running fill
         if adk_name == 'gf12-adk':
-            fill           = Step(this_dir + '/../common/mentor-calibre-fill-gf')
-            merge_gdr      = Step('mentor-calibre-gdsmerge-child',  default=True)
+            fill = default_step(this_dir + '/../common/mentor-calibre-fill-gf')
+            merge_gdr = default_step('mentor-calibre-gdsmerge-child')
         else:
-            fill           = Step('mentor-calibre-fill',            default=True)
-            merge_rdl      = Step('mentor-calibre-gdsmerge-child',  default=True)
+            fill = default_step('mentor-calibre-fill')
+            merge_rdl = default_step('mentor-calibre-gdsmerge-child')
             merge_rdl.set_name('gdsmerge-dragonphy-rdl')
 
-        merge_fill     = Step('mentor-calibre-gdsmerge-child', default=True)
+        merge_fill = default_step('mentor-calibre-gdsmerge-child')
     else:
         assert False, 'Sorry! Removed cadence-pegasus option'
 
-    debugcalibre   = Step('cadence-innovus-debug-calibre', default=True)
+    debugcalibre = default_step('cadence-innovus-debug-calibre')
 
     merge_fill.set_name('gdsmerge-fill')
 
@@ -483,41 +486,41 @@ def construct():
 
     # Connect by name
 
-    g.connect_by_name(adk,      gen_sram)
-    g.connect_by_name(adk,      synth)
-    g.connect_by_name(adk,      iflow)
-    g.connect_by_name(adk,      init)
-    g.connect_by_name(adk,      power)
-    g.connect_by_name(adk,      place)
-    g.connect_by_name(adk,      cts)
-    g.connect_by_name(adk,      postcts_hold)
-    g.connect_by_name(adk,      route)
-    g.connect_by_name(adk,      postroute)
-    g.connect_by_name(adk,      postroute_hold)
-    g.connect_by_name(adk,      signoff)
-    g.connect_by_name(adk,      fill)
-    g.connect_by_name(adk,      merge_fill)
-    g.connect_by_name(adk,      drc)
-    g.connect_by_name(adk,      antenna_drc)
+    g.connect_by_name(adk, gen_sram)
+    g.connect_by_name(adk, synth)
+    g.connect_by_name(adk, iflow)
+    g.connect_by_name(adk, init)
+    g.connect_by_name(adk, power)
+    g.connect_by_name(adk, place)
+    g.connect_by_name(adk, cts)
+    g.connect_by_name(adk, postcts_hold)
+    g.connect_by_name(adk, route)
+    g.connect_by_name(adk, postroute)
+    g.connect_by_name(adk, postroute_hold)
+    g.connect_by_name(adk, signoff)
+    g.connect_by_name(adk, fill)
+    g.connect_by_name(adk, merge_fill)
+    g.connect_by_name(adk, drc)
+    g.connect_by_name(adk, antenna_drc)
 
     # Onyx-specific connections
     if which_soc == 'onyx':
-        g.connect_by_name(adk,      gen_sram_2)
-        g.connect_by_name(adk,      prefill_drc)
-        g.connect_by_name(adk,      merge_gdr)
-        g.connect_by_name(adk,      drc_pm)
-        g.connect_by_name(adk,      drc_dp)
-        g.connect_by_name(adk,      drc_mas)
+        g.connect_by_name(adk, gen_sram_2)
+        g.connect_by_name(adk, prefill_drc)
+        g.connect_by_name(adk, merge_gdr)
+        g.connect_by_name(adk, drc_pm)
+        g.connect_by_name(adk, drc_dp)
+        g.connect_by_name(adk, drc_mas)
         # Use lvs_adk so lvs has access to cells used in lower-level blocks
-        g.connect_by_name(lvs_adk,  lvs)
+        g.connect_by_name(lvs_adk, lvs)
 
     # Amber-specific connections
     if which_soc == 'amber':
-        g.connect_by_name(adk,      merge_rdl)
-        g.connect_by_name(adk,      lvs)
+        g.connect_by_name(adk, merge_rdl)
+        g.connect_by_name(adk, lvs)
 
     # Post-Power DRC check
-    g.connect_by_name(adk,      power_drc)
+    g.connect_by_name(adk, power_drc)
 
     # Connect RTL verification nodes
     g.connect_by_name(rtl, cgra_rtl_sim_compile)
@@ -558,35 +561,38 @@ def construct():
         # global_controller can use rtl from rtl node
         g.connect_by_name(rtl, global_controller)
 
-    g.connect_by_name(rtl,         synth)
-    g.connect_by_name(soc_rtl,     synth)
-    g.connect_by_name(constraints, synth)
-    g.connect_by_name(read_design, synth)
+    def reverse_connect(node1, node2):
+        g.connect_by_name(node2, node1)
 
-    g.connect_by_name(soc_rtl,  io_file)
+    reverse_connect(synth, rtl)
+    reverse_connect(synth, soc_rtl)
+    reverse_connect(synth, constraints)
+    reverse_connect(synth, read_design)
 
-    g.connect_by_name(synth,       iflow)
-    g.connect_by_name(synth,       init)
-    g.connect_by_name(synth,       power)
-    g.connect_by_name(synth,       place)
-    g.connect_by_name(synth,       cts)
+    g.connect_by_name(soc_rtl, io_file)
 
-    g.connect_by_name(iflow,    init)
-    g.connect_by_name(iflow,    power)
-    g.connect_by_name(iflow,    place)
-    g.connect_by_name(iflow,    cts)
-    g.connect_by_name(iflow,    postcts_hold)
-    g.connect_by_name(iflow,    route)
-    g.connect_by_name(iflow,    postroute)
-    g.connect_by_name(iflow,    postroute_hold)
-    g.connect_by_name(iflow,    signoff)
+    g.connect_by_name(synth, iflow)
+    g.connect_by_name(synth, init)
+    g.connect_by_name(synth, power)
+    g.connect_by_name(synth, place)
+    g.connect_by_name(synth, cts)
 
-    g.connect_by_name(custom_init,  init)
-    g.connect_by_name(custom_lvs,   lvs)
+    g.connect_by_name(iflow, init)
+    g.connect_by_name(iflow, power)
+    g.connect_by_name(iflow, place)
+    g.connect_by_name(iflow, cts)
+    g.connect_by_name(iflow, postcts_hold)
+    g.connect_by_name(iflow, route)
+    g.connect_by_name(iflow, postroute)
+    g.connect_by_name(iflow, postroute_hold)
+    g.connect_by_name(iflow, signoff)
+
+    g.connect_by_name(custom_init, init)
+    g.connect_by_name(custom_lvs, lvs)
     g.connect_by_name(custom_power, power)
 
     if which_soc == 'onyx':
-        g.connect_by_name(custom_cts,   cts)
+        g.connect_by_name(custom_cts, cts)
 
     # Connect gen_sram_macro node(s) to all downstream nodes that
     # need them
@@ -604,16 +610,15 @@ def construct():
     # Full chip floorplan stuff
     g.connect_by_name(io_file, init_fc)
     g.connect_by_name(init_fc, init)
-
-    g.connect_by_name(init,           power)
-    g.connect_by_name(power,          place)
-    g.connect_by_name(place,          cts)
-    g.connect_by_name(cts,            postcts_hold)
-    g.connect_by_name(postcts_hold,   route)
-    g.connect_by_name(route,          postroute)
-    g.connect_by_name(postroute,      postroute_hold)
+    g.connect_by_name(init, power)
+    g.connect_by_name(power, place)
+    g.connect_by_name(place, cts)
+    g.connect_by_name(cts, postcts_hold)
+    g.connect_by_name(postcts_hold, route)
+    g.connect_by_name(route, postroute)
+    g.connect_by_name(postroute, postroute_hold)
     g.connect_by_name(postroute_hold, signoff)
-    g.connect_by_name(signoff,        lvs)
+    g.connect_by_name(signoff, lvs)
 
     if which_soc == 'onyx':
         # Merge guardring gds into design
@@ -643,7 +648,7 @@ def construct():
         g.connect(signoff.o('design-merged.gds'), lvs.i('design_merged.gds'))
 
         # Skipping
-        g.connect(signoff.o('design-merged.gds'),   merge_rdl.i('design.gds'))
+        g.connect(signoff.o('design-merged.gds'), merge_rdl.i('design.gds'))
         g.connect(dragonphy.o('dragonphy_RDL.gds'), merge_rdl.i('child.gds'))
         g.connect_by_name(merge_rdl, lvs)
 
@@ -658,17 +663,17 @@ def construct():
         g.connect_by_name(merge_fill, drc)
         g.connect_by_name(merge_fill, antenna_drc)
 
-    g.connect_by_name(adk,          pt_signoff)
-    g.connect_by_name(signoff,      pt_signoff)
+    g.connect_by_name(adk, pt_signoff)
+    g.connect_by_name(signoff, pt_signoff)
 
-    g.connect_by_name(adk,      debugcalibre)
-    g.connect_by_name(synth,    debugcalibre)
-    g.connect_by_name(iflow,    debugcalibre)
-    g.connect_by_name(signoff,  debugcalibre)
+    g.connect_by_name(adk, debugcalibre)
+    g.connect_by_name(synth, debugcalibre)
+    g.connect_by_name(iflow, debugcalibre)
+    g.connect_by_name(signoff, debugcalibre)
 
     if which_soc == 'amber':
-        g.connect_by_name(drc,      debugcalibre)
-        g.connect_by_name(lvs,      debugcalibre)
+        g.connect_by_name(drc, debugcalibre)
+        g.connect_by_name(lvs, debugcalibre)
 
     g.connect_by_name(pre_route, route)
     g.connect_by_name(sealring, signoff)

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -12,6 +12,7 @@ from mflowgen.components import Graph, Step, Subgraph
 from shutil import which
 from common.get_sys_adk import get_sys_adk
 
+
 def sr_override_parms(parmdict):
     '''
     # A mechanism whereby e.g. buildkite can alter parms at the last minute
@@ -24,13 +25,13 @@ def sr_override_parms(parmdict):
     import os
     for e in os.environ:
         # e.g. e="MFLOWGEN_PARM_OVERRIDE_hold_target_slack"
-        if e[0:22]=="MFLOWGEN_PARM_OVERRIDE":
-            parm=e[23:99];     # e.g. parm="hold_target_slack"
+        if e[0:22] == "MFLOWGEN_PARM_OVERRIDE":
+            parm = e[23:99]     # e.g. parm="hold_target_slack"
             print(f'+++ FOUND MFLOWGEN PARAMETER OVERRIDE "{parm}={os.environ[e]}"')
             print(f'BEFOR: parmdict["hold_target_slack"]={parmdict["hold_target_slack"]}')
-            parmdict[parm]=os.environ[e]
+            parmdict[parm] = os.environ[e]
     print(f'AFTER: parmdict["hold_target_slack"]={parmdict["hold_target_slack"]}')
-    return(parmdict)
+    return parmdict
 
 
 def construct():
@@ -60,97 +61,97 @@ def construct():
         power_drc_rule_deck = 'pegasus-drc-block.rule'
 
     parameters = {
-      'construct_path': __file__,
-      'design_name': 'GarnetSOC_pad_frame',
-      'clock_period': 1.1,
-      'adk': adk_name,
-      'adk_view': adk_view,
+        'construct_path': __file__,
+        'design_name': 'GarnetSOC_pad_frame',
+        'clock_period': 1.1,
+        'adk': adk_name,
+        'adk_view': adk_view,
 
-      # Synthesis
-      'flatten_effort': 0,
-      'topographical': True,
+        # Synthesis
+        'flatten_effort': 0,
+        'topographical': True,
 
-      # RTL Generation
-      'array_width': 32,
-      'array_height': 16,
-      'num_glb_tiles': 16,
-      'interconnect_only': False,
-      'use_local_garnet': False,
-      # glb tile memory size (unit: KB)
-      # 'glb_tile_mem_size' : 64,  #  64x16 => 1M global buffer
-      'glb_tile_mem_size': 256,   # 256*16 => 4M global buffer
+        # RTL Generation
+        'array_width': 32,
+        'array_height': 16,
+        'num_glb_tiles': 16,
+        'interconnect_only': False,
+        'use_local_garnet': False,
+        # glb tile memory size (unit: KB)
+        # 'glb_tile_mem_size' : 64,  #  64x16 => 1M global buffer
+        'glb_tile_mem_size': 256,   # 256*16 => 4M global buffer
 
-      # Power Domains
-      'PWR_AWARE': True,
+        # Power Domains
+        'PWR_AWARE': True,
 
-      # Include Garnet?
-      'soc_only': False,
+        # Include Garnet?
+        'soc_only': False,
 
-      # Include SoC core? (use 0 for false, 1 for true)
-      'include_core': 1,
+        # Include SoC core? (use 0 for false, 1 for true)
+        'include_core': 1,
 
-      # Include sealring?
-      'include_sealring': False,
+        # Include sealring?
+        'include_sealring': False,
 
-      # SRAM macros
-      'num_words': 4096,
-      'word_size': 64,
-      'mux_size': 8,
-      'num_subarrays': 2,
-      'partial_write': True,
+        # SRAM macros
+        'num_words': 4096,
+        'word_size': 64,
+        'mux_size': 8,
+        'num_subarrays': 2,
+        'partial_write': True,
 
-      # Low Effort flow
-      'express_flow': False,
-      'skip_verify_connectivity': True,
+        # Low Effort flow
+        'express_flow': False,
+        'skip_verify_connectivity': True,
 
-      # Hold fixing
-      'signoff_engine': True,
-      'hold_target_slack': 0.100,
+        # Hold fixing
+        'signoff_engine': True,
+        'hold_target_slack': 0.100,
 
-      # LVS
-      # - need lvs2 because dragonphy uses LVT cells
-      'lvs_extra_spice_include': 'inputs/adk_lvs2/*.cdl',
-      'lvs_hcells_file': 'inputs/adk/hcells.inc',
-      'lvs_connect_names': '"VDD VSS VDDPST"',
-      'lvs_verify_netlist': 0,
+        # LVS
+        # - need lvs2 because dragonphy uses LVT cells
+        'lvs_extra_spice_include': 'inputs/adk_lvs2/*.cdl',
+        'lvs_hcells_file': 'inputs/adk/hcells.inc',
+        'lvs_connect_names': '"VDD VSS VDDPST"',
+        'lvs_verify_netlist': 0,
 
-      # TSMC16 support for LVS - need lvs2 because dragonphy uses LVT cells
-      'adk_view_lvs2': 'multivt',
+        # TSMC16 support for LVS - need lvs2 because dragonphy uses LVT cells
+        'adk_view_lvs2': 'multivt',
 
-      # TLX Ports Partitions
-      'TLX_FWD_DATA_LO_WIDTH': 16,
-      'TLX_REV_DATA_LO_WIDTH': 45,
+        # TLX Ports Partitions
+        'TLX_FWD_DATA_LO_WIDTH': 16,
+        'TLX_REV_DATA_LO_WIDTH': 45,
 
-      # DRC rule deck
-      'drc_rule_deck': drc_rule_deck,
-      'antenna_drc_rule_deck': antenna_drc_rule_deck,
-      'power_drc_rule_deck': power_drc_rule_deck,
-      'nthreads': 16,
-      'drc_env_setup': 'drcenv-chip.sh',
-      'antenna_drc_env_setup': 'drcenv-chip-ant.sh',
+        # DRC rule deck
+        'drc_rule_deck': drc_rule_deck,
+        'antenna_drc_rule_deck': antenna_drc_rule_deck,
+        'power_drc_rule_deck': power_drc_rule_deck,
+        'nthreads': 16,
+        'drc_env_setup': 'drcenv-chip.sh',
+        'antenna_drc_env_setup': 'drcenv-chip-ant.sh',
 
-      # Testbench
-      'cgra_apps': ["tests/conv_1_2", "tests/conv_2_1"]
+        # Testbench
+        'cgra_apps': ["tests/conv_1_2", "tests/conv_2_1"]
     }
 
     # Note 'lvs_adk_view' not used by amber/tsmc
-    if parameters['PWR_AWARE'] == True:
+    if parameters['PWR_AWARE'] is True:
         parameters['lvs_adk_view'] = adk_view + '-pm'
     else:
         parameters['lvs_adk_view'] = adk_view
 
     # TSMC overrides
-    if adk_name == 'tsmc16': parameters.update({
-      'clock_period': 1.3,
-      'include_sealring': True,
-      'num_words': 2048,
-      'corner': "tt0p8v25c",
-      # Dragonphy
-      'dragonphy_rdl_x': '613.565u',
-      'dragonphy_rdl_y': '3901.872u',
-      'hold_target_slack': 0.060,
+    if adk_name == 'tsmc16':
+        parameters.update({
+            'clock_period': 1.3,
+            'include_sealring': True,
+            'num_words': 2048,
+            'corner': "tt0p8v25c",
+            'dragonphy_rdl_x': '613.565u',
+            'dragonphy_rdl_y': '3901.872u',
+            'hold_target_slack': 0.060,
+        })
 
-    })
     # OG TSMC did not set drc_env_setup etc.
     if adk_name == 'tsmc16':
         parameters.pop('use_local_garnet')
@@ -160,19 +161,19 @@ def construct():
     # 'sram_2' and 'guarding' are onyx/GF-only parameters (for now)
 
     sram_2_params = {
-      # SRAM macros
-      'num_words': 32768,
-      'word_size': 32,
-      'mux_size': 16,
-      'num_subarrays': 8,
-      'partial_write': True,
+        # SRAM macros
+        'num_words': 32768,
+        'word_size': 32,
+        'mux_size': 16,
+        'num_subarrays': 8,
+        'partial_write': True,
     }
 
     guardring_params = {
-      # Merging guardring into GDS
-      'child_gds': 'inputs/adk/guardring.gds',
-      'coord_x': '-49.98u',
-      'coord_y': '-49.92u'
+        # Merging guardring into GDS
+        'child_gds': 'inputs/adk/guardring.gds',
+        'coord_x': '-49.98u',
+        'coord_y': '-49.92u'
     }
 
     # -----------------------------------------------------------------------
@@ -246,10 +247,10 @@ def construct():
     def default_step(step_name):
         return Step(step_name, default=True)
 
-    # Turn off formatting b/c want these cloumns to line up
+    # Turn off formatting b/c want these columns to line up
     # autopep8: off
     info           = default_step('info')  # noqa
-    #constraints   = default_step('constraints')
+    # constraints  = default_step('constraints')
     synth          = default_step('cadence-genus-synthesis')    # noqa
     iflow          = default_step('cadence-innovus-flowsetup')  # noqa
     init           = default_step('cadence-innovus-init')       # noqa
@@ -549,7 +550,7 @@ def construct():
 
     # All of the blocks within this hierarchical design
     # Skip these if we're doing soc_only
-    if parameters['soc_only'] == False:
+    if parameters['soc_only'] is False:
         blocks = [tile_array, glb_top, global_controller]
         if which_soc == 'onyx':
             blocks += [xgcd]
@@ -708,7 +709,7 @@ def construct():
     g.update_params(parameters)
 
     if which_soc == 'onyx':
-        # Provide different parameter set to second sram node, so it can actually 
+        # Provide different parameter set to second sram node, so it can actually
         # generate a different sram
         gen_sram_2.update_params(sram_2_params)
 
@@ -726,29 +727,31 @@ def construct():
     synth.update_params({'TLX_REV_DATA_LO_WIDTH': parameters['TLX_REV_DATA_LO_WIDTH']}, True)
     init.update_params({'soc_only': parameters['soc_only']}, True)
 
-    if which_soc == 'amber': init.update_params(
-      {'order': [
-        'main.tcl','quality-of-life.tcl',
-        'stylus-compatibility-procs.tcl','floorplan.tcl','io-fillers.tcl',
-        'alignment-cells.tcl',
-        'analog-bumps/route-phy-bumps.tcl',
-        'analog-bumps/bump-connect.tcl',
-        'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
-        'place-macros.tcl', 'dont-touch.tcl'
-      ]}
-    )
+    if which_soc == 'amber':
+        init.update_params(
+            {'order': [
+                'main.tcl', 'quality-of-life.tcl',
+                'stylus-compatibility-procs.tcl', 'floorplan.tcl', 'io-fillers.tcl',
+                'alignment-cells.tcl',
+                'analog-bumps/route-phy-bumps.tcl',
+                'analog-bumps/bump-connect.tcl',
+                'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
+                'place-macros.tcl', 'dont-touch.tcl'
+            ]}
+        )
 
-    if which_soc == 'onyx': init.update_params(
-      {'order': [
-        'main.tcl','quality-of-life.tcl',
-        'stylus-compatibility-procs.tcl','floorplan.tcl','io-fillers.tcl',
-        'alignment-cells.tcl',
-        # 'analog-bumps/route-phy-bumps.tcl',
-        # 'analog-bumps/bump-connect.tcl',
-        'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
-        'place-macros.tcl', 'dont-touch.tcl'
-      ]}
-    )
+    if which_soc == 'onyx':
+        init.update_params(
+            {'order': [
+                'main.tcl', 'quality-of-life.tcl',
+                'stylus-compatibility-procs.tcl', 'floorplan.tcl', 'io-fillers.tcl',
+                'alignment-cells.tcl',
+                # 'analog-bumps/route-phy-bumps.tcl',
+                # 'analog-bumps/bump-connect.tcl',
+                'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
+                'place-macros.tcl', 'dont-touch.tcl'
+            ]}
+        )
 
     # glb_top parameters update
     glb_top.update_params({'array_width': parameters['array_width']}, True)
@@ -765,8 +768,10 @@ def construct():
 
     # Power node order manipulation
     order = power.get_param('order')
+
     # Move endcap/welltap insertion to end of power step to improve runtime
     order.append('add-endcaps-welltaps.tcl')
+
     # Stream out post-power GDS so that we can run DRC here
     order.append('innovus-foundation-flow/custom-scripts/stream-out.tcl')
     order.append('attach-results-to-outputs.tcl')
@@ -779,9 +784,11 @@ def construct():
 
     # Signoff order additions
     order = signoff.get_param('order')
+
     # Add sealring at beginning of signoff, so it's in before we stream out GDS
-    if parameters['include_sealring'] == True:
+    if parameters['include_sealring'] is True:
         order.insert(0, 'add-sealring.tcl')
+
     # Add netlist-fixing script before we save new netlist
     index = order.index('generate-results.tcl')
     order.insert(index, 'netlist-fixing.tcl')

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -60,63 +60,77 @@ def construct():
         power_drc_rule_deck = 'pegasus-drc-block.rule'
 
     parameters = {
-      'construct_path'    : __file__,
-      'design_name'       : 'GarnetSOC_pad_frame',
-      'clock_period'      : 1.1,
-      'adk'               : adk_name,
-      'adk_view'          : adk_view,
+      'construct_path': __file__,
+      'design_name': 'GarnetSOC_pad_frame',
+      'clock_period': 1.1,
+      'adk': adk_name,
+      'adk_view': adk_view,
+
       # Synthesis
-      'flatten_effort'    : 0,
-      'topographical'     : True,
+      'flatten_effort': 0,
+      'topographical': True,
+
       # RTL Generation
-      'array_width'       : 32,
-      'array_height'      : 16,
-      'num_glb_tiles'     : 16,
-      'interconnect_only' : False,
-      'use_local_garnet'  : False,
+      'array_width': 32,
+      'array_height': 16,
+      'num_glb_tiles': 16,
+      'interconnect_only': False,
+      'use_local_garnet': False,
       # glb tile memory size (unit: KB)
       # 'glb_tile_mem_size' : 64,  #  64x16 => 1M global buffer
-      'glb_tile_mem_size' : 256,   # 256*16 => 4M global buffer
+      'glb_tile_mem_size': 256,   # 256*16 => 4M global buffer
+
       # Power Domains
-      'PWR_AWARE'         : True,
+      'PWR_AWARE': True,
+
       # Include Garnet?
-      'soc_only'          : False,
+      'soc_only': False,
+
       # Include SoC core? (use 0 for false, 1 for true)
-      'include_core'      : 1,
+      'include_core': 1,
+
       # Include sealring?
-      'include_sealring'  : False,
+      'include_sealring': False,
+
       # SRAM macros
-      'num_words'         : 4096,
-      'word_size'         : 64,
-      'mux_size'          : 8,
-      'num_subarrays'     : 2,
-      'partial_write'     : True,
+      'num_words': 4096,
+      'word_size': 64,
+      'mux_size': 8,
+      'num_subarrays': 2,
+      'partial_write': True,
+
       # Low Effort flow
-      'express_flow'             : False,
-      'skip_verify_connectivity' : True,
+      'express_flow': False,
+      'skip_verify_connectivity': True,
+
       # Hold fixing
-      'signoff_engine' : True,
-      'hold_target_slack'  : 0.100,
+      'signoff_engine': True,
+      'hold_target_slack': 0.100,
+
       # LVS
       # - need lvs2 because dragonphy uses LVT cells
-      'lvs_extra_spice_include' : 'inputs/adk_lvs2/*.cdl',
-      'lvs_hcells_file'   : 'inputs/adk/hcells.inc',
-      'lvs_connect_names' : '"VDD VSS VDDPST"',
-      'lvs_verify_netlist' : 0,
+      'lvs_extra_spice_include': 'inputs/adk_lvs2/*.cdl',
+      'lvs_hcells_file': 'inputs/adk/hcells.inc',
+      'lvs_connect_names': '"VDD VSS VDDPST"',
+      'lvs_verify_netlist': 0,
+
       # TSMC16 support for LVS - need lvs2 because dragonphy uses LVT cells
-      'adk_view_lvs2'     : 'multivt',
+      'adk_view_lvs2': 'multivt',
+
       # TLX Ports Partitions
-      'TLX_FWD_DATA_LO_WIDTH' : 16,
-      'TLX_REV_DATA_LO_WIDTH' : 45,
+      'TLX_FWD_DATA_LO_WIDTH': 16,
+      'TLX_REV_DATA_LO_WIDTH': 45,
+
       # DRC rule deck
-      'drc_rule_deck'         : drc_rule_deck,
-      'antenna_drc_rule_deck' : antenna_drc_rule_deck,
-      'power_drc_rule_deck'   : power_drc_rule_deck,
-      'nthreads'              : 16,
-      'drc_env_setup'         : 'drcenv-chip.sh',
-      'antenna_drc_env_setup' : 'drcenv-chip-ant.sh',
+      'drc_rule_deck': drc_rule_deck,
+      'antenna_drc_rule_deck': antenna_drc_rule_deck,
+      'power_drc_rule_deck': power_drc_rule_deck,
+      'nthreads': 16,
+      'drc_env_setup': 'drcenv-chip.sh',
+      'antenna_drc_env_setup': 'drcenv-chip-ant.sh',
+
       # Testbench
-      'cgra_apps' : ["tests/conv_1_2", "tests/conv_2_1"]
+      'cgra_apps': ["tests/conv_1_2", "tests/conv_2_1"]
     }
 
     # Note 'lvs_adk_view' not used by amber/tsmc
@@ -127,14 +141,14 @@ def construct():
 
     # TSMC overrides
     if adk_name == 'tsmc16': parameters.update({
-      'clock_period'      : 1.3,
-      'include_sealring'  : True,
-      'num_words'         : 2048,
-      'corner'            : "tt0p8v25c",
+      'clock_period': 1.3,
+      'include_sealring': True,
+      'num_words': 2048,
+      'corner': "tt0p8v25c",
       # Dragonphy
-      'dragonphy_rdl_x'   : '613.565u',
-      'dragonphy_rdl_y'   : '3901.872u',
-      'hold_target_slack'  : 0.060,
+      'dragonphy_rdl_x': '613.565u',
+      'dragonphy_rdl_y': '3901.872u',
+      'hold_target_slack': 0.060,
 
     })
     # OG TSMC did not set drc_env_setup etc.
@@ -147,18 +161,18 @@ def construct():
 
     sram_2_params = {
       # SRAM macros
-      'num_words'         : 32768,
-      'word_size'         : 32,
-      'mux_size'          : 16,
-      'num_subarrays'     : 8,
-      'partial_write'     : True,
+      'num_words': 32768,
+      'word_size': 32,
+      'mux_size': 16,
+      'num_subarrays': 8,
+      'partial_write': True,
     }
 
     guardring_params = {
       # Merging guardring into GDS
-      'child_gds' : 'inputs/adk/guardring.gds',
-      'coord_x'   : '-49.98u',
-      'coord_y'   : '-49.92u'
+      'child_gds': 'inputs/adk/guardring.gds',
+      'coord_x': '-49.98u',
+      'coord_y': '-49.92u'
     }
 
     #-----------------------------------------------------------------------
@@ -696,7 +710,7 @@ def construct():
         gen_sram_2.update_params(sram_2_params)
 
         # LVS adk has separate view parameter
-        lvs_adk.update_params({'adk_view' : parameters['lvs_adk_view']})
+        lvs_adk.update_params({'adk_view': parameters['lvs_adk_view']})
 
     # Since we are adding an additional input script to the generic Innovus
     # steps, we modify the order parameter for that node which determines
@@ -705,8 +719,8 @@ def construct():
     # DC needs these param to set the NO_CGRA macro
     synth.update_params({'soc_only': parameters['soc_only']}, True)
     # DC needs these params to set macros in soc rtl
-    synth.update_params({'TLX_FWD_DATA_LO_WIDTH' : parameters['TLX_FWD_DATA_LO_WIDTH']}, True)
-    synth.update_params({'TLX_REV_DATA_LO_WIDTH' : parameters['TLX_REV_DATA_LO_WIDTH']}, True)
+    synth.update_params({'TLX_FWD_DATA_LO_WIDTH': parameters['TLX_FWD_DATA_LO_WIDTH']}, True)
+    synth.update_params({'TLX_REV_DATA_LO_WIDTH': parameters['TLX_REV_DATA_LO_WIDTH']}, True)
     init.update_params({'soc_only': parameters['soc_only']}, True)
 
     if which_soc == 'amber': init.update_params(

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
-#=========================================================================
+# =========================================================================
 # construct.py
-#=========================================================================
+# =========================================================================
 # Author :
 # Date   :
 #
@@ -37,9 +37,9 @@ def construct():
 
     g = Graph()
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Parameters
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     adk_name = get_sys_adk()  # E.g. 'gf12-adk' or 'tsmc16'
     adk_view = 'multivt'
@@ -175,9 +175,9 @@ def construct():
       'coord_y': '-49.92u'
     }
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Create nodes
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     this_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -188,53 +188,53 @@ def construct():
 
     # Custom steps
 
-    rtl            = Step(this_dir + '/../common/rtl')
-    soc_rtl        = Step(this_dir + '/../common/soc-rtl-v2')
+    rtl = Step(this_dir + '/../common/rtl')
+    soc_rtl = Step(this_dir + '/../common/soc-rtl-v2')
 
     if adk_name == "tsmc16":
-        gen_sram       = Step(this_dir + '/../common/gen_sram_macro_amber')
-        constraints    = Step(this_dir + '/constraints_amber')
+        gen_sram = Step(this_dir + '/../common/gen_sram_macro_amber')
+        constraints = Step(this_dir + '/constraints_amber')
     else:
-        gen_sram       = Step(this_dir + '/../common/gen_sram_macro')
-        constraints    = Step(this_dir + '/constraints')
+        gen_sram = Step(this_dir + '/../common/gen_sram_macro')
+        constraints = Step(this_dir + '/constraints')
 
-    read_design    = Step(this_dir + '/../common/fc-custom-read-design')
+    read_design = Step(this_dir + '/../common/fc-custom-read-design')
     if adk_name == 'tsmc16':
-        custom_init          = Step(this_dir + '/custom-init-amber')
-        custom_lvs           = Step(this_dir + '/custom-lvs-rules-amber')
-        custom_power         = Step(this_dir + '/../common/custom-power-chip-amber')
-        init_fc              = Step(this_dir + '/../common/init-fullchip-amber')
+        custom_init = Step(this_dir + '/custom-init-amber')
+        custom_lvs = Step(this_dir + '/custom-lvs-rules-amber')
+        custom_power = Step(this_dir + '/../common/custom-power-chip-amber')
+        init_fc = Step(this_dir + '/../common/init-fullchip-amber')
     else:
-        custom_init          = Step(this_dir + '/custom-init')
-        custom_lvs           = Step(this_dir + '/custom-lvs-rules')
-        custom_power         = Step(this_dir + '/../common/custom-power-chip')
-        custom_cts           = Step(this_dir + '/custom-cts')
-        init_fc              = Step(this_dir + '/../common/init-fullchip')
-    io_file        = Step(this_dir + '/io_file')
-    pre_route      = Step(this_dir + '/pre-route')
-    sealring       = Step(this_dir + '/sealring')
+        custom_init = Step(this_dir + '/custom-init')
+        custom_lvs = Step(this_dir + '/custom-lvs-rules')
+        custom_power = Step(this_dir + '/../common/custom-power-chip')
+        custom_cts = Step(this_dir + '/custom-cts')
+        init_fc = Step(this_dir + '/../common/init-fullchip')
+    io_file = Step(this_dir + '/io_file')
+    pre_route = Step(this_dir + '/pre-route')
+    sealring = Step(this_dir + '/sealring')
     netlist_fixing = Step(this_dir + '/../common/fc-netlist-fixing')
     if which_soc == 'onyx':
-        drc_pm         = Step(this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
-        drc_dp         = Step(this_dir + '/gf-drc-dp')
-        drc_mas        = Step(this_dir + '/../common/gf-mentor-calibre-drc-mas')
+        drc_pm = Step(this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
+        drc_dp = Step(this_dir + '/gf-drc-dp')
+        drc_mas = Step(this_dir + '/../common/gf-mentor-calibre-drc-mas')
 
     # Block-level designs
 
-    tile_array        = Subgraph(this_dir + '/../tile_array', 'tile_array')
-    glb_top           = Subgraph(this_dir + '/../glb_top', 'glb_top')
+    tile_array = Subgraph(this_dir + '/../tile_array', 'tile_array')
+    glb_top = Subgraph(this_dir + '/../glb_top', 'glb_top')
     global_controller = Subgraph(this_dir + '/../global_controller', 'global_controller')
 
     if which_soc == 'amber':
-        dragonphy         = Step(this_dir + '/dragonphy')
+        dragonphy = Step(this_dir + '/dragonphy')
     elif which_soc == 'onyx':
-        xgcd              = Step(this_dir + '/xgcd')
+        xgcd = Step(this_dir + '/xgcd')
 
     # CGRA simulation
 
-    cgra_rtl_sim_compile  = Step(this_dir + '/cgra_rtl_sim_compile')
-    cgra_rtl_sim_run      = Step(this_dir + '/cgra_rtl_sim_run')
-    cgra_sim_build        = Step(this_dir + '/cgra_sim_build')
+    cgra_rtl_sim_compile = Step(this_dir + '/cgra_rtl_sim_compile')
+    cgra_rtl_sim_run = Step(this_dir + '/cgra_rtl_sim_run')
+    cgra_sim_build = Step(this_dir + '/cgra_sim_build')
     # cgra_gl_sim_compile   = Step(this_dir + '/cgra_gl_sim_compile')
     # cgra_gl_sim_run       = Step(this_dir + '/cgra_gl_sim_run')
     # cgra_gl_ptpx          = Step(this_dir + '/cgra_gl_ptpx')
@@ -246,6 +246,8 @@ def construct():
     def default_step(step_name):
         return Step(step_name, default=True)
 
+    # Turn off formatting b/c want these cloumns to line up
+    # autopep8: off
     info           = default_step('info')
     #constraints   = default_step('constraints')
     synth          = default_step('cadence-genus-synthesis')
@@ -260,6 +262,7 @@ def construct():
     postroute_hold = default_step('cadence-innovus-postroute_hold')
     signoff        = default_step('cadence-innovus-signoff')
     pt_signoff     = default_step('synopsys-pt-timing-signoff')
+    # autopep8: on
 
     if which("calibre") is not None:
         drc = default_step('mentor-calibre-drc')
@@ -426,9 +429,9 @@ def construct():
         soc_rtl.pre_extend_commands([cmd2])
         soc_rtl.pre_extend_commands([cmd3])
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Graph -- Add nodes
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     g.add_step(info)
     g.add_step(rtl)
@@ -494,9 +497,9 @@ def construct():
         g.add_step(merge_rdl)
         g.add_step(dragonphy)
 
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Graph -- Add edges
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     # Connect by name
 
@@ -695,9 +698,9 @@ def construct():
 
     # Post-Power DRC
     g.connect(power.o('design-merged.gds'), power_drc.i('design_merged.gds'))
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
     # Parameterize
-    #-----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
 
     # Allow user to override parms with env in a limited sort of way
     parameters = sr_override_parms(parameters)
@@ -740,8 +743,8 @@ def construct():
         'main.tcl','quality-of-life.tcl',
         'stylus-compatibility-procs.tcl','floorplan.tcl','io-fillers.tcl',
         'alignment-cells.tcl',
-        #'analog-bumps/route-phy-bumps.tcl',
-        #'analog-bumps/bump-connect.tcl',
+        # 'analog-bumps/route-phy-bumps.tcl',
+        # 'analog-bumps/bump-connect.tcl',
         'gen-bumps.tcl', 'check-bumps.tcl', 'route-bumps.tcl',
         'place-macros.tcl', 'dont-touch.tcl'
       ]}

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -180,8 +180,6 @@ def construct():
     # Create nodes
     # -----------------------------------------------------------------------
 
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-
     # ADK step
 
     g.set_adk(adk_name)
@@ -189,58 +187,65 @@ def construct():
 
     # Custom steps
 
-    rtl = Step(this_dir + '/../common/rtl')
-    soc_rtl = Step(this_dir + '/../common/soc-rtl-v2')
+    def custom_step(path):
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        return Step(this_dir + path)
+
+    rtl = custom_step('/../common/rtl')
+    soc_rtl = custom_step('/../common/soc-rtl-v2')
 
     if adk_name == "tsmc16":
-        gen_sram = Step(this_dir + '/../common/gen_sram_macro_amber')
-        constraints = Step(this_dir + '/constraints_amber')
+        gen_sram = custom_step('/../common/gen_sram_macro_amber')
+        constraints = custom_step('/constraints_amber')
     else:
-        gen_sram = Step(this_dir + '/../common/gen_sram_macro')
-        constraints = Step(this_dir + '/constraints')
+        gen_sram = custom_step('/../common/gen_sram_macro')
+        constraints = custom_step('/constraints')
 
-    read_design = Step(this_dir + '/../common/fc-custom-read-design')
+    read_design = custom_step('/../common/fc-custom-read-design')
+
     if adk_name == 'tsmc16':
-        custom_init = Step(this_dir + '/custom-init-amber')
-        custom_lvs = Step(this_dir + '/custom-lvs-rules-amber')
-        custom_power = Step(this_dir + '/../common/custom-power-chip-amber')
-        init_fc = Step(this_dir + '/../common/init-fullchip-amber')
+        custom_init = custom_step('/custom-init-amber')
+        custom_lvs = custom_step('/custom-lvs-rules-amber')
+        custom_power = custom_step('/../common/custom-power-chip-amber')
+        init_fc = custom_step('/../common/init-fullchip-amber')
     else:
-        custom_init = Step(this_dir + '/custom-init')
-        custom_lvs = Step(this_dir + '/custom-lvs-rules')
-        custom_power = Step(this_dir + '/../common/custom-power-chip')
-        custom_cts = Step(this_dir + '/custom-cts')
-        init_fc = Step(this_dir + '/../common/init-fullchip')
-    io_file = Step(this_dir + '/io_file')
-    pre_route = Step(this_dir + '/pre-route')
-    sealring = Step(this_dir + '/sealring')
-    netlist_fixing = Step(this_dir + '/../common/fc-netlist-fixing')
+        custom_init = custom_step('/custom-init')
+        custom_lvs = custom_step('/custom-lvs-rules')
+        custom_power = custom_step('/../common/custom-power-chip')
+        custom_cts = custom_step('/custom-cts')
+        init_fc = custom_step('/../common/init-fullchip')
+
+    io_file = custom_step('/io_file')
+    pre_route = custom_step('/pre-route')
+    sealring = custom_step('/sealring')
+    netlist_fixing = custom_step('/../common/fc-netlist-fixing')
     if which_soc == 'onyx':
-        drc_pm = Step(this_dir + '/../common/gf-mentor-calibre-drcplus-pm')
-        drc_dp = Step(this_dir + '/gf-drc-dp')
-        drc_mas = Step(this_dir + '/../common/gf-mentor-calibre-drc-mas')
+        drc_pm = custom_step('/../common/gf-mentor-calibre-drcplus-pm')
+        drc_dp = custom_step('/gf-drc-dp')
+        drc_mas = custom_step('/../common/gf-mentor-calibre-drc-mas')
 
     # Block-level designs
 
+    this_dir = os.path.dirname(os.path.abspath(__file__))
     tile_array = Subgraph(this_dir + '/../tile_array', 'tile_array')
     glb_top = Subgraph(this_dir + '/../glb_top', 'glb_top')
     global_controller = Subgraph(this_dir + '/../global_controller', 'global_controller')
 
     if which_soc == 'amber':
-        dragonphy = Step(this_dir + '/dragonphy')
+        dragonphy = custom_step('/dragonphy')
     elif which_soc == 'onyx':
-        xgcd = Step(this_dir + '/xgcd')
+        xgcd = custom_step('/xgcd')
 
     # CGRA simulation
 
-    cgra_rtl_sim_compile = Step(this_dir + '/cgra_rtl_sim_compile')
-    cgra_rtl_sim_run = Step(this_dir + '/cgra_rtl_sim_run')
-    cgra_sim_build = Step(this_dir + '/cgra_sim_build')
-    # cgra_gl_sim_compile   = Step(this_dir + '/cgra_gl_sim_compile')
-    # cgra_gl_sim_run       = Step(this_dir + '/cgra_gl_sim_run')
-    # cgra_gl_ptpx          = Step(this_dir + '/cgra_gl_ptpx')
-    # cgra_rtl_sim_verdict  = Step(this_dir + '/cgra_rtl_sim_verdict')
-    # cgra_gl_sim_verdict   = Step(this_dir + '/cgra_gl_sim_verdict')
+    cgra_rtl_sim_compile = custom_step('/cgra_rtl_sim_compile')
+    cgra_rtl_sim_run = custom_step('/cgra_rtl_sim_run')
+    cgra_sim_build = custom_step('/cgra_sim_build')
+    # cgra_gl_sim_compile   = custom_step('/cgra_gl_sim_compile')
+    # cgra_gl_sim_run       = custom_step('/cgra_gl_sim_run')
+    # cgra_gl_ptpx          = custom_step('/cgra_gl_ptpx')
+    # cgra_rtl_sim_verdict  = custom_step('/cgra_rtl_sim_verdict')
+    # cgra_gl_sim_verdict   = custom_step('/cgra_gl_sim_verdict')
 
     # Default steps
 
@@ -270,7 +275,7 @@ def construct():
         lvs = default_step('mentor-calibre-lvs')
         # GF has a different way of running fill
         if adk_name == 'gf12-adk':
-            fill = default_step(this_dir + '/../common/mentor-calibre-fill-gf')
+            fill = custom_step('/../common/mentor-calibre-fill-gf')
             merge_gdr = default_step('mentor-calibre-gdsmerge-child')
         else:
             fill = default_step('mentor-calibre-fill')

--- a/mflowgen/full_chip/construct.py
+++ b/mflowgen/full_chip/construct.py
@@ -248,20 +248,20 @@ def construct():
 
     # Turn off formatting b/c want these cloumns to line up
     # autopep8: off
-    info           = default_step('info')
+    info           = default_step('info')  # noqa
     #constraints   = default_step('constraints')
-    synth          = default_step('cadence-genus-synthesis')
-    iflow          = default_step('cadence-innovus-flowsetup')
-    init           = default_step('cadence-innovus-init')
-    power          = default_step('cadence-innovus-power')
-    place          = default_step('cadence-innovus-place')
-    cts            = default_step('cadence-innovus-cts')
-    postcts_hold   = default_step('cadence-innovus-postcts_hold')
-    route          = default_step('cadence-innovus-route')
-    postroute      = default_step('cadence-innovus-postroute')
-    postroute_hold = default_step('cadence-innovus-postroute_hold')
-    signoff        = default_step('cadence-innovus-signoff')
-    pt_signoff     = default_step('synopsys-pt-timing-signoff')
+    synth          = default_step('cadence-genus-synthesis')    # noqa
+    iflow          = default_step('cadence-innovus-flowsetup')  # noqa
+    init           = default_step('cadence-innovus-init')       # noqa
+    power          = default_step('cadence-innovus-power')      # noqa
+    place          = default_step('cadence-innovus-place')      # noqa
+    cts            = default_step('cadence-innovus-cts')        # noqa
+    postcts_hold   = default_step('cadence-innovus-postcts_hold')  # noqa
+    route          = default_step('cadence-innovus-route')         # noqa
+    postroute      = default_step('cadence-innovus-postroute')     # noqa
+    postroute_hold = default_step('cadence-innovus-postroute_hold')  # noqa
+    signoff        = default_step('cadence-innovus-signoff')         # noqa
+    pt_signoff     = default_step('synopsys-pt-timing-signoff')      # noqa
     # autopep8: on
 
     if which("calibre") is not None:


### PR DESCRIPTION
Scrubbed three `mflowgen/*/construct.py` files to remove lint errors. This brings overall garnet repo lint PEP8 style error count down from 9978 to 6337:

BEFORE: https://buildkite.com/stanford-aha/garnet/builds/4981
```...........................Found 9978 E errors```

AFTER: https://buildkite.com/stanford-aha/garnet/builds/4992
```...........................Found 6337 E errors```
