### PR TITLE
Simplify cgra2mu ready and

### DIFF
--- a/garnet.py
+++ b/garnet.py
@@ -27,6 +27,7 @@ from gemstone.generator.const import Const
 from canal.util import IOSide
 from canal.logic import ReadyValidLoopBack
 from matrix_unit.cgra2mu_ready_and import cgra2mu_ready_and
+from matrix_unit.mu2cgra_pipeline_unit import mu2cgra_pipeline_unit
 from kratos.util import to_magma
 
 # set the debug mode to false to speed up construction
@@ -69,6 +70,7 @@ class Garnet(Generator):
         self.include_E64_hw = args.include_E64_hw
         self.include_multi_bank_hw = args.include_multi_bank_hw
         self.include_mu_glb_hw = args.include_mu_glb_hw
+        self.pipeline_mu2cgra = args.pipeline_mu2cgra
 
         # Build GLB unless interconnect_only (CGRA-only) requested
 
@@ -197,9 +199,11 @@ class Garnet(Generator):
                 )
 
             # Matrix unit <-> interconnnect ports connection
-            self.cgra2mu_ready_and = FromMagma(to_magma(cgra2mu_ready_and(height=num_output_channels), flatten_array=True))
-
+            self.cgra2mu_ready_and = FromMagma(to_magma(cgra2mu_ready_and(height=int(num_output_channels/2)), flatten_array=True))
             self.mu2cgra_rv_loopback_and = FromMagma(to_magma(ReadyValidLoopBack(), flatten_array=True))
+
+            if self.pipeline_mu2cgra:
+                self.mu2cgra_pipeline_unit = FromMagma(to_magma(mu2cgra_pipeline_unit(num_output_channels=num_output_channels, mu_datawidth=mu_datawidth), flatten_array=True))
 
             if dense_only:
                 cgra_track_width = 16
@@ -214,12 +218,19 @@ class Garnet(Generator):
             mu_io_endX = mu_io_startX + num_mu_io_tiles - 1
 
             # Ready-valid loopback
-            self.wire(self.mu2cgra_rv_loopback_and.ports.valid_in, self.convert(self.ports.mu2cgra_valid, magma.Bits[1]))
+            if self.pipeline_mu2cgra:
+                self.wire(self.mu2cgra_rv_loopback_and.ports.valid_in, self.convert(self.mu2cgra_pipeline_unit.ports.mu2cgra_valid_d, magma.Bits[1]))
+            else:
+                self.wire(self.mu2cgra_rv_loopback_and.ports.valid_in, self.convert(self.ports.mu2cgra_valid, magma.Bits[1]))
             self.wire(self.mu2cgra_rv_loopback_and.ports.ready_in, self.convert(self.cgra2mu_ready_and.ports.anded_ready_out, magma.Bits[1]))
+
+            if self.pipeline_mu2cgra:
+                self.wire(self.ports.clk_in, self.mu2cgra_pipeline_unit.ports.clk)
+                self.wire(self.ports.reset_in, self.mu2cgra_pipeline_unit.ports.reset)
+                self.wire(self.convert(self.ports.mu2cgra_valid, magma.Bits[1]), self.mu2cgra_pipeline_unit.ports[f"mu2cgra_valid"])
 
             for i in range(num_output_channels):
                 io_num = i % 2
-
                 mu_io_tile_row = self.height + 1
                 cgra_col_num = mu_io_startX + i // 2
 
@@ -228,20 +239,29 @@ class Garnet(Generator):
                     self.wire(Const(
                         0), self.interconnect.ports[f"mu2io_{cgra_track_width}_{io_num}_X{cgra_col_num:02X}_Y{mu_io_tile_row:02X}"][cgra_track_width - width_difference:cgra_track_width])
 
-                self.wire(
-                    self.ports.mu2cgra[i], self.interconnect.ports[f"mu2io_{cgra_track_width}_{io_num}_X{cgra_col_num:02X}_Y{mu_io_tile_row:02X}"][:cgra_track_width - width_difference])
+                if self.pipeline_mu2cgra:
+                    self.wire(self.ports.mu2cgra[i], self.mu2cgra_pipeline_unit.ports[f"mu2cgra_{i}"])
+                    self.wire(self.mu2cgra_pipeline_unit.ports[f"mu2cgra_d_{i}"], self.interconnect.ports[f"mu2io_{cgra_track_width}_{io_num}_X{cgra_col_num:02X}_Y{mu_io_tile_row:02X}"][:cgra_track_width - width_difference])
+                else:
+                    self.wire(self.ports.mu2cgra[i], self.interconnect.ports[f"mu2io_{cgra_track_width}_{io_num}_X{cgra_col_num:02X}_Y{mu_io_tile_row:02X}"][:cgra_track_width - width_difference])
                 # Gated valid goes into the tile array, broadcast to all I/O tiles
                 self.wire(
                     self.convert(self.mu2cgra_rv_loopback_and.ports.valid_out, magma.bit),
                     self.interconnect.ports[f"mu2io_{cgra_track_width}_{io_num}_X{cgra_col_num:02X}_Y{mu_io_tile_row:02X}_valid"])
 
