### PR TITLE
Verilator fix

### DIFF
--- a/tests/install-verilator.sh
+++ b/tests/install-verilator.sh
@@ -36,9 +36,7 @@ if insufficient $version; then
     cd /usr/share/verilator; git checkout v5.028
     cd /usr/share/verilator; unset VERILATOR_ROOT; autoconf; ./configure
 
-    # WTF is "NPROC"???
-    # cd /usr/share/verilator; unset VERILATOR_ROOT; make -j $(NPROC) || echo ERROR
-    cd /usr/share/verilator; unset VERILATOR_ROOT; make || echo ERROR
+    cd /usr/share/verilator; unset VERILATOR_ROOT; make -j 4 || echo ERROR
     cd /usr/share/verilator; make clean || echo ERROR cannot clean for some reason i guess
     test -e /usr/local/bin/verilator && mv /usr/local/bin/verilator /usr/local/bin/verilator.orig || echo NOT YET
     cd /usr/local/bin; ln -s /usr/share/verilator/bin/verilator

--- a/tests/install-verilator.sh
+++ b/tests/install-verilator.sh
@@ -35,8 +35,9 @@ if insufficient $version; then
     cd /usr/share; test -d verilator || git clone https://github.com/verilator/verilator
     cd /usr/share/verilator; git checkout v5.028
     cd /usr/share/verilator; unset VERILATOR_ROOT; autoconf; ./configure
-
-    cd /usr/share/verilator; unset VERILATOR_ROOT; make -j 4 || echo ERROR
+    echo It looks like we have `nproc` processors available.
+    NPROC=$((`nproc`/2)) || NPROC=1  # Don't be greedy
+    cd /usr/share/verilator; unset VERILATOR_ROOT; make -j $NPROC || echo ERROR
     cd /usr/share/verilator; make clean || echo ERROR cannot clean for some reason i guess
     test -e /usr/local/bin/verilator && mv /usr/local/bin/verilator /usr/local/bin/verilator.orig || echo NOT YET
     cd /usr/local/bin; ln -s /usr/share/verilator/bin/verilator

--- a/tests/install-verilator.sh
+++ b/tests/install-verilator.sh
@@ -35,7 +35,10 @@ if insufficient $version; then
     cd /usr/share; test -d verilator || git clone https://github.com/verilator/verilator
     cd /usr/share/verilator; git checkout v5.028
     cd /usr/share/verilator; unset VERILATOR_ROOT; autoconf; ./configure
-    cd /usr/share/verilator; unset VERILATOR_ROOT; make -j $(NPROC) || echo ERROR
+
+    # WTF is "NPROC"???
+    # cd /usr/share/verilator; unset VERILATOR_ROOT; make -j $(NPROC) || echo ERROR
+    cd /usr/share/verilator; unset VERILATOR_ROOT; make || echo ERROR
     cd /usr/share/verilator; make clean || echo ERROR cannot clean for some reason i guess
     test -e /usr/local/bin/verilator && mv /usr/local/bin/verilator /usr/local/bin/verilator.orig || echo NOT YET
     cd /usr/local/bin; ln -s /usr/share/verilator/bin/verilator

--- a/tests/install-verilator.sh
+++ b/tests/install-verilator.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
+
+HELP='
+DESCRIPTION:
+  Look for verilator 5.028 or better; if not found, install it.
+  May require sudo privilege.
+'
+[ "$1" == "--help" ] && echo "$HELP" && exit
+# ------------------------------------------------------------------------
 set -x
+
+# Verilator must be 5.028 or better maybe
+function insufficient { awk "BEGIN {if ($1 < 5.028) exit(0); else exit(13)}"; }
+
 
 # E.g. verilator --version = "Verilator 5.032 2025-01-01 rev (Debian 5.032-1)"
 if ! verilator --version >& /dev/null; then version=0.0
 else version=$(verilator --version |& cut -d " " -f2); fi
 
-# Verilator must be 5.028 or better maybe
-function insufficient { awk "BEGIN {if ($1 < 5.028) exit(0); else exit(13)}"; }
 if insufficient $version; then
 
     # Only works with g++-10 else "unrecognized option ‘-fcoroutines’"
@@ -25,3 +35,6 @@ if insufficient $version; then
     yes | apt install -t plucky verilator
     verilator --version
 fi
+
+
+

--- a/tests/install-verilator.sh
+++ b/tests/install-verilator.sh
@@ -32,10 +32,10 @@ if insufficient $version; then
     echo -------------------------------
 
     echo "--- MAKE SETUP: Install verilator 5.028"
+    set -x
     cd /usr/share; test -d verilator || git clone https://github.com/verilator/verilator
     cd /usr/share/verilator; git checkout v5.028
     cd /usr/share/verilator; unset VERILATOR_ROOT; autoconf; ./configure
-    echo It looks like we have `nproc` processors available.
     NPROC=$((`nproc`/2)) || NPROC=1  # Don't be greedy
     cd /usr/share/verilator; unset VERILATOR_ROOT; make -j $NPROC || echo ERROR
     cd /usr/share/verilator; make clean || echo ERROR cannot clean for some reason i guess

--- a/tests/test_app/tb/garnet_test.sv
+++ b/tests/test_app/tb/garnet_test.sv
@@ -6,7 +6,9 @@
 ** Change history:  10/14/2020 - Implement the first version
 **===========================================================================*/
 import "DPI-C" function int initialize_monitor(int num_cols);
-import "DPI-C" function int get_external_mu_active_arr_env_var();
+
+// UNUSED methinks but verilator dies when it can't be found ("undefined reference")
+// import "DPI-C" function int get_external_mu_active_arr_env_var();
 
 program garnet_test #(
     parameter int MAX_NUM_APPS = 1000


### PR DESCRIPTION
Oops sorry guys, it looks as though the verilator-based CI has been broken for awhile. The problem appears to be 1) a new verilator-install package that stopped working 
https://github.com/StanfordAHA/garnet/actions/runs/16061689737/job/45328791009

followed by 2) a new undefined/unused external function 'get_external_mu_active_arr_env_var'
https://github.com/StanfordAHA/garnet/actions/runs/16119890790/job/45482706951

This change goes back to the older method of compiling verilator from scratch. It's slower but should be more robust. And 2) removes the unused function.

