### PR TITLE
Zircon conv5 host tiling; misc code fixes

### DIFF
--- a/garnet.py
+++ b/garnet.py
@@ -1127,7 +1127,7 @@ def build_verilog(args, garnet):
     matrix_unit_params["MU_AXI_ADDR_WIDTH"] = 30
     matrix_unit_params["MU_AXI_DATA_WIDTH"] = 64
     gen_param_header(top_name="matrix_unit_param",
-                     params=matrix_unit_params,
+                     matrix_unit_params=matrix_unit_params, glb_params=args.glb_params,
                      output_folder=os.path.join(garnet_home, "matrix_unit/header"))
     input_base_addr_reg = Reg(name="MU_AXI_INPUT_BASE_R", addr=8, lsb=0, msb=0)
     weight_base_addr_reg = Reg(name="MU_AXI_WEIGHT_BASE_R", addr=16, lsb=0, msb=0)

--- a/matrix_unit/matrix_unit_main.py
+++ b/matrix_unit/matrix_unit_main.py
@@ -3,16 +3,17 @@ import math
 import os
 
 
-def gen_param_header(top_name, params, output_folder):
+def gen_param_header(top_name, matrix_unit_params, glb_params, output_folder):
     h_filename = os.path.join(output_folder, f"{top_name}.h")
     svh_filename = os.path.join(output_folder, f"{top_name}.svh")