-                self.wire(
-                    self.cgra2mu_ready_and.ports[f"readys_in_{i}"],
-                    self.convert(
-                        self.interconnect.ports[f"mu2io_{cgra_track_width}_{io_num}_X{cgra_col_num:02X}_Y{mu_io_tile_row:02X}_ready"],
-                        magma.Bits[1]))
+                if (i % 2) == 0:
+                    self.wire(
+                        self.cgra2mu_ready_and.ports[f"readys_in_{int(i/2)}"],
+                        self.convert(
+                            self.interconnect.ports[f"mu2io_{cgra_track_width}_{io_num}_X{cgra_col_num:02X}_Y{mu_io_tile_row:02X}_ready"],
+                            magma.Bits[1]))
 
-            self.wire(self.convert(self.cgra2mu_ready_and.ports.anded_ready_out, magma.bit), self.ports.cgra2mu_ready)
+            if self.pipeline_mu2cgra:
+                self.wire(self.convert(self.cgra2mu_ready_and.ports.anded_ready_out, magma.Bits[1]), self.mu2cgra_pipeline_unit.ports.cgra2mu_ready_d)
+                self.wire(self.ports.cgra2mu_ready, self.convert(self.mu2cgra_pipeline_unit.ports.cgra2mu_ready, magma.bit))
+            else:
+                self.wire(self.ports.cgra2mu_ready, self.convert(self.cgra2mu_ready_and.ports.anded_ready_out, magma.bit))
+
 
             # Matrix unit <-> GLB ports connection
             if self.include_mu_glb_hw:
@@ -928,6 +948,7 @@ def parse_args():
     parser.add_argument('--include-mu-glb-hw', action="store_true")
     parser.add_argument('--use-non-split-fifos', action="store_true")
     parser.add_argument('--exclude-glb-ring-switch', action="store_true")
+    parser.add_argument('--pipeline-mu2cgra', action="store_true")
 
     # Daemon choices are maybe ['help', 'launch', 'use', 'kill', 'force', 'status', 'wait']
     parser.add_argument('--daemon', type=str, choices=GarnetDaemon.choices, default=None)
@@ -1044,12 +1065,21 @@ def build_verilog(args, garnet):
     if not garnet_home:
         garnet_home = os.path.dirname(os.path.abspath(__file__))
     from matrix_unit.matrix_unit_main import gen_param_header
+    from matrix_unit.matrix_unit_main import gen_regspace_header
+    from matrix_unit.matrix_unit_main import Reg
     matrix_unit_params = {}
     matrix_unit_params["MU_DATAWIDTH"] = args.mu_datawidth
     matrix_unit_params["MU_OC_0"] = args.mu_oc_0
+    matrix_unit_params["MU_AXI_ADDR_WIDTH"] = 30
+    matrix_unit_params["MU_AXI_DATA_WIDTH"] = 64
     gen_param_header(top_name="matrix_unit_param",
                      params=matrix_unit_params,
                      output_folder=os.path.join(garnet_home, "matrix_unit/header"))
+    input_base_addr_reg = Reg(name="MU_AXI_INPUT_BASE_R", addr=8, lsb=0, msb=0)
+    weight_base_addr_reg = Reg(name="MU_AXI_WEIGHT_BASE_R", addr=16, lsb=0, msb=0)
+    bias_base_addr_reg = Reg(name="MU_AXI_BIAS_BASE_R", addr=24, lsb=0, msb=0)
+    header_list = [input_base_addr_reg, weight_base_addr_reg, bias_base_addr_reg]
+    gen_regspace_header(header_list, "matrix_unit/header/matrix_unit_regspace")
 
 
 def pnr(garnet, args, app):

