### PR TITLE
Freeze lassen at 77c32df from 2024

### DIFF
--- a/mflowgen/common/rtl/gen_rtl.sh
+++ b/mflowgen/common/rtl/gen_rtl.sh
@@ -9,6 +9,7 @@ function get_amber_updates {
       cd /aha/canal        && git checkout 6fec524;
       cd /aha/clockwork    && git checkout efdd95e;
       cd /aha/lake         && git checkout 837ffe1;
+      cd /aha/lassen       && git checkout 77c32df;
     '
 }
 function update_kratos {


### PR DESCRIPTION
Recent changes in the lassen repo broke my weekly amber build
<https://buildkite.com/tapeout-aha/fullchip/builds/640>

This change fixes it by using an older known-good lassen version instead of the master branch
<https://buildkite.com/tapeout-aha/fullchip/builds/641>

This change affects only me and my weekly amber build, so I will spare you the need for external review...when/if the tests pass I will merge.