-    gen_header_files(params=params,
+    gen_header_files(matrix_unit_params=matrix_unit_params,
+                     glb_params=glb_params,
                      svh_filename=svh_filename,
                      h_filename=h_filename,
                      header_name="matrix_unit")
 
 
-def gen_header_files(params, svh_filename, h_filename, header_name):
+def gen_header_files(matrix_unit_params, glb_params, svh_filename, h_filename, header_name):
     # mod_params = asdict(params)
 
     folder = svh_filename.rsplit('/', 1)[0]
@@ -25,7 +26,7 @@ def gen_header_files(params, svh_filename, h_filename, header_name):
         f.write(f"`ifndef {header_name.upper()}_PARAM\n")
         f.write(f"`define {header_name.upper()}_PARAM\n")
         f.write(f"package {header_name}_param;\n")
-        for k, v in params.items():
+        for k, v in matrix_unit_params.items():
             if type(v) is str:
                 continue
             v = int(v)
@@ -33,10 +34,14 @@ def gen_header_files(params, svh_filename, h_filename, header_name):
         f.write("endpackage\n")
         f.write("`endif\n")
 
+        num_tile_id_bits_in_mu_addr = glb_params.tile_sel_addr_width - math.log2(glb_params.mu_word_num_tiles)
+        if num_tile_id_bits_in_mu_addr > 1:
+            f.write(f"`define DEFAULT_MU_ADDR_TRANSL_LEGAL 1\n")
+
     os.makedirs(os.path.dirname(h_filename), exist_ok=True)
     with open(h_filename, "w") as f:
         f.write("#pragma once\n")
-        for k, v in params.items():
+        for k, v in matrix_unit_params.items():
             if type(v) is str:
                 continue
             v = int(v)

--- a/tests/test_app/genesis_tb/top.svp
+++ b/tests/test_app/genesis_tb/top.svp
@@ -344,6 +344,7 @@ module top;
             integer inputScale_data_file;
             integer weightScale_data_file;
             integer systolic_array_output_data_file;
+            integer matrix_unit_done_file; // Dump when the matrix unit is done
             initial begin
                 input_data_file = $fopen("input_data_mu_in.txt", "w");
                 if (input_data_file == 0) begin
@@ -380,6 +381,12 @@ module top;
                     $display("Error: Could not open systolic_array_mu.txt file.");
                     $finish;
                 end
+
+                matrix_unit_done_file = $fopen("matrix_unit_done.txt", "w");
+                if (matrix_unit_done_file == 0) begin
+                    $display("Error: Could not open matrix_unit_done.txt file.");
+                    $finish;
+                end
             end
 
             always @(posedge clk) begin
@@ -405,6 +412,10 @@ module top;
 
                 if (dut.matrixUnit_1.bb.outputsFromSystolicArray_vld & dut.matrixUnit_1.bb.outputsFromSystolicArray_rdy) begin
                     $fwrite(systolic_array_output_data_file, "[%0t] outputsFromSystolicArray_dat = %0128x\n", $time, dut.matrixUnit_1.bb.outputsFromSystolicArray_dat);
+                end
+
+                if (dut.matrixUnit_1.bb.doneSignal_vld) begin
+                    $fwrite(matrix_unit_done_file, "[%0t] Matrix unit done", $time);
                 end
             end
     \`endif

--- a/tests/test_app/lib/map.c
+++ b/tests/test_app/lib/map.c
@@ -454,16 +454,7 @@ int update_io_tile_configuration(struct IOTileInfo *io_tile_info, struct ConfigI
     // Convert extent/stride hardware-friendly
     for (int i = 0; i < loop_dim; i++) {
         extent[i] = io_tile_info->extent[i] - 2;
-
-        if (exchange_64_mode && E64_packed) {
-            if (i == 0) {
-                dma_range[i] = (io_tile_info->extent[i]/4) - 2;
-            } else {
-                dma_range[i] = extent[i];
-            }
-        } else {
-            dma_range[i] = extent[i];
-        }
+        dma_range[i] = extent[i];
 
         cycle_stride[i] = io_tile_info->cycle_stride[i];
         data_stride[i] = io_tile_info->data_stride[i];
@@ -472,13 +463,8 @@ int update_io_tile_configuration(struct IOTileInfo *io_tile_info, struct ConfigI
         // Also skip it if configured in bank toggle mode
         if (!(hacked_for_mu_tiling || bank_toggle_mode)){
             for (int j = 0; j < i; j++) {
-                if (exchange_64_mode && E64_packed && j == 0) {
-                    cycle_stride[i] -= io_tile_info->cycle_stride[j] * (io_tile_info->extent[j]/4 - 1);
-                    data_stride[i] -= io_tile_info->data_stride[j] * (io_tile_info->extent[j]/4 - 1);
-                } else {
-                    cycle_stride[i] -= io_tile_info->cycle_stride[j] * (io_tile_info->extent[j] - 1);
-                    data_stride[i] -= io_tile_info->data_stride[j] * (io_tile_info->extent[j] - 1);
-                }
+                cycle_stride[i] -= io_tile_info->cycle_stride[j] * (io_tile_info->extent[j] - 1);
+                data_stride[i] -= io_tile_info->data_stride[j] * (io_tile_info->extent[j] - 1);
             }
         } else {
             if (hacked_for_mu_tiling)

--- a/tests/test_app/lib/map.c
+++ b/tests/test_app/lib/map.c
@@ -253,9 +253,13 @@ int glb_map(void *kernel_, int dpr_enabled) {
             if (get_E64_multi_bank_mode_config() && io_tile_info->E64_packed) {
                 io_tile_info->start_addr =
                 (io_tile_info->start_addr << CGRA_BYTE_OFFSET) + ((tile * 2 + j%2) << BANK_ADDR_WIDTH);
+                io_tile_info->gold_check_start_addr =
+                (io_tile_info->gold_check_start_addr << CGRA_BYTE_OFFSET) + ((tile * 2 + j%2) << BANK_ADDR_WIDTH);
             } else {
                 io_tile_info->start_addr =
                 (io_tile_info->start_addr << CGRA_BYTE_OFFSET) + ((tile * 2 + 1) << BANK_ADDR_WIDTH);
+                io_tile_info->gold_check_start_addr =
+                (io_tile_info->gold_check_start_addr << CGRA_BYTE_OFFSET) + ((tile * 2 + 1) << BANK_ADDR_WIDTH);
             }
 
             printf("Mapping output_%0d_block_%0d to global buffer\n", i, j);

--- a/tests/test_app/lib/parser.h
+++ b/tests/test_app/lib/parser.h
@@ -44,6 +44,7 @@ struct IOTileInfo {
     enum IO io;
     int tile;
     int start_addr;
+    int gold_check_start_addr; // for gold check, may be different from start_addr
     int cycle_start_addr;
 
     struct Position pos;
@@ -55,6 +56,7 @@ struct IOTileInfo {
     int data_stride[LOOP_LEVEL];
     int extent[LOOP_LEVEL];
     int E64_packed;
+    int extent_multiplier;
 
     // For back-to-back kernels
     int is_glb_input;

--- a/tests/test_app/tb/environment.sv
+++ b/tests/test_app/tb/environment.sv
@@ -101,13 +101,13 @@ task Env_read_data();
                 if (j % 2 == 0) begin
                     // In bank toggle mode, the entire GLB tile is used for storing data, and we need to start from bank 0
                     // Note that by default the output IO tile has a bank offset to match default odd pos x in map.c, so we need to subtract 1 bank offset
-                    start_addr = kernel.outputs[i].io_tiles[j].start_addr - (1 << BANK_ADDR_WIDTH);
+                    start_addr = kernel.outputs[i].io_tiles[j].gold_check_start_addr - (1 << BANK_ADDR_WIDTH);
                 end else begin
-                    start_addr = kernel.outputs[i].io_tiles[j].start_addr;
+                    start_addr = kernel.outputs[i].io_tiles[j].gold_check_start_addr;
                 end
             end else begin
                 data_q = new[kernel.outputs[i].io_tiles[j].io_block_data.size()];
-                start_addr = kernel.outputs[i].io_tiles[j].start_addr; // 0x1000 or some such
+                start_addr = kernel.outputs[i].io_tiles[j].gold_check_start_addr; // 0x1000 or some such
             end
             $display("[%s] IO tile %0d start_addr = 0x%x", kernel.name, j, start_addr);
             ProcDriver_read_data();

--- a/tests/test_app/tb/kernel.sv
+++ b/tests/test_app/tb/kernel.sv
@@ -359,6 +359,8 @@ function Kernel::new(string app_dir, int dpr);
         end else begin
             for (int j = 0; j < num_io_tiles; j++) begin
             num_pixels = input_data[i].size / num_io_tiles;
+            // To ensure all data gets read out. Useful when applying E64 packing 
+            num_pixels = num_pixels * get_io_tile_extent_multiplier(io_info, j);
                 inputs[i].io_tiles[j].num_data = num_pixels;
                 inputs[i].io_tiles[j].io_block_data = new[num_pixels];
                 // NOTE: We assume only innermost loop is unrolled.
@@ -440,6 +442,7 @@ function Kernel::new(string app_dir, int dpr);
                 end
             end
 
+            // To ensure all data gets read out. Useful when applying E64 packing or k-dim host tiling in zircon
             num_pixels = num_pixels * get_io_tile_extent_multiplier(io_info, j);
 
             // For GLB tiling read memory region of entire feature map

--- a/tests/test_app/tb/kernel.sv
+++ b/tests/test_app/tb/kernel.sv
@@ -86,6 +86,10 @@ import "DPI-C" function int get_io_tile_start_addr(
     chandle info,
     int index
 );
+import "DPI-C" function int get_io_tile_gold_check_start_addr(
+    chandle info,
+    int index
+);
 import "DPI-C" function int get_io_tile_map_tile(
     chandle info,
     int index
@@ -114,6 +118,10 @@ import "DPI-C" function int get_io_tile_is_glb_input( // for back-to-back kernel
     int index
 );
 import "DPI-C" function int get_io_tile_E64_packed(
+    chandle info,
+    int index
+);
+import "DPI-C" function int get_io_tile_extent_multiplier(
     chandle info,
     int index
 );
@@ -168,6 +176,7 @@ typedef bitstream_entry_t bitstream_t[];
 typedef struct {
     int tile;
     int start_addr;
+    int gold_check_start_addr; // for gold check, may be different from start_addr
     int num_data;
     int is_glb_input; // for back-to-back kernels to judge if input is already in glb
     int E64_packed;
@@ -431,6 +440,8 @@ function Kernel::new(string app_dir, int dpr);
                 end
             end
 
+            num_pixels = num_pixels * get_io_tile_extent_multiplier(io_info, j);
+
             // For GLB tiling read memory region of entire feature map
             if (num_glb_tiling > 0) begin
                 num_pixels = num_pixels * num_glb_tiling;
@@ -672,6 +683,7 @@ function int Kernel::kernel_map();
         for (int j = 0; j < outputs[i].num_io_tiles; j++) begin
             outputs[i].io_tiles[j].tile = get_io_tile_map_tile(io_info, j);
             outputs[i].io_tiles[j].start_addr = get_io_tile_start_addr(io_info, j);
+            outputs[i].io_tiles[j].gold_check_start_addr = get_io_tile_gold_check_start_addr(io_info, j);
             outputs[i].io_tiles[j].E64_packed = get_io_tile_E64_packed(io_info, j);
             outputs[i].io_tiles[j].bank_toggle_mode = get_io_tile_bank_toggle_mode(io_info, j);
         end

--- a/tests/test_app/tb/proc_driver.sv
+++ b/tests/test_app/tb/proc_driver.sv
@@ -106,11 +106,16 @@ task ProcDriver_write_8b_network_data();
         // This will write data to Bank 0, Bank 1, Bank 2, Bank 3...Bank 0 Bank 1 Bank 2 Bank 3 in a cycle
         // ProcDriver_write_waddr = {cur_addr[20:18], cur_addr[4:3], cur_addr[17:5], cur_addr[2:0]};
         // NOTE: This doesn't work on small CGRAs (e.g. fast regression)
-        ProcDriver_write_waddr = {  cur_addr[MU_ADDR_WIDTH - 1 : MU_ADDR_WIDTH - 1 - (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1)],
-                                    cur_addr[BANK_BYTE_OFFSET + (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1) - 1 : BANK_BYTE_OFFSET],
-                                    cur_addr[MU_ADDR_WIDTH - 1 - (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES)) : BANK_BYTE_OFFSET + (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1)],
-                                    cur_addr[BANK_BYTE_OFFSET - 1 : 0]
-                            };
+        // Setting it to 0 for now for that case. To make it work in the future, need to do something like {curr_addr[18:18], [4:3], [17:5], [2:0]}
+        `ifdef DEFAULT_MU_ADDR_TRANSL_LEGAL
+            ProcDriver_write_waddr = {  cur_addr[MU_ADDR_WIDTH - 1 : MU_ADDR_WIDTH - 1 - (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1)],
+                                        cur_addr[BANK_BYTE_OFFSET + (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1) - 1 : BANK_BYTE_OFFSET],
+                                        cur_addr[MU_ADDR_WIDTH - 1 - (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES)) : BANK_BYTE_OFFSET + (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1)],
+                                        cur_addr[BANK_BYTE_OFFSET - 1 : 0]
+                                };
+        `else
+            ProcDriver_write_waddr = 0;
+        `endif
         ProcDriver_write_wdata = bdata;
         ProcDriver_write();
         cur_addr += 8;  // Counts hex 8,10,18,20...(8x2^10 == 0x1000