--- a/matrix_unit/matrix_unit_main.py
+++ b/matrix_unit/matrix_unit_main.py
@@ -41,3 +41,33 @@ def gen_header_files(params, svh_filename, h_filename, header_name):
                 continue
             v = int(v)
             f.write(f"#define {k.upper()} {v}\n")
+
+@dataclass
+class Reg():
+    name: str
+    addr: int
+    lsb: int
+    msb: int
+
+
+def gen_regspace_header(header_list, path: str):
+    svh_path = path + '.svh'
+    with open(svh_path, "w") as f:
+        for header in header_list:
+            if isinstance(header, Reg):
+                f.write(f"`define {header.name} 'h{format(header.addr, 'x')}\n")
+                f.write(f"`define {header.name + '_LSB'} {header.lsb}\n")
+                f.write(f"`define {header.name + '_MSB'} {header.msb}\n")
+            else:
+                exception = f"Unknown header type: {type(header)}"
+                raise TypeError(exception)
+
+    h_path = path + '.h'
+    with open(h_path, "w") as f:
+        f.write(f"#pragma once\n")
+        for header in header_list:
+            if isinstance(header, Reg):
+                f.write(f"#define {header.name} {hex(header.addr)}\n")
+            else:
+                exception = f"Unknown header type: {type(header)}"
+                raise TypeError(exception)

--- a/matrix_unit/mu2cgra_pipeline_unit.py
+++ b/matrix_unit/mu2cgra_pipeline_unit.py
@@ -1,0 +1,59 @@
+from kratos import Generator, verilog, const, clog2
+from global_buffer.design.fifo import FIFO
+
+
+class mu2cgra_pipeline_unit(Generator):
+    def __init__(self, num_output_channels=32, mu_datawidth=16, fifo_depth=2, fifo_name_suffix="mu2cgra_pipeline_fifo", add_flush=False, add_clk_en=True):
+        super().__init__(f"mu2cgra_pipeline_unit", debug=True)
+
+        self.mu_datawidth = mu_datawidth
+        self.num_output_channels = num_output_channels
+        self.fifo_depth = fifo_depth
+        self.fifo_name_suffix = fifo_name_suffix
+
+        # Clock and reset
+        self.clk = self.clock("clk")
+        self.reset = self.reset("reset")
+
+        # Interface with matrix unit
+        self.mu2cgra = self.input("mu2cgra", mu_datawidth, size=num_output_channels)
+        self.mu2cgra_valid = self.input("mu2cgra_valid", 1)
+        self.cgra2mu_ready = self.output("cgra2mu_ready", 1)
+
+        # Interface with CGRA
+        self.mu2cgra_d = self.output("mu2cgra_d", mu_datawidth, size=num_output_channels)
+        self.mu2cgra_valid_d = self.output("mu2cgra_valid_d", 1)
+        self.cgra2mu_ready_d = self.input("cgra2mu_ready_d", 1)
+
+        # Create a FIFO for each channel
+        for channel in range(num_output_channels):
+            pipeline_fifo = FIFO(self.mu_datawidth, 2)
+
+            fifo_full = self.var(f"fifo_full_{channel}", 1)
+            fifo_empty = self.var(f"fifo_empty_{channel}", 1)
+
+            self.add_child(f"pipeline_fifo_channel_{channel}",
+                            pipeline_fifo,
+                            clk=self.clk,
+                            clk_en=const(1, 1),
+                            reset=self.reset,
+                            # TODO: Figure out what to put here for flush
+                            flush=const(0, 1),
+                            data_in=self.mu2cgra[channel],
+                            data_out=self.mu2cgra_d[channel],
+                            push=self.mu2cgra_valid,
+                            pop=self.cgra2mu_ready_d,
+                            full=fifo_full,
+                            empty=fifo_empty,
+                            almost_full_diff=1,
+                            almost_empty_diff=1)
+
+            if channel == 0:
+                self.wire(self.cgra2mu_ready, ~fifo_full)
+                self.wire(self.mu2cgra_valid_d, ~fifo_empty)
+
+
+if __name__ == "__main__":
+    dut = mu2cgra_pipeline_unit()
+    verilog(dut, filename="mu2cgra_pipeline_unit.sv",
+            optimize_if=False)


### PR DESCRIPTION
This RTL change reduces the depth of the cgra2mu_ready_and tree from 32->1 to 16->1, which may improve timing and area. Furthermore, this path may now be optionally pipelined (to meet timing if needed) by adding "pipeline-mu2cgra" flag to the aha garnet.