### PR TITLE
Anti intel hack hack

### DIFF
--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -9,7 +9,6 @@ function get_amber_updates {
       cd /aha/canal        && git checkout 6fec524;
       cd /aha/clockwork    && git checkout efdd95e;
       cd /aha/lake         && git checkout 837ffe1;
-      cd /aha/lassen       && git checkout 77c32df;
     '
 }
 function update_kratos {
@@ -260,7 +259,6 @@ if [ "$use_container" == True ]; then
 
            # For details about this anti-pohan/intel hack hack
            # see garnet pull request #TBD ~ March 2025
-           # Note we are still in double-quote regime (I hope)
            if [ '$WHICH_SOC' == 'amber' ]; then
              echo '--- BEGIN egregious anti-pohan-hack hack'
              cp design.v design.v.orig

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -258,11 +258,13 @@ if [ "$use_container" == True ]; then
            cat global_buffer/systemRDL/output/glb_jrdl_logic.sv >> design.v
            cat global_controller/systemRDL/output/*.sv >> design.v
 
-           # For details about the anti-pohan hack hack see garnet pull request #TBD ~ March 2025
+           # For details about this anti-pohan/intel hack hack
+           # see garnet pull request #TBD ~ March 2025
            # Note we are still in double-quote regime (I hope)
            if [ '$WHICH_SOC' == 'amber' ]; then
              echo '--- BEGIN egregious anti-pohan-hack hack'
              cp design.v design.v.orig
+             sed -i 's|// \(clk.*Are we stalling.*\)|\1|' design.v
              sed -i '/.*CG Hack/,/[)][;]/s,^,// ,' design.v
              diff design.v.orig design.v || printf '\n\n'
            fi

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -9,6 +9,7 @@ function get_amber_updates {
       cd /aha/canal        && git checkout 6fec524;
       cd /aha/clockwork    && git checkout efdd95e;
       cd /aha/lake         && git checkout 837ffe1;
+      cd /aha/lassen       && git checkout 77c32df;
     '
 }
 function update_kratos {
@@ -153,7 +154,7 @@ if [ "$use_container" == True ]; then
       if [ "$use_local_garnet" == True ]; then
         docker exec $container_name /bin/bash -c "rm -rf /aha/garnet"
         # Clone local garnet repo to prevent copying untracked files
-        git clone $GARNET_HOME ./garnet
+        test -e ./garnet || git clone $GARNET_HOME ./garnet
         docker cp ./garnet $container_name:/aha/garnet
       fi
       
@@ -261,9 +262,9 @@ if [ "$use_container" == True ]; then
            # Note we are still in double-quote regime (I hope)
            if [ '$WHICH_SOC' == 'amber' ]; then
              echo '--- BEGIN egregious anti-pohan-hack hack'
-             cp design.v tmp.v
+             cp design.v design.v.orig
              sed -i '/.*CG Hack/,/[)][;]/s,^,// ,' design.v
-             diff design.v tmp.v || printf '\n\n'
+             diff design.v.orig design.v || printf '\n\n'
            fi
          fi"
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -263,7 +263,7 @@ if [ "$use_container" == True ]; then
              echo '--- BEGIN egregious anti-pohan-hack hack'
              cp design.v tmp.v
              sed -i '/.*CG Hack/,/[)][;]/s,^,// ,' design.v
-             diff design.v tmp.v
+             diff design.v tmp.v || printf '\n\n'
            fi
          fi"
 

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -256,8 +256,16 @@ if [ "$use_container" == True ]; then
            cat global_buffer/systemRDL/output/glb_jrdl_decode.sv >> design.v
            cat global_buffer/systemRDL/output/glb_jrdl_logic.sv >> design.v
            cat global_controller/systemRDL/output/*.sv >> design.v
-         fi"
 
+           # For details about the anti-pohan hack hack see garnet pull request #TBD ~ March 2025
+           # Note we are still in double-quote regime (I hope)
+           if [ '$WHICH_SOC' == 'amber' ]; then
+             echo '--- BEGIN egregious anti-pohan-hack hack'
+             cp design.v tmp.v
+             sed -i '/.*CG Hack/,/[)][;]/s,^,// ,' design.v
+             diff design.v tmp.v
+           fi
+         fi"
 
       echo '--- gen_rtl docker cleanup BEGIN' `date +%H:%M`
 


### PR DESCRIPTION
### Problem

Apparently pohan hacked an intel-specific module into the global controller
```
less -N $GARNET/global_controller/rtl/genesis/glc_jtag_ctrl.svp
    228 // clk = ((all_stalled_tck & !sys_clk_activated) ...
    233 // CG Hack by pohan
    234 b0mcilb05hn1n16x5 u_icg_hack (
    235         .te                     (1'b0),
    236         .en                     (!((all_stalled_tck...
    237         .clk                    (clk_domain),
    238         .clkout                 (clk)
    239 );
```

Okay fine, whatever works EXCEPT that now when I do the weekly amber tapeout oops I get an error during GLC synthesis "Cannot resolve reference to 'b0mcilb05hn1n16x5'," see e.g. <https://buildkite.com/tapeout-aha/fullchip/builds/626>.

### Solution
Okay so I could try and untangle the code that actually builds the GLC and thus try and do things the "right" way, but that path is fraught with danger and uncertainty, and I in no way want to get in the way of the imminent upcoming tapeout.

So instead I propose to do a new hack on top of the old hack, i.e. I am adding a snippet of code in the `gen_rtl.sh` script that, if and only if we are doing an amber build, will undo Pohan's hack.

The sed scripts in the modified `gen_rtl.sh` are designed to do this, *if-and-only-if* env var `WHICH_SOC == amber`
```
BEFORE
< // clk = ((all_stalled_tck & !sys_clk...
< 
< // CG Hack by pohan
< b0mcilb05hn1n16x5 u_icg_hack (
<         .te                     (1'b0),
<         .en                     (!((all_stalled_tck & !sys_clk...
<         .clk                    (clk_domain),
<         .clkout                 (clk)
< );
------------------------------------------------------------------------
AFTER
> clk = ((all_stalled_tck & !sys_clk...
> 
> // // CG Hack by pohan
> // b0mcilb05hn1n16x5 u_icg_hack (
> //         .te                     (1'b0),
> //         .en                     (!((all_stalled_tck & !sys_clk...
> //         .clk                    (clk_domain),
> //         .clkout                 (clk)
> // );
```

Haha yes this is terrible, but I think it's the best way for us to all get what we want in the short term. With any luck my builds will start working again and, because my hack is predicated by the "$WHICH_SOC" == "amber" condition, it should in no wise impact the intel tapeout.

I implemented and tested this fix, and amber fullchip test passes now: <https://buildkite.com/tapeout-aha/fullchip/builds/626>.

### TODO
Meanwhile somebody should file an official garnet issue documenting the hacks and requesting a better fix for the future (presumably after tapeout maybe).