@@ -142,11 +147,16 @@ task ProcDriver_write_16b_network_data();
         // This will write data to Bank 0, Bank 1, Bank 2, Bank 3...Bank 0 Bank 1 Bank 2 Bank 3 in a cycle
         // ProcDriver_write_waddr = {cur_addr[20:18], cur_addr[4:3], cur_addr[17:5], cur_addr[2:0]};
         // NOTE: This doesn't work on small CGRAs (e.g. fast regression)
-        ProcDriver_write_waddr = {  cur_addr[MU_ADDR_WIDTH - 1 : MU_ADDR_WIDTH - 1 - (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1)],
-                                    cur_addr[BANK_BYTE_OFFSET + (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1) - 1 : BANK_BYTE_OFFSET],
-                                    cur_addr[MU_ADDR_WIDTH - 1 - (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES)) : BANK_BYTE_OFFSET + (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1)],
-                                    cur_addr[BANK_BYTE_OFFSET - 1 : 0]
-                            };
+        // Setting it to 0 for now for that case. To make it work in the future, need to do something like {curr_addr[18:18], [4:3], [17:5], [2:0]}
+        `ifdef DEFAULT_MU_ADDR_TRANSL_LEGAL
+            ProcDriver_write_waddr = {  cur_addr[MU_ADDR_WIDTH - 1 : MU_ADDR_WIDTH - 1 - (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1)],
+                                        cur_addr[BANK_BYTE_OFFSET + (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1) - 1 : BANK_BYTE_OFFSET],
+                                        cur_addr[MU_ADDR_WIDTH - 1 - (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES)) : BANK_BYTE_OFFSET + (TILE_SEL_ADDR_WIDTH - $clog2(MU_WORD_NUM_TILES) - 1)],
+                                        cur_addr[BANK_BYTE_OFFSET - 1 : 0]
+                                };
+        `else
+            ProcDriver_write_waddr = 0;
+        `endif
         ProcDriver_write_wdata = bdata;
         ProcDriver_write();
         cur_addr += 8;  // Counts hex 8,10,18,20...(8x2^10 == 0x1000


### PR DESCRIPTION
This PR includes various code fixes & improvements:

1) Modifies the gold check logic to support Zircon k-dim host tiling
2) Cleans up the E64 extent scaling logic, so that all extents in design_meta are 1:1 with the HW config
3) Fixes the fast regression, previously broken due to its incompatibility with other zircon parameters (e.g. MU port width)

Corresponding AHA PR: https://github.com/StanfordAHA/aha/pull/2065