### PR TITLE
Glb tiling for dwconv

### DIFF
--- a/garnet.py
+++ b/garnet.py
@@ -592,22 +592,48 @@ class Garnet(Generator):
                 bitstream += self.interconnect.get_node_bitstream_config(source_node, dest_node)
         return bitstream
 
+    def write_zero_to_config_regs(self, bitstream):
+        from gemstone.common.configurable import ConfigRegister
+
+        # This is a fix for the Onyx pond hardware to avoid random flushes in the pond from previous layers
+        for loc, tile in self.interconnect.tile_circuits.items():
+            for feature in tile.features():
+                for child in feature.children():
+                    if isinstance(child, ConfigRegister):
+                        # comment out these lines if want to debug reg name
+                        # if feature.instance_name is None:
+                        #     print(tile.instance_name, feature.name() + "_inst0", child.instance_name, "none")
+                        # else:
+                        #     print(tile.instance_name, feature.instance_name, child.instance_name)
+                        if feature.instance_name: # write zeros to all config registers of interconnect
+                            feature_addr = tile.features().index(feature)
+                            child_addr = child.addr
+                            tile_id_width = tile.tile_id_width
+                            slice_start = tile.feature_config_slice.start
+                            tile_id = self.interconnect.get_tile_id(*loc)
+                            addr = (
+                                tile_id
+                                | (child_addr << slice_start)
+                                | (feature_addr << tile_id_width)
+                            )
+                            bitstream.append((addr,0))
+
+
     def generate_bitstream(self, halide_src, placement, routing, id_to_name, instance_to_instr, netlist, bus,
-                           compact=False):
+                           compact=False, end_to_end=False):
         routing_fix = archipelago.power.reduce_switching(routing, self.interconnect,
                                                          compact=compact)
         routing.update(routing_fix)
 
         bitstream = []
-        skip_addr = self.interconnect.get_skip_addr()
+        if end_to_end: self.write_zero_to_config_regs(bitstream)
+        bitstream += self.interconnect.get_route_bitstream(routing)
         bitstream += self.fix_pond_flush_bug(placement, routing)
         bitstream += self.get_placement_bitstream(placement, id_to_name,
                                                   instance_to_instr)
-        # Skip zeros for placement bitstream
-        bitstream = compress_config_data(bitstream, skip_compression=skip_addr, skip_zero=True)
-        bitstream += self.interconnect.get_route_bitstream(routing)
-        # Avoid skipping zeros for routing bitstream to reset pipelining registers in back-to-back kernels
-        bitstream = compress_config_data(bitstream, skip_compression=skip_addr, skip_zero=False)
+
+        skip_addr = self.interconnect.get_skip_addr()
+        bitstream = compress_config_data(bitstream, skip_compression=skip_addr)
         inputs, outputs = self.get_input_output(netlist)
         input_interface, output_interface, \
             (reset, valid, en) = self.get_io_interface(inputs,
@@ -691,6 +717,9 @@ def parse_args():
     parser.add_argument("--input-file", type=str, default="", dest="input")
     parser.add_argument("--output-file", type=str, default="", dest="output")
     parser.add_argument("--gold-file", type=str, default="", dest="gold")
+    parser.add_argument("--end-to-end", action="store_true", default=False,
+                    help="Enable end-to-end configuration for bitstream generation")
+
 
     parser.add_argument("-v", "--verilog", action="store_true")
     parser.add_argument("--no-pd", "--no-power-domain", action="store_true")
@@ -831,7 +860,8 @@ def pnr(garnet, args, app):
     bitstream, iorved_tuple = garnet.generate_bitstream(
         args.app,
         placement, routing, id_to_name, instance_to_instr, netlist, bus,
-        compact=args.compact
+        compact=args.compact,
+        end_to_end=args.end_to_end
     )
     (inputs, outputs, reset, valid, en, delay) = iorved_tuple
 

--- a/tests/test_app/lib/map.h
+++ b/tests/test_app/lib/map.h
@@ -4,7 +4,7 @@
 
 int glb_map(void *kernel, int dpr_enabled);
 int initialize_monitor(int num_cols);
-int update_io_tile_configuration(struct IOTileInfo *io_tile_info, struct ConfigInfo *config_info);
+int update_io_tile_configuration(struct IOTileInfo *io_tile_info, struct ConfigInfo *config_info, struct KernelInfo *kernel_info);
 void update_bs_configuration(struct BitstreamInfo *bs_info);
 void add_config(struct ConfigInfo *config_info, int addr, int data);
 

--- a/tests/test_app/lib/parser.h
+++ b/tests/test_app/lib/parser.h
@@ -75,6 +75,10 @@ struct KernelInfo {
     int reset_port;
     int opal_dense_scanner_workaround;
 
+    // control glb tiling
+    int num_glb_tiling;
+    int glb_tiling_cnt;
+
     char bin_dir[BUFFER_SIZE];
     char coreir_filename[BUFFER_SIZE];
     char bitstream_filename[BUFFER_SIZE];
@@ -112,6 +116,9 @@ int get_num_io_tiles(void *info, int index);
 int get_io_tile_x(void *info, int index);
 int get_io_tile_y(void *info, int index);
 int get_reset_index(void *info);
+int get_num_glb_tiling(void *info); // for GLB tiling
+int get_glb_tiling_cnt(void *info); // for GLB tiling
+void update_glb_tiling_cnt(void *info, int cnt); // for GLB tiling
 
 char *get_placement_filename(void *info);
 char *get_bitstream_filename(void *info);


### PR DESCRIPTION
1. update testbenches to support glb tiling, which runs the same kernel multiple times for conv with large number of channels
2. add end-to-end arg in garnet.py and write 0s to interconnect config regs in bitstream to avoid random flushes caused by previous kernels