### PR TITLE
restrict CI runs to a single host

### DIFF
--- a/.buildkite/ci.yml
+++ b/.buildkite/ci.yml
@@ -8,8 +8,11 @@ steps:
 
 # ------------------------------------------------------------------------
 - label: "Get latest docker"
-  agents:
-    docker: "true"
+
+  # Agents must have tag hostname=<hostname>
+  # And then this will guarantee that all steps run on the same host, see?
+  agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
+
   commands:
   - docker pull $IMAGE
 
@@ -22,8 +25,7 @@ steps:
   # For now at least; set soft_fail so failing lint does not fail pipeline
   soft_fail: true
 
-  agents:
-    docker: "true"
+  agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
 
   commands:
 
@@ -48,7 +50,7 @@ steps:
 
 # ------------------------------------------------------------------------
 - label: ":wrench: Verilator"
-  agents: { docker: "true" }
+  agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
   commands:
 
   # Container setup
@@ -68,7 +70,7 @@ steps:
 
 # ------------------------------------------------------------------------
 - label: ":wrench: Verilator 2"
-  agents: { docker: "true" }
+  agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
   commands:
   - echo "This test disabled b/c takes too long (2.5hr)"; exit
 
@@ -89,7 +91,7 @@ steps:
 
 # ------------------------------------------------------------------------
 - label: ":wrench: Aha regressions"
-  agents: { docker: "true" }
+  agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
   commands:
 
   # In case Lint step failed to clean up correctly
@@ -117,7 +119,7 @@ steps:
 # 3. Delete any and all unused docker images.
 
 - label: "Delete container"
-  agents: { docker: "true" }
+  agents: { hostname: $BUILDKITE_AGENT_META_DATA_HOSTNAME }
   commands:
   - set -x; docker kill $CONTAINER || true
   - set -x; docker kill $VCONTAINER || true


### PR DESCRIPTION
Currently, if two different steps in the same buildkite CI pipeline run on two different machines, it can cause trouble. I.e. if an initial step 'build docker' creates a docker image/container on r8cad-docker, and a later step 'regression 1' step tries to use that image/container, it will of course not find it.

This change ensures that the entire pipeline runs on a single machine.
