### PR TITLE
Stop killing aha regressions

### DIFF
--- a/.buildkite/bin/docker-clean.sh
+++ b/.buildkite/bin/docker-clean.sh
@@ -15,7 +15,7 @@ function dps() {
 }
 echo '+++ BEFORE'; dps; printf '\n'
 
-
+# Kill any container with 'deleteme' in its name AND whose ps matches the given pattern.
 function deldocks() {
   pat="$1"
   # echo '------------------------------------------------------------------------'
@@ -26,19 +26,20 @@ function deldocks() {
   printf '\n'
 }
 
+# Get rid of all 'deleteme' containers that are months old
 echo '+++ MONTHS'
 deldocks 'months ago'
 
+# Get rid of all 'deleteme' containers that are weeks old
 echo '+++ WEEKS'
 deldocks 'weeks ago'
 
+# Allow at least 5 days for very long-running tasks to clear (e.g. aha full regression)
 echo '+++ DAYS'
-deldocks 'days ago'
+deldocks '[56789] days ago'
 
-echo '+++ HOURS'
-deldocks '[456789] hours ago'
+# DO NOT kill containers less than one day old.
+# This can destory e.g. in-progress 19-hour aha regressions...
+# deldocks '[456789] hours ago'
 
 echo '+++ AFTER'; dps; printf '\n'
-
-# docker ps | grep deleteme | grep 'months ago'
-# docker ps | grep deleteme | grep 'months ago' | awk '{print $1}' | xargs docker kill

--- a/.buildkite/bin/docker-clean.sh
+++ b/.buildkite/bin/docker-clean.sh
@@ -39,7 +39,7 @@ echo '+++ DAYS'
 deldocks '[56789] days ago'
 
 # DO NOT kill containers less than one day old.
-# This can destory e.g. in-progress 19-hour aha regressions...
+# This can destroy e.g. in-progress 19-hour aha regressions...
 # deldocks '[456789] hours ago'
 
 echo '+++ AFTER'; dps; printf '\n'

--- a/.buildkite/ci.yml
+++ b/.buildkite/ci.yml
@@ -72,6 +72,6 @@ steps:
   agents:
     docker: "true"
   commands:
-  - docker kill $CONTAINER || true
-  - .buildkite/bin/docker-clean.sh || true
-  - docker image prune -a  --force --filter "until=24h" --filter=label='description=garnet' || true
+  - set -x; docker kill $CONTAINER || true
+  - set -x; .buildkite/bin/docker-clean.sh || true
+  - set -x; yes | docker image prune -a --filter "until=72h" --filter=label='description=garnet' || true

--- a/.buildkite/ci.yml
+++ b/.buildkite/ci.yml
@@ -78,4 +78,4 @@ steps:
   commands:
   - set -x; docker kill $CONTAINER || true
   - set -x; .buildkite/bin/docker-clean.sh || true
-  - set -x; yes | docker image prune -a --filter || true
+  - set -x; yes | docker image prune -a --filter=label='description=garnet' || true

--- a/.buildkite/ci.yml
+++ b/.buildkite/ci.yml
@@ -68,6 +68,10 @@ steps:
 # ALWAYS clean up regardless of test success or failure
 - wait: { continue_on_failure: true }
 
+# 1. Delete our own docker container, which we are done with.
+# 2. Look for old/stale containers and delete them as well.
+# 3. Delete all unused docker images older than 72 hours.
+
 - label: "Delete container"
   agents:
     docker: "true"

--- a/.buildkite/ci.yml
+++ b/.buildkite/ci.yml
@@ -70,7 +70,7 @@ steps:
 
 # 1. Delete our own docker container, which we are done with.
 # 2. Look for old/stale containers and delete them as well.
-# 3. Delete all unused docker images older than 72 hours.
+# 3. Delete any and all unused docker images.
 
 - label: "Delete container"
   agents:
@@ -78,4 +78,4 @@ steps:
   commands:
   - set -x; docker kill $CONTAINER || true
   - set -x; .buildkite/bin/docker-clean.sh || true
-  - set -x; yes | docker image prune -a --filter "until=72h" --filter=label='description=garnet' || true
+  - set -x; yes | docker image prune -a --filter || true


### PR DESCRIPTION
These changes are designed to address the aha regression-failure problem described in aha issue 1959 https://github.com/StanfordAHA/aha/issues/1959.

I discovered two pertinent errors, both related to the garnet CI script `ci.yml`, whose "docker cleanup" step does three things
* a) delete the docker container that was used to do the CI test;
* b) look for other old/stale containers and delete them as well, by invoking a script `docker-clean.sh`;
* c) delete all unused docker images older than 24 hours.

The first error was in step (c), which is supposed to delete unused docker images. Previously, it did this with a command `docker image prune --force`. The `--force` arg was supposed to prevent the command from asking "do you really want to do this?"  Unfortunately, it had the side effect of deleting *all* docker images whether or not someone was actively using the image (i.e. an aha full regression).

Also, the "older than 24 hours" is not very useful, since that pertains to the time the image was built, not the time it was downloaded. Many of the images that we use are days or even weeks old.

So I got rid of the `--force` option and instead used the `yes` command to answer the prompt. And I bumped the `until` requirement from 24 to 72 hours, even though that really doesn't help much of anything.

The  second error relates to the `docker-clean.sh` script from item (1b) above, which was killing all containers more than 4 hours old. Since the containers in question include aha full-regressions that take as much as 19 hours to complete, this was obviously a bad idea. So now the docker-clean script waits at least 5 days before deciding that a container needs deleting.
