### PR TITLE
CAD problems related to recent r7->r8 upgrade

### DIFF
--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -319,17 +319,18 @@ source $garnet/mflowgen/setup-garnet.sh
 echo Recheck python/pip versions
 check_pyversions
 
-##############################################################################
-# OA_HOME weirdness
-# OA_HOME *** WILL DRIVE ME MAD!!! ***
-echo "--- UNSET OA_HOME"
-echo ""
-echo "buildkite (but not arm7 (???)) errs if OA_HOME is set"
-echo "BEFORE: OA_HOME=$OA_HOME"
-echo "unset OA_HOME"
-unset OA_HOME
-echo "AFTER:  OA_HOME=$OA_HOME"
-echo ""
+# 08/2024 Moving this to setup-garnet.sh!!!
+# ##############################################################################
+# # OA_HOME weirdness
+# # OA_HOME *** WILL DRIVE ME MAD!!! ***
+# echo "--- UNSET OA_HOME"
+# echo ""
+# echo "buildkite (but not arm7 (???)) errs if OA_HOME is set"
+# echo "BEFORE: OA_HOME=$OA_HOME"
+# echo "unset OA_HOME"
+# unset OA_HOME
+# echo "AFTER:  OA_HOME=$OA_HOME"
+# echo ""
 
 # Okay let's check and see what we got.
 echo "--- REQUIREMENTS CHECK, sourcing $garnet/bin/requirements_check.sh"; echo ""

--- a/mflowgen/bin/setup-buildkite.sh
+++ b/mflowgen/bin/setup-buildkite.sh
@@ -314,23 +314,12 @@ echo "--- ENVIRONMENT - CAD TOOLS"; echo ""
 echo Sourcing $garnet/mflowgen/setup-garnet.sh ...
 source $garnet/mflowgen/setup-garnet.sh
 
+# 08/2024 OA_HOME weirdness was here (ish), now is offloaded to setup-garnet.sh
+
 ##############################################################################
 # Recheck python/pip versions b/c CAD modules can muck them up :(
 echo Recheck python/pip versions
 check_pyversions
-
-# 08/2024 Moving this to setup-garnet.sh!!!
-# ##############################################################################
-# # OA_HOME weirdness
-# # OA_HOME *** WILL DRIVE ME MAD!!! ***
-# echo "--- UNSET OA_HOME"
-# echo ""
-# echo "buildkite (but not arm7 (???)) errs if OA_HOME is set"
-# echo "BEFORE: OA_HOME=$OA_HOME"
-# echo "unset OA_HOME"
-# unset OA_HOME
-# echo "AFTER:  OA_HOME=$OA_HOME"
-# echo ""
 
 # Okay let's check and see what we got.
 echo "--- REQUIREMENTS CHECK, sourcing $garnet/bin/requirements_check.sh"; echo ""

--- a/mflowgen/setup-garnet.sh
+++ b/mflowgen/setup-garnet.sh
@@ -38,6 +38,22 @@ else
     [ "$WHICH_SOC" == "amber" ] || module load calibre/2021.2_18
 fi
 
+module load prime/latest
+module load ext/latest
+
+##############################################################################
+# OA_HOME weirdness -- 08/2024 moved this here verbatim from setup-buildkite.sh
+# OA_HOME *** WILL DRIVE ME MAD!!! ***
+echo "--- UNSET OA_HOME"
+echo ""
+echo "buildkite (but not arm7 (???)) errs if OA_HOME is set"
+echo "BEFORE: OA_HOME=$OA_HOME"
+echo "unset OA_HOME"
+unset OA_HOME
+echo "AFTER:  OA_HOME=$OA_HOME"
+echo ""
+
+
 # 08/2024 Joe upgraded system to redhat-compatible "rocket" i.e.
 # 'cat /etc/redhat-release' yields the string "Rocky Linux release 8.10 (Green Obsidian)"
 # calibre binaries die because they invoke a script 'calibre_host_info' that expects
@@ -47,11 +63,16 @@ fi
 
 # We can prevent this (maybe?) by setting an environment variable
 # 'export USE_CALIBRE_VCO=aoi' that shortcuts the OS check.
-export USE_CALIBRE_VCO=aoi
 
-module load prime/latest
-module load ext/latest
+test -e /etc/os-release && source /etc/os-release  # Sets os-related vars including ID
+[ "$ID" == "rocky" ] && export USE_CALIBRE_VCO=aoi
+
+# 08/2024 Joe upgraded some of the machines from rhel 7 to rocket 8
+# and oh boy did that mess things up
 
 # Let's try a thing maybe
