### PR TITLE
Fix onyx gold bug

### DIFF
--- a/bin/rtl-goldcheck.sh
+++ b/bin/rtl-goldcheck.sh
@@ -162,7 +162,7 @@ if [ "$ndiffs" != "0" ]; then
 
     printf "Test FAILED with $ndiffs diffs\n\n"
     printf "Top 40 diffs:"
-    $vcompare $f1 $f2 | head -40
+    (set -o pipefail; $vcompare $f1 $f2 | head -40)
     printf "\ndiff $f1 $f2"
     printf "Test FAILED with $ndiffs diffs\n"
     exit 13

--- a/bin/rtl-goldcheck.sh
+++ b/bin/rtl-goldcheck.sh
@@ -153,6 +153,9 @@ printf "\n"
 
 vcompare=/aha/garnet/bin/rtl-goldcompare.sh
 
+set -e          # FAIL if any single command fails from here down
+set -o pipefail # FAIL if any command in any pipe fails from here down
+
 echo "$vcompare $f1 $f2"
 ndiffs=`$vcompare $f1 $f2 | wc -l`
 if [ "$ndiffs" != "0" ]; then
@@ -166,6 +169,7 @@ if [ "$ndiffs" != "0" ]; then
     printf "\ndiff $f1 $f2"
     printf "Test FAILED with $ndiffs diffs\n"
     exit 13
+else
+    echo "Test PASSED"
 fi
 
-echo "Test PASSED"

--- a/bin/rtl-goldcheck.sh
+++ b/bin/rtl-goldcheck.sh
@@ -153,9 +153,6 @@ printf "\n"
 
 vcompare=/aha/garnet/bin/rtl-goldcompare.sh
 
-set -e          # FAIL if any single command fails from here down
-set -o pipefail # FAIL if any command in any pipe fails from here down
-
 echo "$vcompare $f1 $f2"
 ndiffs=`$vcompare $f1 $f2 | wc -l`
 if [ "$ndiffs" != "0" ]; then
@@ -165,7 +162,7 @@ if [ "$ndiffs" != "0" ]; then
 
     printf "Test FAILED with $ndiffs diffs\n\n"
     printf "Top 40 diffs:"
-    (set -o pipefail; $vcompare $f1 $f2 | head -40)
+    $vcompare $f1 $f2 | head -40
     printf "\ndiff $f1 $f2"
     printf "Test FAILED with $ndiffs diffs\n"
     exit 13

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -22,7 +22,9 @@ EXAMPLES
 
 #     sed 's/clk_gate_unq/clk_gate/'    | # Treat clk_gate_unq same as clk_gate :(
 
