### PR TITLE
clean up back-to-back kernels for dense

### DIFF
--- a/global_buffer/io_placement.py
+++ b/global_buffer/io_placement.py
@@ -1,5 +1,6 @@
 import re
 import os
+import json
 
 
 def atoi(text):
@@ -9,6 +10,56 @@ def atoi(text):
 def natural_keys(text):
     return [atoi(c) for c in re.split(r'(\d+)', text)]
 
+def parse_glb_bank_config(app_dir, id_to_name, inputs, outputs, valid, placement):
+    # parse the glb_bank_config.json to specify bank locations
+    with open(app_dir + "/glb_bank_config.json", "r") as f:
+        glb_json = json.load(f)
+
+    # Handling inputs
+    input_types = glb_json["inputs"].keys()
+    inputs_dict = {input_type: [] for input_type in input_types}
+    index_counters = {input_type: 0 for input_type in input_types}
+
+    for input_blk_id in inputs:
+        input_blk_name = id_to_name[input_blk_id]
+        type_name = next((input_type for input_type in input_types if input_type in input_blk_name), None)
+        if type_name:
+            dict_idx = index_counters[type_name]
+            coordinate = (glb_json["inputs"][type_name][dict_idx], 0)
+            inputs_dict[type_name].append({input_blk_id: coordinate})
+            index_counters[type_name] += 1
+
+    # Handling outputs
+    output_types = glb_json["outputs"].keys()
+    outputs_dict = {output_type: [] for output_type in output_types}
+    index_counters = {output_type: 0 for output_type in output_types}
+
+    for idx, output_blk_id in enumerate(outputs):
+        output_blk_name = id_to_name[output_blk_id]
+        type_name = next((output_type for output_type in output_types if output_type in output_blk_name), None)
+        if type_name:
+            dict_idx = index_counters[type_name]
+            coordinate = (glb_json["outputs"][type_name][dict_idx], 0)
+            outputs_dict[type_name].append({output_blk_id: coordinate})
+            outputs_dict[type_name].append({valid[idx]: coordinate})
+            index_counters[type_name] += 1
+
+    # Assert that all the inputs and outputs have been placed
+    assert sum(len(coords) for coords in inputs_dict.values()) == len(inputs), "Inputs in glb_bank_config.json do not match the number of inputs in the design"
+    assert sum(len(coords) for coords in outputs_dict.values()) // 2 == len(outputs), "Outputs in glb_bank_config.json do not match the number of outputs in the design"
+
+    # Update the placement dictionary with input coordinates
+    for type_name, coord_list in inputs_dict.items():
+        for coord_dict in coord_list:
+            for blk_id, coord in coord_dict.items():
+                placement[blk_id] = coord
+
+    # Update the placement dictionary with output coordinates
+    for type_name, coord_list in outputs_dict.items():
+        for coord_dict in coord_list:
+            for blk_id, coord in coord_dict.items():
+                placement[blk_id] = coord
+    return placement
 
 def place_io_blk(id_to_name, app_dir):
     """Hacky function to place the IO blocks"""
@@ -93,4 +144,9 @@ def place_io_blk(id_to_name, app_dir):
             for dat in data:
                 name, x, y = tuple(dat.split(" "))
                 placement[name] = (x.strip(), y.strip())
+
+    # parse the glb_bank_config.json to specify bank locations
+    if os.path.isfile(app_dir + "/glb_bank_config.json"):
+        placement = parse_glb_bank_config(app_dir, id_to_name, inputs, outputs, valid, placement)
+
     return placement

--- a/tests/test_app/lib/map.c
+++ b/tests/test_app/lib/map.c
@@ -174,6 +174,10 @@ int glb_map(void *kernel_, int dpr_enabled) {
         }
     }
 
