### PR TITLE
aha bashrc needs to be re-examined maybe

### DIFF
--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -137,6 +137,9 @@ if [ "$use_container" == True ]; then
       # MAKE SURE the docker container gets killed when this script dies.
       trap "docker kill $container_name" EXIT
 
+      # aha/bashrc does important things in bg, but does not normally get invoked via 'docker exec'
+      docker exec $container_name /bin/bash -c 'source /aha/aha/bin/docker-bashrc; wait'
+
       # Delete all dangling images created more than 6 hours ago.
       # Notice that we prune images *after* starting container (pruner
       # will refuse to kill image w/ active container)


### PR DESCRIPTION
Before using the docker container, certain things must happen e.g. restoring `.git. metadata for the clockwork submodule. Normally, this happens on first invocation by way of commands in the container's `/root/.bashrc` file. Unfortunately, `.bashrc` does an early-out when the container is accessed only by `docker exec` commands, which is what garnet fullchip build currently does by default. The early-out happens before reaching the crucial command `source /aha/aha/bin/bashrc`.

This fixes that, by invoking `source /aha/aha/bin/bashrc` explicitly, without using the `.bashrc` indirection.

I'm not including anyone else on this review, because at this point I think I am the only one using fullchip builds...