-unset OA_UNSUPPORTED_PLAT
-export OA_HOME=/cad/cadence/ICADVM20.10.330/oa_v22.60.090
+test -e /etc/os-release && source /etc/os-release  # Sets os-related vars including ID
+if [ "$ID" == "rocky" ]; then
+    unset OA_UNSUPPORTED_PLAT
+    export OA_HOME=/cad/cadence/ICADVM20.10.330/oa_v22.60.090
+fi

--- a/mflowgen/setup-garnet.sh
+++ b/mflowgen/setup-garnet.sh
@@ -1,15 +1,6 @@
-# 08/2024 Joe upgraded system to redhat-compatible "rocky" i.e.
-# 'cat /etc/redhat-release' yields the string "Rocky Linux release 8.10 (Green Obsidian)"
-# calibre binaries die because they invoke a script 'calibre_host_info' that expects
-# 'cat /etc/redhat-release' to test positive for `egrep -i 'centos|red *hat|redhat|suse|sles'`,
-# so 'cgra_info' sets 'OS_VENDOR=unknown' and then the follow-on script 'calibre_vco'
-# errs out with a message like "Invalid operating system environment"
-
-# We can prevent this (maybe?) by setting an environment variable
-# 'export USE_CALIBRE_VCO=aoi' that shortcuts the OS check.
-# Lots of things break if we don't do this FIRST
-
-test -e /etc/os-release && source /etc/os-release  # Sets os-related vars including ID
+# Hack to fix things that broke during r7->r8 upgrade, see
+# https://github.com/StanfordAHA/garnet/issues/1085
+test -e /etc/os-release && source /etc/os-release
 [ "$ID" == "rocky" ] && export USE_CALIBRE_VCO=aoi
 
 source /cad/modules/tcl/init/sh
@@ -55,6 +46,7 @@ fi
 module load prime/latest
 module load ext/latest
 
+# (This is the older OA fix)
 ##############################################################################
 # OA_HOME weirdness -- 08/2024 moved this here verbatim from setup-buildkite.sh
 # OA_HOME *** WILL DRIVE ME MAD!!! ***
@@ -67,14 +59,12 @@ unset OA_HOME
 echo "AFTER:  OA_HOME=$OA_HOME"
 echo ""
 
-
-# 08/2024 Joe upgraded some of the machines from rhel 7 to rocky 8
-# and oh boy did that mess things up
-
-# Let's try a thing maybe
+# (This is the newer OA fix)
+# Hack to fix things that broke during r7->r8 upgrade, see
+# https://github.com/StanfordAHA/garnet/issues/1085
 test -e /etc/os-release && source /etc/os-release  # Sets os-related vars including ID
 if [ "$ID" == "rocky" ]; then
-    echo "reset OA_HOME" etc.
+    echo "Reset OA_HOME" etc.
     unset OA_UNSUPPORTED_PLAT
     export OA_HOME=/cad/cadence/ICADVM20.10.330/oa_v22.60.090
     echo "NOW:  OA_HOME=$OA_HOME"

--- a/mflowgen/setup-garnet.sh
+++ b/mflowgen/setup-garnet.sh
@@ -38,6 +38,16 @@ else
     [ "$WHICH_SOC" == "amber" ] || module load calibre/2021.2_18
 fi
 
+# 08/2024 Joe upgraded system to redhat-compatible "rocket" i.e.
+# 'cat /etc/redhat-release' yields the string "Rocky Linux release 8.10 (Green Obsidian)"
+# calibre binaries die because they invoke a script 'calibre_host_info' that expects
+# 'cat /etc/redhat-release' to test positive for `egrep -i 'centos|red *hat|redhat|suse|sles'`,
+# so 'cgra_info' sets 'OS_VENDOR=unknown' and then the follow-on script 'calibre_vco'
+# errs out with a message like "Invalid operating system environment"
+
+# We can prevent this (maybe?) by setting an environment variable
+# 'export USE_CALIBRE_VCO=aoi' that shortcuts the OS check.
+export USE_CALIBRE_VCO=aoi
+
 module load prime/latest
 module load ext/latest
-

