### PR TITLE
Aham3soc

### DIFF
--- a/mflowgen/common/soc-rtl-v2/run.sh
+++ b/mflowgen/common/soc-rtl-v2/run.sh
@@ -18,6 +18,8 @@ fi
 # Clone the ARM IP Repo
 # git clone git@r7arm-aha:nyengele/aham3soc_armip.git aham3soc_armip  # No longer works
 # git clone /sim/repos/aham3soc_armip aham3soc_armip                  # No longer exists! (on r8arm-aha)
+
+# Copy ARM IP from local cache
 cp -r /sim/buildkite-agent/aham3soc_armip_cache aham3soc_armip
 
 # Generate Pad Frame

--- a/mflowgen/common/soc-rtl-v2/run.sh
+++ b/mflowgen/common/soc-rtl-v2/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Get Current Directory
 CUR_DIR=$(pwd)
@@ -7,19 +8,17 @@ CUR_DIR=$(pwd)
 git clone https://github.com/StanfordAHA/AhaM3SoC.git aham3soc
 
 if [ "$WHICH_SOC" == "amber" ]; then
-# NOW: to make this branch (master-tsmc) work, must use amber soc
-# FIXME/TODO: should be part of top-level parms
-# FIXME/TODO: whrere are top-level parms???
-amber_soc=83dca39f4e4568ae134f0af69c2ad1b0c8adf6e7
-(cd aham3soc; git checkout $amber_soc)
-
-# Clone the ARM IP Repo
-git clone git@r7arm-aha:nyengele/aham3soc_armip.git aham3soc_armip
-else
-# Clone the ARM IP Repo
-git clone /sim/repos/aham3soc_armip aham3soc_armip
+    # NOW: to make this branch (master-tsmc) work, must use amber soc
+    # FIXME/TODO: should be part of top-level parms
+    # FIXME/TODO: whrere are top-level parms???
+    amber_soc=83dca39f4e4568ae134f0af69c2ad1b0c8adf6e7
+    (cd aham3soc; git checkout $amber_soc)
 fi
 
+# Clone the ARM IP Repo
+# git clone git@r7arm-aha:nyengele/aham3soc_armip.git aham3soc_armip  # No longer works
+# git clone /sim/repos/aham3soc_armip aham3soc_armip                  # No longer exists! (on r8arm-aha)
+cp -r /sim/buildkite-agent/aham3soc_armip_cache aham3soc_armip
 
 # Generate Pad Frame
 mkdir -p aham3soc_pad_frame

--- a/tests/install-verilator.sh
+++ b/tests/install-verilator.sh
@@ -19,10 +19,8 @@ else version=$(verilator --version |& cut -d " " -f2); fi
 
 if insufficient $version; then
 
-    # Only works with g++-10 else "unrecognized option ‘-fcoroutines’"
-    echo "--- MAKE SETUP: Install g++-10, autoconf, bison, help2man"
-    yes | (apt update; apt upgrade; apt install g++-10)
-    (cd /usr/bin; test -e g++ && mv g++ g++.orig; ln -s g++-10 g++)
+    # Hey guess what we have g++-13 available in the container now
+    (cd /usr/bin; test -e g++ && mv g++ g++.orig; ln -s g++-13 g++)
     echo -------------------------------
 
     echo These are missing in docker ATM 


### PR DESCRIPTION
Weekly amber fullchip builds stopped working because of problems with the aham3soc repo on r8arm-aha
<https://buildkite.com/tapeout-aha/fullchip/builds/713>

I am pretty sure that the aham3soc repo is no longer being maintained, so here I have changed the fullchip flow to use a cached version instead.

A second problem arose while I was working on this, in that our verilator CI test stopped working because
1) it was suddenly unable to build verilator v5 because
2) our garnet docker container seems no-longer-able able to build g++ v10
<https://github.com/StanfordAHA/garnet/actions/runs/25222763239/job/73958816875>

Fortunately, the lastest garnet image already has g++ v13 available, which is more than adequate to build verilator, so I changed the CI to use that instead. This makes the CI much faster and also, more importantly, it is not failing anymore
<https://github.com/StanfordAHA/garnet/actions/runs/25409653913>

The next fullchip run starts on Friday evening, so I hope we can get this approved and merged before then!