### PR TITLE
Do not wait (long) for docker bashrc

### DIFF
--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -138,17 +138,7 @@ if [ "$use_container" == True ]; then
       trap "docker kill $container_name" EXIT
 
       # aha/bashrc does important things in bg, but does not normally get invoked via 'docker exec'
-      # docker exec $container_name /bin/bash -c 'source /aha/aha/bin/docker-bashrc; wait'
-
-      docker exec $container_name /bin/bash -c 'source /aha/aha/bin/docker-bashrc' &
-      # Wait 60s for the essentials in bashrc to take effect, then continue
-      echo wait5-1/6; sleep 5
-      echo wait5-2/6; sleep 5
-      echo wait5-3/6; sleep 5
-      echo wait5-4/6; sleep 5
-      echo wait5-5/6; sleep 5
-      echo wait5-6/6; sleep 5
-
+      docker exec $container_name /bin/bash -c 'source /aha/aha/bin/docker-bashrc --fast'
 
       # Delete all dangling images created more than 6 hours ago.
       # Notice that we prune images *after* starting container (pruner

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -138,7 +138,16 @@ if [ "$use_container" == True ]; then
       trap "docker kill $container_name" EXIT
 
       # aha/bashrc does important things in bg, but does not normally get invoked via 'docker exec'
-      docker exec $container_name /bin/bash -c 'source /aha/aha/bin/docker-bashrc --fast'
+      docker exec $container_name /bin/bash -c 'source /aha/aha/bin/docker-bashrc' &
+
+      # Wait 30s for the essentials in bashrc to take effect, then continue
+      echo wait5-1/6; sleep 5
+      echo wait5-2/6; sleep 5
+      echo wait5-3/6; sleep 5
+      echo wait5-4/6; sleep 5
+      echo wait5-5/6; sleep 5
+      echo wait5-6/6; sleep 5
+
 
       # Delete all dangling images created more than 6 hours ago.
       # Notice that we prune images *after* starting container (pruner

--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -138,7 +138,17 @@ if [ "$use_container" == True ]; then
       trap "docker kill $container_name" EXIT
 
       # aha/bashrc does important things in bg, but does not normally get invoked via 'docker exec'
-      docker exec $container_name /bin/bash -c 'source /aha/aha/bin/docker-bashrc; wait'
+      # docker exec $container_name /bin/bash -c 'source /aha/aha/bin/docker-bashrc; wait'
+
+      docker exec $container_name /bin/bash -c 'source /aha/aha/bin/docker-bashrc' &
+      # Wait 60s for the essentials in bashrc to take effect, then continue
+      echo wait5-1/6; sleep 5
+      echo wait5-2/6; sleep 5
+      echo wait5-3/6; sleep 5
+      echo wait5-4/6; sleep 5
+      echo wait5-5/6; sleep 5
+      echo wait5-6/6; sleep 5
+
 
       # Delete all dangling images created more than 6 hours ago.
       # Notice that we prune images *after* starting container (pruner


### PR DESCRIPTION
gen-rtl.sh was waiting for bashrc background jobs to finish before generating RTL.

The background jobs are supposed to finish quickly, but apparently they don't always.

This change fixes the gen-rtl script so that it does not wait on the background jobs anymore, i.e. it puts the entire bashrc source job in the background.

bashrc does however do things that gen-rtl needs, but these things should only take a couple seconds at most, so I added a mandatory 60-second wait after starting the background bashrc job.