+    // unset padding var after a kernel is mapped
+    if(getenv("pad_o_left") != NULL) unsetenv("pad_o_left");
+    if(getenv("pad_o_right") != NULL) unsetenv("pad_o_right");
+
     // configure flush crossbar
     int kernel_crossbar_config = 0;
     if (!kernel->opal_dense_scanner_workaround) {
@@ -301,6 +305,10 @@ int update_io_tile_configuration(struct IOTileInfo *io_tile_info, struct ConfigI
         mux_sel = 0b10;
 
     if (io_tile_info->io == Input) {
+
+        // Point to the other bank if the input is stored in GLB
+        if (io_tile_info->is_glb_input == 1) start_addr = start_addr + (1 << BANK_ADDR_WIDTH);
+
         if (strcmp(io_tile_info->mode, "RV") == 0)
             mode = LD_DMA_VALID_MODE_READY_VALID;
         else

--- a/tests/test_app/lib/parser.c
+++ b/tests/test_app/lib/parser.c
@@ -202,6 +202,13 @@ int parse_io_tile_info(struct IOTileInfo *io_tile_info, json_t const *io_tile_js
         cnt++;
     }
 
+    // Parse is_glb_input for back-to-back kernels
+    json_t const *is_glb_input_json = json_getProperty(io_tile_json, "is_glb_input");
+    if (!is_glb_input_json || JSON_INTEGER != json_getType(is_glb_input_json)) {
+        io_tile_info->is_glb_input = 0;  // Default to 0 if not found or not an integer
+    } else {
+        io_tile_info->is_glb_input = json_getInteger(is_glb_input_json);
+    }
     return SUCCESS;
 }
 
@@ -670,6 +677,11 @@ int get_io_tile_cycle_stride(void *info, int index, int stride_idx) {
 int get_io_tile_extent(void *info, int index, int extent_idx) {
     GET_IO_INFO(info);
     return io_info->io_tiles[index].extent[extent_idx];
+}
+
+int get_io_tile_is_glb_input(void *info, int index) {
+    GET_IO_INFO(info);
+    return io_info->io_tiles[index].is_glb_input;
 }
 
 int get_output_size(void *info, int index) {

--- a/tests/test_app/lib/parser.h
+++ b/tests/test_app/lib/parser.h
@@ -52,6 +52,9 @@ struct IOTileInfo {
     int cycle_stride[LOOP_LEVEL];
     int data_stride[LOOP_LEVEL];
     int extent[LOOP_LEVEL];
+
+    // For back-to-back kernels
+    int is_glb_input;
 };
 
 struct IOInfo {
@@ -98,6 +101,7 @@ int get_io_tile_loop_dim(void *info, int index);
 int get_io_tile_extent(void *info, int index, int extent_idx);
 int get_io_tile_cycle_stride(void *info, int index, int stride_idx);
 int get_io_tile_data_stride(void *info, int index, int stride_idx);
+int get_io_tile_is_glb_input(void *info, int index); // for back-to-back kernels judge if the input is already in global buffer
 
 // helper functions to access data from SV testbench
 int get_num_groups(void *info);

--- a/tests/test_app/tb/environment.sv
+++ b/tests/test_app/tb/environment.sv
@@ -77,6 +77,10 @@ task Environment::write_data(Kernel kernel);
     repeat (10) @(vifc_proc.cbd);
     foreach (kernel.inputs[i]) begin
         foreach (kernel.inputs[i].io_tiles[j]) begin
+            if (kernel.inputs[i].io_tiles[j].is_glb_input == 1) begin
+                // Skip writing input data that is already in GLB
+                continue;
+            end
             start_time = $realtime;
             $display("[%s] write input_%0d_block_%0d to glb start at %0t", kernel.name, i, j,
                      start_time);

--- a/tests/test_app/tb/kernel.sv
+++ b/tests/test_app/tb/kernel.sv
@@ -76,6 +76,10 @@ import "DPI-C" function int get_io_tile_cycle_stride(
     int index,
     int stride_idx
 );
+import "DPI-C" function int get_io_tile_is_glb_input( // for back-to-back kernels
+    chandle info,
+    int index
+);
 import "DPI-C" function chandle get_kernel_configuration(chandle info);
 import "DPI-C" function chandle get_pcfg_configuration(chandle info);
 import "DPI-C" function int get_configuration_size(chandle info);
@@ -117,6 +121,7 @@ typedef struct {
     int tile;
     int start_addr;
     int num_data;
+    int is_glb_input; // for back-to-back kernels to judge if input is already in glb
     data_array_t io_block_data;
 } IOTile;
 
@@ -455,6 +460,7 @@ function int Kernel::kernel_map();
         for (int j = 0; j < inputs[i].num_io_tiles; j++) begin
             inputs[i].io_tiles[j].tile = get_io_tile_map_tile(io_info, j);
             inputs[i].io_tiles[j].start_addr = get_io_tile_start_addr(io_info, j);
+            inputs[i].io_tiles[j].is_glb_input = get_io_tile_is_glb_input(io_info, j); // for back-to-back kernels
         end
     end
 


### PR DESCRIPTION
1. In bitstream generation avoid skipping zeros for routing to reset pipelining registers.
2. In IO placement parse glb bank config's location info.
3. Skip writing input data in testbench if they have been already in GLB.
4. Adjust starting address for inputs that are taken from output banks of the previous layer.