--- a/mflowgen/setup-garnet.sh
+++ b/mflowgen/setup-garnet.sh
@@ -1,3 +1,17 @@
+# 08/2024 Joe upgraded system to redhat-compatible "rocky" i.e.
+# 'cat /etc/redhat-release' yields the string "Rocky Linux release 8.10 (Green Obsidian)"
+# calibre binaries die because they invoke a script 'calibre_host_info' that expects
+# 'cat /etc/redhat-release' to test positive for `egrep -i 'centos|red *hat|redhat|suse|sles'`,
+# so 'cgra_info' sets 'OS_VENDOR=unknown' and then the follow-on script 'calibre_vco'
+# errs out with a message like "Invalid operating system environment"
+
+# We can prevent this (maybe?) by setting an environment variable
+# 'export USE_CALIBRE_VCO=aoi' that shortcuts the OS check.
+# Lots of things break if we don't do this FIRST
+
+test -e /etc/os-release && source /etc/os-release  # Sets os-related vars including ID
+[ "$ID" == "rocky" ] && export USE_CALIBRE_VCO=aoi
+
 source /cad/modules/tcl/init/sh
 
 module load base/1.0
@@ -53,19 +67,6 @@ unset OA_HOME
 echo "AFTER:  OA_HOME=$OA_HOME"
 echo ""
 
-
-# 08/2024 Joe upgraded system to redhat-compatible "rocky" i.e.
-# 'cat /etc/redhat-release' yields the string "Rocky Linux release 8.10 (Green Obsidian)"
-# calibre binaries die because they invoke a script 'calibre_host_info' that expects
-# 'cat /etc/redhat-release' to test positive for `egrep -i 'centos|red *hat|redhat|suse|sles'`,
-# so 'cgra_info' sets 'OS_VENDOR=unknown' and then the follow-on script 'calibre_vco'
-# errs out with a message like "Invalid operating system environment"
-
-# We can prevent this (maybe?) by setting an environment variable
-# 'export USE_CALIBRE_VCO=aoi' that shortcuts the OS check.
-
-test -e /etc/os-release && source /etc/os-release  # Sets os-related vars including ID
-[ "$ID" == "rocky" ] && export USE_CALIBRE_VCO=aoi
 
 # 08/2024 Joe upgraded some of the machines from rhel 7 to rocky 8
 # and oh boy did that mess things up

--- a/mflowgen/setup-garnet.sh
+++ b/mflowgen/setup-garnet.sh
@@ -51,3 +51,7 @@ export USE_CALIBRE_VCO=aoi
 
 module load prime/latest
 module load ext/latest
+
+# Let's try a thing maybe
+unset OA_UNSUPPORTED_PLAT
+export OA_HOME=/cad/cadence/ICADVM20.10.330/oa_v22.60.090

--- a/mflowgen/setup-garnet.sh
+++ b/mflowgen/setup-garnet.sh
@@ -54,7 +54,7 @@ echo "AFTER:  OA_HOME=$OA_HOME"
 echo ""
 
 
-# 08/2024 Joe upgraded system to redhat-compatible "rocket" i.e.
+# 08/2024 Joe upgraded system to redhat-compatible "rocky" i.e.
 # 'cat /etc/redhat-release' yields the string "Rocky Linux release 8.10 (Green Obsidian)"
 # calibre binaries die because they invoke a script 'calibre_host_info' that expects
 # 'cat /etc/redhat-release' to test positive for `egrep -i 'centos|red *hat|redhat|suse|sles'`,
@@ -67,12 +67,16 @@ echo ""
 test -e /etc/os-release && source /etc/os-release  # Sets os-related vars including ID
 [ "$ID" == "rocky" ] && export USE_CALIBRE_VCO=aoi
 
-# 08/2024 Joe upgraded some of the machines from rhel 7 to rocket 8
+# 08/2024 Joe upgraded some of the machines from rhel 7 to rocky 8
 # and oh boy did that mess things up
 
 # Let's try a thing maybe
 test -e /etc/os-release && source /etc/os-release  # Sets os-related vars including ID
 if [ "$ID" == "rocky" ]; then
+    echo "reset OA_HOME" etc.
     unset OA_UNSUPPORTED_PLAT
     export OA_HOME=/cad/cadence/ICADVM20.10.330/oa_v22.60.090
+    echo "NOW:  OA_HOME=$OA_HOME"
+    echo "NOW:  OA_UNSUPPORTED_PLAT is unset"
+    echo "NOW:  USE_CALIBRE_VCO=$USE_CALIBRE_VCO"
 fi


### PR DESCRIPTION
Many of our CAD machines recently upgraded from Red Hat version 7 (r7) to Rocky Linux version 8 (r8). This broke some stuff. In particular, the weekly Amber full-chip builds that run on r8arm-aha (formerly r7arm-aha) needed some tweaking to make them work.

For more details see issue https://github.com/StanfordAHA/garnet/issues/1085.
