### PR TITLE
Handle general case where some tensors may not exist

### DIFF
--- a/tests/test_app/tb/environment.sv
+++ b/tests/test_app/tb/environment.sv
@@ -136,7 +136,7 @@ task Env_mu_configure();
     $timeformat(-9, 2, " ns", 0);
     start_time = $realtime;
     $display("[%s] MU configuration start at %0t", kernel.name, start_time);
-    mu_serialized_params = dnn_layer.serialized_matrix_params;
+    mu_serialized_params = dnn_layer.serialized_matrix_params_info.tensor_32b;
     MU_AxilDriver_serialized_params_write();
 
     // input base address
@@ -479,34 +479,44 @@ task Env_write_network_data();
     $display("[%s] write network params to glb start at %0t", kernel.name, start_time);
 
     // inputActivation (INT8)
-    start_addr = dnn_layer.inputActivation_start_addr;
-    $display("inputActivation_start_addr = 0x%0h", start_addr);
-    data_q_8b = dnn_layer.inputActivation;
+    if (dnn_layer.inputActivation_info.tensor_exists) begin
+        start_addr = dnn_layer.inputActivation_info.start_addr;
+        $display("inputActivation_start_addr = 0x%0h", start_addr);
+        data_q_8b = dnn_layer.inputActivation_info.tensor_8b;
     ProcDriver_write_8b_network_data();
+    end
 
     // inputScale (E8M0)
-    start_addr = dnn_layer.inputScale_start_addr;
-    $display("inputScale_start_addr = 0x%0h", start_addr);
-    data_q_8b = dnn_layer.inputScale;
-    ProcDriver_write_8b_network_data();
+    if (dnn_layer.inputScale_info.tensor_exists) begin
+        start_addr = dnn_layer.inputScale_info.start_addr;
+        $display("inputScale_start_addr = 0x%0h", start_addr);
+        data_q_8b = dnn_layer.inputScale_info.tensor_8b;
+        ProcDriver_write_8b_network_data();
+    end
 
-    // weight INT8
-    start_addr = dnn_layer.weight_start_addr;
-    $display("weight_start_addr = 0x%0h", start_addr);
-    data_q_8b = dnn_layer.weight;
-    ProcDriver_write_8b_network_data();
+    // weight (INT8)
+    if (dnn_layer.weight_info.tensor_exists) begin
+        start_addr = dnn_layer.weight_info.start_addr;
+        $display("weight_start_addr = 0x%0h", start_addr);
+        data_q_8b = dnn_layer.weight_info.tensor_8b;
+        ProcDriver_write_8b_network_data();
+    end
 
     // weightScale (E8M0)
-    start_addr = dnn_layer.weightScale_start_addr;
-    $display("weightScale_start_addr = 0x%0h", start_addr);
-    data_q_8b = dnn_layer.weightScale;
-    ProcDriver_write_8b_network_data();
+    if (dnn_layer.weightScale_info.tensor_exists) begin
+        start_addr = dnn_layer.weightScale_info.start_addr;
+        $display("weightScale_start_addr = 0x%0h", start_addr);
+        data_q_8b = dnn_layer.weightScale_info.tensor_8b;
+        ProcDriver_write_8b_network_data();
+    end
 
     // bias (bFloat16)
-    start_addr = dnn_layer.bias_start_addr;
-    $display("bias_start_addr = 0x%0h", start_addr);
-    data_q_16b = dnn_layer.bias;
-    ProcDriver_write_16b_network_data();
+    if (dnn_layer.bias_info.tensor_exists) begin
+        start_addr = dnn_layer.bias_info.start_addr;
+        $display("bias_start_addr = 0x%0h", start_addr);
+        data_q_16b = dnn_layer.bias_info.tensor_16b;
+        ProcDriver_write_16b_network_data();
+    end
 
     end_time = $realtime;
     $display("[%s] write network params to glb end at %0t", kernel.name, end_time);


### PR DESCRIPTION
Generalizes the MU mapping flow to support layers where some tensors (e.g., inputScale, weightScale) may not exist. 

Corresponding AHA PR: (https://github.com/StanfordAHA/aha/pull/2076)