### PR TITLE
Add sparse dense conversion

### DIFF
--- a/tests/test_app/lib/map.c
+++ b/tests/test_app/lib/map.c
@@ -160,7 +160,7 @@ int glb_map(void *kernel_) {
 
     // configure flush crossbar
     int kernel_crossbar_config = 0;
-    if (!kernel->is_sparse) {
+    if (!kernel->opal_dense_scanner_workaround) {
         for (int i = group_start; i < group_start + num_groups; i++) {
             crossbar_config[i] = first_input_tile;
         }

--- a/tests/test_app/lib/parser.c
+++ b/tests/test_app/lib/parser.c
@@ -361,6 +361,15 @@ void *parse_metadata(char *filename) {
         puts("Error, the placement property is not found.");
         exit(1);
     }
+
+    // parse the sparse app indicator field
+    json_t const *is_sparse_json = json_getProperty(testing_json, "is_sparse");
+    if (!is_sparse_json || JSON_INTEGER != json_getType(is_sparse_json)) {
+        info->is_sparse = 0;
+    } else {
+        info->is_sparse = json_getInteger(is_sparse_json);
+    }
+
     strncpy(info->placement_filename, dir, strnlen(dir, BUFFER_SIZE));
     strncat(info->placement_filename, json_getValue(place_json), BUFFER_SIZE);
 
@@ -545,6 +554,11 @@ int get_num_inputs(void *info) {
 int get_num_outputs(void *info) {
     GET_KERNEL_INFO(info);
     return kernel_info->num_outputs;
+}
+
+int get_is_sparse(void *info) {
+    GET_KERNEL_INFO(info);
+    return kernel_info->is_sparse;
 }
 
 void *get_io_tile_info(void *info, int index) {

--- a/tests/test_app/lib/parser.c
+++ b/tests/test_app/lib/parser.c
@@ -363,11 +363,11 @@ void *parse_metadata(char *filename) {
     }
 
     // parse the sparse app indicator field
-    json_t const *is_sparse_json = json_getProperty(testing_json, "is_sparse");
-    if (!is_sparse_json || JSON_INTEGER != json_getType(is_sparse_json)) {
-        info->is_sparse = 0;
+    json_t const *opal_dense_scanner_workaround_json = json_getProperty(testing_json, "opal_dense_scanner_workaround");
+    if (!opal_dense_scanner_workaround_json || JSON_INTEGER != json_getType(opal_dense_scanner_workaround_json)) {
+        info->opal_dense_scanner_workaround = 0;
     } else {
-        info->is_sparse = json_getInteger(is_sparse_json);
+        info->opal_dense_scanner_workaround = json_getInteger(opal_dense_scanner_workaround_json);
     }
 
     strncpy(info->placement_filename, dir, strnlen(dir, BUFFER_SIZE));
@@ -556,9 +556,9 @@ int get_num_outputs(void *info) {
     return kernel_info->num_outputs;
 }
 
-int get_is_sparse(void *info) {
+int get_opal_dense_scanner_workaround(void *info) {
     GET_KERNEL_INFO(info);
-    return kernel_info->is_sparse;
+    return kernel_info->opal_dense_scanner_workaround;
 }
 
 void *get_io_tile_info(void *info, int index) {

--- a/tests/test_app/lib/parser.h
+++ b/tests/test_app/lib/parser.h
@@ -70,6 +70,7 @@ struct KernelInfo {
     int num_groups;
     // index to the inputs, need to multiply by 2
     int reset_port;
+    int is_sparse;
 
     char bin_dir[BUFFER_SIZE];
     char coreir_filename[BUFFER_SIZE];

--- a/tests/test_app/lib/parser.h
+++ b/tests/test_app/lib/parser.h
@@ -70,7 +70,7 @@ struct KernelInfo {
     int num_groups;
     // index to the inputs, need to multiply by 2
     int reset_port;
-    int is_sparse;
+    int opal_dense_scanner_workaround;
 
     char bin_dir[BUFFER_SIZE];
     char coreir_filename[BUFFER_SIZE];

--- a/tests/test_memory_core/build_tb.py
+++ b/tests/test_memory_core/build_tb.py
@@ -1711,6 +1711,18 @@ def software_gold(app_name, matrix_tmp_dir, give_tensor=False, print_inputs=None
         output_matrix = b_mat
         output_format = "CSF"
         output_name = "X"
+    elif 'mat_sp2dn.gv' in app_name:
+        b_mat = get_tensor(input_name='B', shapes=[10, 12], give_tensor=give_tensor, tmp_dir=matrix_tmp_dir,
+                           dump=matrix_tmp_dir, suffix=suffix, clean=clean, tensor_ordering=tensor_orderings['B'],
+                           sparsity=1.0, format="UNC")
+        c_mat = get_tensor(input_name='C', shapes=[10, 12], give_tensor=False, tmp_dir=matrix_tmp_dir,
+                           dump=matrix_tmp_dir, suffix=suffix, clean=False, tensor_ordering=tensor_orderings['C'],
+                           sparsity=0.8)
+
+        input_dims['B'] = tuple(b_mat.shape)
+        output_matrix = c_mat
+        output_format = "CSF"
+        output_name = "X"
     elif 'mat_identity_dense.gv' in app_name:
         b_matrix = MatrixGenerator(name="B", shape=[10, 10], sparsity=0.7, format='UNC', dump_dir=matrix_tmp_dir)
         b_matrix.dump_outputs()

--- a/tests/test_memory_core/build_tb.py
+++ b/tests/test_memory_core/build_tb.py
@@ -1450,7 +1450,8 @@ def prepare_glb_collateral(glb_dir=None, bitstream=None, matrices_in=None, desig
         ],
         "bitstream": "bitstream.bs",
         "coreir": "design_top.json",
-        "placement": "design.place"
+        "placement": "design.place",
+        "is_sparse": 1
     }
     design_meta_json["IOs"] = {
         "inputs": [],

--- a/tests/test_memory_core/build_tb.py
+++ b/tests/test_memory_core/build_tb.py
@@ -1451,7 +1451,8 @@ def prepare_glb_collateral(glb_dir=None, bitstream=None, matrices_in=None, desig
         "bitstream": "bitstream.bs",
         "coreir": "design_top.json",
         "placement": "design.place",
-        "is_sparse": 1
+        # TODO: remove this workaround once the dense scanner is fixed
+        "opal_dense_scanner_workaround": 1
     }
     design_meta_json["IOs"] = {
         "inputs": [],

--- a/tests/test_memory_core/build_tb.py
+++ b/tests/test_memory_core/build_tb.py
@@ -1702,6 +1702,15 @@ def software_gold(app_name, matrix_tmp_dir, give_tensor=False, print_inputs=None
         output_matrix = b_mat
         output_format = "CSF"
         output_name = "X"
+    elif 'mat_dn2sp.gv' in app_name:
+        b_mat = get_tensor(input_name='B', shapes=[10, 12], give_tensor=give_tensor, tmp_dir=matrix_tmp_dir,
+                           dump=matrix_tmp_dir, suffix=suffix, clean=clean, tensor_ordering=tensor_orderings['B'],
+                           sparsity=0.8, format="UNC")
+        
+        input_dims['B'] = tuple(b_mat.shape)
+        output_matrix = b_mat
+        output_format = "CSF"
+        output_name = "X"
     elif 'mat_identity_dense.gv' in app_name:
         b_matrix = MatrixGenerator(name="B", shape=[10, 10], sparsity=0.7, format='UNC', dump_dir=matrix_tmp_dir)
         b_matrix.dump_outputs()


### PR DESCRIPTION
1. Add software gold generation for sparse to dense and dense to sparse conversion.
2. Fix bug in map.c where the flush signal for tiles residing in columns larger than 16 are not configured
3. Workaround for the currently broken dense scanner. This is done by setting the "opal_dense_scanner_workaround" flag in the deisng_meta.json file. If this flag is set, the flush signal is configured to be from a unused GLB tile.