### PR TITLE
Update checkout action

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Checkout submodules
       shell: bash

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
 
     - name: Checkout submodules
       shell: bash

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,11 +27,6 @@ jobs:
         git submodule sync --recursive
         git submodule update --init --force --recursive --depth=1
 
-#       run: |
-#         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-#         git submodule sync --recursive
-#         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-
     - name: Pull and run docker
       shell: bash
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,9 +24,13 @@ jobs:
     - name: Checkout submodules
       shell: bash
       run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+        git submodule update --init --force --recursive --depth=1
+
+#       run: |
+#         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+#         git submodule sync --recursive
+#         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
     - name: Pull and run docker
       shell: bash

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Checkout submodules
       shell: bash

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -11,7 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Checkout submodules
       shell: bash

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -11,7 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
 
     - name: Checkout submodules
       shell: bash

--- a/.github/workflows/verilator.yml
+++ b/.github/workflows/verilator.yml
@@ -11,14 +11,13 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Checkout submodules
       shell: bash
       run: |
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+        git submodule update --init --force --recursive --depth=1
 
     - name: Run test
       shell: bash


### PR DESCRIPTION
Github keeps complaining about our usage of deprecated version`actions/checkout@v2`.
This code change updates the actions to ~--v4--~ v6, which is new enough to avoid the warning, and old enough to work unchanged with the rest of our existing code.