-function vcompare {
+# Use parens for subshell so as not to screw up 'pipefail' setting in outer scope
+function vcompare { (
+    set -o pipefail # Fail if any part of the following pipe fails
     cat $1 |
     sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
     sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
@@ -31,11 +33,11 @@ function vcompare {
     sed '/^\s*$/d'         | # No blank lines
     sort                   | # Out-of-order is okay
     cat
-}
+) }
+
 # FAIL if something is wrong with vcompare
-set -o pipefail
-vcompare $1 > /dev/null
-vcompare $2 > /dev/null
+vcompare $1 > /dev/null || exit 13
+vcompare $2 > /dev/null || exit 13
 
 # Do the final compare
 diff -Bb -I Date <(vcompare $1) <(vcompare $2)

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -28,7 +28,7 @@ set -o pipefail # FAIL if any command in any pipe fails from here down
 function vcompare { (
     cat $1 |
     sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
-    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
+    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate/' | # Treat gate0 same as gate :(
     sed 's/,$//'           | # No trailing commas
     sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
     sed '/^\s*$/d'         | # No blank lines

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -27,7 +27,7 @@ set -o pipefail # FAIL if any command in any pipe fails from here down
 function vcompare {
     cat $1 |
     sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
-    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate/' | # Treat gate0 same as gate :(
+    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
     sed 's/,$//'           | # No trailing commas
     sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
     sed '/^\s*$/d'         | # No blank lines

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -22,23 +22,26 @@ EXAMPLES
 
 #     sed 's/clk_gate_unq/clk_gate/'    | # Treat clk_gate_unq same as clk_gate :(
 
-set -e          # FAIL if any single command fails from here down
 set -o pipefail # FAIL if any command in any pipe fails from here down
 
-function vcompare { (
+function vcompare {
     cat $1 |
     sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
-    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate/' | # Treat gate0 same as gate :(
+    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
     sed 's/,$//'           | # No trailing commas
     sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
     sed '/^\s*$/d'         | # No blank lines
     sort                   | # Out-of-order is okay
     cat
-) }
+}
 
 # FAIL if something is wrong with vcompare
-vcompare $1 > /dev/null
-vcompare $2 > /dev/null
+errmsg='vcompare script failed in rtl-goldcompare.sh'
+if ! vcompare $1 > /dev/null; then echo $errmsg; exit 13; fi
+if ! vcompare $2 > /dev/null; then echo $errmsg; exit 13; fi
+
+# vcompare $1 > /dev/null || echo 'vcompare script failed in rtl-goldcompare.sh'
+# vcompare $2 > /dev/null || echo 'vcompare script failed in rtl-goldcompare.sh'
 
 # Do the final compare
 diff -Bb -I Date <(vcompare $1) <(vcompare $2)

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -22,9 +22,10 @@ EXAMPLES
 
 #     sed 's/clk_gate_unq/clk_gate/'    | # Treat clk_gate_unq same as clk_gate :(
 
-# Use parens for subshell so as not to screw up 'pipefail' setting in outer scope
+set -e          # FAIL if any single command fails from here down
+set -o pipefail # FAIL if any command in any pipe fails from here down
+
 function vcompare { (
-    set -o pipefail # Fail if any part of the following pipe fails
     cat $1 |
     sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
     sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
@@ -36,8 +37,8 @@ function vcompare { (
 ) }
 
 # FAIL if something is wrong with vcompare
-vcompare $1 > /dev/null || exit 13
-vcompare $2 > /dev/null || exit 13
+vcompare $1 > /dev/null
+vcompare $2 > /dev/null
 
 # Do the final compare
 diff -Bb -I Date <(vcompare $1) <(vcompare $2)

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -24,8 +24,8 @@ EXAMPLES
 
 function vcompare {
     cat $1 |
-    sed 's/_O._value_O/_Ox_value_O/g'                    | # Treat all zeroes as equivalent
-    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
+    sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
+    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate/' | # Treat gate0 same as gate :(
     sed 's/,$//'           | # No trailing commas
     sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
     sed '/^\s*$/d'         | # No blank lines

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -25,7 +25,7 @@ EXAMPLES
 function vcompare {
     cat $1 |
     sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
-    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate/' | # Treat gate0 same as gate :(
+    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
     sed 's/,$//'           | # No trailing commas
     sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
     sed '/^\s*$/d'         | # No blank lines

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -33,6 +33,7 @@ function vcompare {
     cat
 }
 # FAIL if something is wrong with vcompare
+set -o pipefail
 vcompare $1 > /dev/null
 vcompare $2 > /dev/null
 

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -27,7 +27,7 @@ set -o pipefail # FAIL if any command in any pipe fails from here down
 function vcompare {
     cat $1 |
     sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
-    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
+    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate/' | # Treat gate0 same as gate :(
     sed 's/,$//'           | # No trailing commas
     sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
     sed '/^\s*$/d'         | # No blank lines

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -25,7 +25,7 @@ EXAMPLES
 function vcompare {
     cat $1 |
     sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
-    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
+    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate/' | # Treat gate0 same as gate :(
     sed 's/,$//'           | # No trailing commas
     sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
     sed '/^\s*$/d'         | # No blank lines

--- a/bin/rtl-goldcompare.sh
+++ b/bin/rtl-goldcompare.sh
@@ -25,11 +25,16 @@ EXAMPLES
 function vcompare {
     cat $1 |
     sed 's/_O._value_O/_Ox_value_O/g'                     | # Treat all zeroes as equivalent
-    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate/' | # Treat gate0 same as gate :(
+    sed 's/clk_gate0 glb_clk_gate/clk_gate glb_clk_gate' | # Treat gate0 same as gate :(
     sed 's/,$//'           | # No trailing commas
     sed 's/unq[0-9*]/unq/' | # Canonicalize unq's
     sed '/^\s*$/d'         | # No blank lines
     sort                   | # Out-of-order is okay
     cat
 }
+# FAIL if something is wrong with vcompare
+vcompare $1 > /dev/null
+vcompare $2 > /dev/null
+
+# Do the final compare
 diff -Bb -I Date <(vcompare $1) <(vcompare $2)


### PR DESCRIPTION
Oops, looks like the onyx gold check in the mflowgen buildkite pipeline has been silently failing for some time now. See e.g. this build, where the "Gold RTL" step says PASSED although, when you look at the log, it failed utterly because of a sed script error.

https://buildkite.com/tapeout-aha/mflowgen/builds/8124
```
Comparing 92061 lines of design.v
versus    91793 lines of onyx-4x2.v
 
/aha/garnet/bin/rtl-goldcompare.sh design.v onyx-4x2.v
sed: -e expression #1, char 46: unterminated `s' command
sed: -e expression #1, char 46: unterminated `s' command
Test PASSED
```
I fixed the sed script and also changed the test so that future failures will not say "PASSED".

https://buildkite.com/tapeout-aha/mflowgen/builds/8137

Note that the test still fails, but not silently, and not because of the sed script. This new failure will be addressed in a later change.
